### PR TITLE
Messaging consolidation

### DIFF
--- a/daliuge-runtime/dlg/manager/node_manager.py
+++ b/daliuge-runtime/dlg/manager/node_manager.py
@@ -360,7 +360,7 @@ class ZMQPubSubMixIn(object):
     def subscribe(self, host, port):
         timeout = 5
         finished_evt = threading.Event()
-        endpoint = "tcp://%s:%d" % (host, port)
+        endpoint = "tcp://%s:%d" % (utils.zmq_safe(host), port)
         self._subscriptions.put(ZMQPubSubMixIn.subscription(endpoint, finished_evt))
         if not finished_evt.wait(timeout):
             raise DaliugeException("ZMQ subscription not achieved within %d seconds" % (timeout,))

--- a/daliuge-runtime/dlg/manager/node_manager.py
+++ b/daliuge-runtime/dlg/manager/node_manager.py
@@ -392,6 +392,7 @@ class ZMQPubSubMixIn(object):
                     logger.debug("Got an 'Again' when publishing event")
                     time.sleep(0.01)
                     continue
+        pub.close()
 
     def _zmq_sub_queue_thread(self):
         while self._pubsub_running:
@@ -427,6 +428,7 @@ class ZMQPubSubMixIn(object):
                 # Figure out what to do here
                 logger.exception("Something bad happened in %s:%d to ZMQ :'(", self._events_host, self._events_port)
                 break
+        sub.close()
 
 
 # So far we currently support ZMQ only for event publishing

--- a/daliuge-runtime/dlg/rpc.py
+++ b/daliuge-runtime/dlg/rpc.py
@@ -31,7 +31,6 @@ import importlib
 import logging
 import os
 import threading
-import time
 
 from six.moves import queue as Queue  # @UnresolvedImport
 

--- a/daliuge-runtime/setup.py
+++ b/daliuge-runtime/setup.py
@@ -153,10 +153,6 @@ extra_requires = {
     # spead is required only for a specific app and its test, which we
     # skip anyway if spead is not found
     "spead": ["spead2==0.4.0"],
-    # Pyro4 and RPyC are semi-supported RPC alternatives
-    # (while zerorpc is the default)
-    "pyro": ["Pyro4>=4.47"],  # 4.47 contains a fix we contributed
-    "rpyc": ["rpyc"],
     # drive-casa is used by some manual tests under test/integrate
     "drive-casa": ["drive-casa>0.7"],
     # MPI support (MPIApp drops and HPC experiments) requires mpi4py


### PR DESCRIPTION
This set of changes contains a series of improvements on the inter-node messaging system:

 * It creates a single Context object used by both the ZeroMQ publisher/subscriber and the ZeroRPC client/server code of the Node Manager. Previously the ZeroMQ publisher/subscriber, the ZeroRPC server, and each ZeroRPC client created their own Context objects, which implicitly creates a new I/O thread. Reducing these Context objects to a single one reduces this to a single I/O thread shared by all ZeroMQ-based code.
 * The naming of most of the internal members of the ZeroMQ publisher/subscriber class has been improved for easier code readibility.
 * A docstring has been added to the same class to explain how the code works internally, and which other alternatives have been sought.
 * The subscription mechanism has been improved to ensure the physical connection between a subscriber and the publisher it attempts to connect to is actually established before claiming success. This otherwise race condition was previously a constant source of (very) spurious errors in unit tests, and while it cannot be proven that the race condition doesn't exist anymore, we hope this change will improve the situation.