### PR TITLE
Docker builds of context i.s.o. master

### DIFF
--- a/docker/dfms/Dockerfile_incontext
+++ b/docker/dfms/Dockerfile_incontext
@@ -1,0 +1,8 @@
+# We need the base image we build with the other Dockerfile
+FROM dfms/centos7:base
+
+# Get the DFMS sources and install them in the system
+COPY / /daliuge
+
+RUN cd /daliuge && \
+    pip install .

--- a/docker/dfms/build.sh
+++ b/docker/dfms/build.sh
@@ -5,4 +5,10 @@ dir=$(dirname $0)
 cd $dir
 
 # Go!
-docker build --no-cache -t dfms/centos7:latest .
+if [ -f ../../setup.py ]; then
+    cd ../..
+    docker build --no-cache -t dfms/centos7:latest -f docker/dfms/Dockerfile_incontext .
+else
+    docker build --no-cache -t dfms/centos7:latest .
+fi
+


### PR DESCRIPTION
I encountered the issue that when checking out a specific version of DaLiuGE (for the sake of reproducibility) and building the corresponding Dockerfile, it would essentially checkout master inside the Docker image.

I have been struggling a bit on the implementation. Reading out the branch/tag from the environment does not work when the build is started from the release tarbal (which has all git info stripped). Also I think the Dockerfile should be portable irrespective of the rest of the repo. 

So in the end I propose to add a Dockerfile for in-context builds and make the build.sh check if setup.py exists, in which case it will copy the context to /daliuge in the container and build. If setup.py does not exist, it will revert to pulling the master and build from there. 