### PR TITLE
CWL-related fixes for python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 # run the tests, making sure subprocesses generate coverage information
 script:
  - COVFILES=
- - test -n "$NO_DLG_TRANSLATOR" || { (cd daliuge-translator && py.test --cov) && COVFILES+=" daliuge-translator/.coverage"; }
+ - test -n "$NO_DLG_TRANSLATOR" || { (cd daliuge-translator && pip install -r test-requirements.txt && py.test --cov) && COVFILES+=" daliuge-translator/.coverage"; }
  - test -n "$NO_DLG_RUNTIME" || { (cd daliuge-runtime && py.test --cov) && COVFILES+=" daliuge-runtime/.coverage"; }
  - coverage combine $COVFILES
  - test -z "$TEST_OPENAPI" || (cd OpenAPI/tests && ./test_managers_openapi.sh)

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -31,10 +31,15 @@ STORAGE_TYPES = {'memory', 'file', 'ngas', 'null', 'json'}
 if sys.version_info[0] > 2:
     def b2s(b, enc='utf8'):
         return b.decode(enc)
+    def u2s(u):
+        return u
 else:
     def b2s(b, enc='utf8'):
         return b
+    def u2s(u, enc='utf-8'):
+        return u.encode(enc)
 b2s.__doc__ = "Converts bytes into a string"
+u2s.__doc__ = 'Converts text into a string'
 
 
 class dropdict(dict):

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -22,11 +22,14 @@
 
 import logging
 import os
-import cwlgen
 from zipfile import ZipFile
 
-#from ..common import dropdict, get_roots
+import cwlgen
 
+from dlg import common
+
+
+#from ..common import dropdict, get_roots
 logger = logging.getLogger(__name__)
 
 
@@ -133,7 +136,8 @@ def create_command_line_tool(node, filename):
 
     #print("base_command:!" + base_command + "!")
 
-    cwl_tool = cwlgen.CommandLineTool(tool_id=node['app'], label=node['nm'], base_command=base_command, cwl_version='v1.0')
+    # cwlgen's Serializer class doesn't support python 2.7's unicode types
+    cwl_tool = cwlgen.CommandLineTool(tool_id=node['app'], label=common.u2s(node['nm']), base_command=base_command, cwl_version='v1.0')
 
     # add inputs
     for index, input in enumerate(inputs):

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -83,6 +83,7 @@ write_version_info()
 
 install_requires = [
     "bottle",
+    "cwlgen",
     "daliuge-common==%s" % (VERSION,),
     "metis>=0.2a3",
     # Python 3.6 is only supported in NetworkX 2 and above
@@ -94,7 +95,6 @@ install_requires = [
     "pyswarm",
     # 1.10 contains an important race-condition fix on lazy-loaded modules
     "six>=1.10",
-    "cwlgen",
 ]
 
 setup(

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -95,8 +95,6 @@ install_requires = [
     # 1.10 contains an important race-condition fix on lazy-loaded modules
     "six>=1.10",
     "cwlgen",
-    "cwltool",
-    "gitpython",
 ]
 
 setup(

--- a/daliuge-translator/test-requirements.txt
+++ b/daliuge-translator/test-requirements.txt
@@ -1,0 +1,11 @@
+cwltool
+gitpython
+# cwltool's dependency breaks cwlgen's in python 2.7,
+# so we explicitly need to install a version that works
+# for both
+# A similar situation happens with typing, with pip failing
+# to automatically upgrade to >=3.7.4 when an installed
+# "typing" module satisfies a previous, more relaxed
+# constraint (e.g., >=3.5)
+ruamel.yaml==0.16.0; python_version=='2.7'
+typing>=3.7.4

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -212,6 +212,6 @@ class TestPGGen(unittest.TestCase):
             zip_ref.close()
 
             cmd = ['cwltool', '--validate', out]
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            p.communicate()
-            self.assertEqual(p.returncode, 0)
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            self.assertEqual(p.returncode, 0, b'stdout:\n' + stdout + b'\nstderr:\n' + stderr)


### PR DESCRIPTION
This a series of commits that fix the python 2.7 test failures. As mentioned in an earlier email I first took out the test-only dependencies into a new `test-requirements.txt` file, and also included there the necessary bits to ensure the test indirect dependencies are correctly installed.

After fixing the initial dependency conflict problem I found another one, which I also fixed. Once those were fixed yet another problem surfaced, related to how `cwlgen` handles `unicode` objects (it doesn't). I therefore added a fix for that problem as well.

After all these changes the Travis builds are back to green.