### PR TITLE
YAN-424 - CWL output to stdout

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -71,18 +71,13 @@ if sys.version_info[0] > 2:
         return b.decode(enc)
     def u2s(u):
         return u
-    def s2b(s, enc='utf-8'):
-        return s.encode(enc)
 else:
     def b2s(b, enc='utf8'):
         return b
     def u2s(u, enc='utf-8'):
         return u.encode(enc)
-    def s2b(s, enc='utf-8'):
-        return s
 b2s.__doc__ = "Converts bytes into a string"
 u2s.__doc__ = 'Converts text into a string'
-s2b.__doc__ = 'Converts a string into bytes'
 
 
 class dropdict(dict):

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -71,13 +71,18 @@ if sys.version_info[0] > 2:
         return b.decode(enc)
     def u2s(u):
         return u
+    def s2b(s, enc='utf-8'):
+        return s.encode(enc)
 else:
     def b2s(b, enc='utf8'):
         return b
     def u2s(u, enc='utf-8'):
         return u.encode(enc)
+    def s2b(s, enc='utf-8'):
+        return s
 b2s.__doc__ = "Converts bytes into a string"
 u2s.__doc__ = 'Converts text into a string'
+s2b.__doc__ = 'Converts a string into bytes'
 
 
 class dropdict(dict):

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -100,9 +100,9 @@ def create_workflow(drops, cwl_filename):
     zipBuffer = io.BytesIO()
     zipObj = ZipFile(zipBuffer, 'w')
     for step_file in step_files:
-        step_file_buffer = io.BytesIO(step_file["contents"])
+        step_file_buffer = io.BytesIO(common.u2s(step_file["contents"]))
         zipObj.writestr(step_file["filename"], step_file_buffer.getvalue())
-    workflow_file_buffer = io.BytesIO(cwl_workflow.export_string())
+    workflow_file_buffer = io.BytesIO(common.u2s(cwl_workflow.export_string()))
     zipObj.writestr(cwl_filename, workflow_file_buffer.getvalue())
     zipObj.close()
 

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -23,6 +23,7 @@
 import logging
 import os
 from zipfile import ZipFile
+import io
 
 import cwlgen
 
@@ -33,7 +34,7 @@ from dlg import common
 logger = logging.getLogger(__name__)
 
 
-def create_workflow(drops, pgt_path, cwl_path, zip_path):
+def create_workflow(drops, pgt_path, cwl_path):
     """
     Create a CWL workflow from a given Physical Graph Template
 
@@ -99,11 +100,14 @@ def create_workflow(drops, pgt_path, cwl_path, zip_path):
         f.write(cwl_workflow.export_string())
 
     # put workflow and command line tool description files all together in a zip
-    zipObj = ZipFile(zip_path, 'w')
+    zipBuffer = io.BytesIO()
+    zipObj = ZipFile(zipBuffer, 'w')
     for step_file in step_files:
         zipObj.write(step_file, os.path.basename(step_file))
     zipObj.write(cwl_path, os.path.basename(cwl_path))
     zipObj.close()
+
+    return zipBuffer.getvalue()
 
 
 def create_command_line_tool(node, filename):

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -100,9 +100,9 @@ def create_workflow(drops, cwl_filename):
     zipBuffer = io.BytesIO()
     zipObj = ZipFile(zipBuffer, 'w')
     for step_file in step_files:
-        step_file_buffer = io.BytesIO(common.u2s(step_file["contents"]))
+        step_file_buffer = io.BytesIO(common.s2b(step_file["contents"]))
         zipObj.writestr(step_file["filename"], step_file_buffer.getvalue())
-    workflow_file_buffer = io.BytesIO(common.u2s(cwl_workflow.export_string()))
+    workflow_file_buffer = io.BytesIO(common.s2b(cwl_workflow.export_string()))
     zipObj.writestr(cwl_filename, workflow_file_buffer.getvalue())
     zipObj.close()
 

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -22,8 +22,8 @@
 
 import logging
 import os
+import six
 from zipfile import ZipFile
-import io
 
 import cwlgen
 
@@ -34,7 +34,7 @@ from dlg import common
 logger = logging.getLogger(__name__)
 
 
-def create_workflow(drops, cwl_filename):
+def create_workflow(drops, cwl_filename, buffer):
     """
     Create a CWL workflow from a given Physical Graph Template
 
@@ -97,16 +97,11 @@ def create_workflow(drops, cwl_filename):
             cwl_workflow.steps.append(step)
 
     # put workflow and command line tool description files all together in a zip
-    zipBuffer = io.BytesIO()
-    zipObj = ZipFile(zipBuffer, 'w')
+    zipObj = ZipFile(buffer, 'w')
     for step_file in step_files:
-        step_file_buffer = io.BytesIO(common.s2b(step_file["contents"]))
-        zipObj.writestr(step_file["filename"], step_file_buffer.getvalue())
-    workflow_file_buffer = io.BytesIO(common.s2b(cwl_workflow.export_string()))
-    zipObj.writestr(cwl_filename, workflow_file_buffer.getvalue())
+        zipObj.writestr(step_file["filename"], six.b(step_file["contents"]))
+    zipObj.writestr(cwl_filename, six.b(cwl_workflow.export_string()))
     zipObj.close()
-
-    return zipBuffer.getvalue()
 
 
 def create_command_line_tool(node):

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -209,26 +209,20 @@ def pgtcwl_get():
         # get PGT from manager
         pgtp = pg_mgr.get_pgt(pgt_name)
 
-        # debug
-        print("pgtp:" + str(pgtp) + ":" + str(dir(pgtp)))
-
         # build filename for CWL file from PGT filename
         cwl_filename = pgt_name[:-6] + ".cwl"
         zip_filename = pgt_name[:-6] + ".zip"
 
-        # get paths used while creating the CWL files
-        root_path = pgt_path("")
-        zip_path = pgt_path(zip_filename)
-
-        # create the CWL workflow
-        zip_contents = create_workflow(pgtp.drops, cwl_filename);
-
-        # maybe eventually we don't need to write to file
-        with open(zip_path, 'wb') as f:
-            f.write(zip_contents)
+        # create the workflow
+        import io
+        buffer = io.BytesIO()
+        create_workflow(pgtp.drops, cwl_filename, buffer)
 
         # respond with download of ZIP file
-        return static_file(zip_filename, root=root_path, download=True)
+        response.content_type = 'application/zip'
+        response.set_header("Content-Disposition", "attachment; filename=%s" % (zip_filename))
+        return buffer.getvalue()
+
     else:
         response.status = 404
         return "{0}: JSON graph {1} not found\n".format(err_prefix, pgt_name)

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -222,7 +222,11 @@ def pgtcwl_get():
         zip_path = pgt_path(zip_filename)
 
         # create the CWL workflow
-        create_workflow(pgtp.drops, root_path, cwl_path, zip_path);
+        zip_contents = create_workflow(pgtp.drops, root_path, cwl_path);
+
+        # maybe eventually we don't need to write to file
+        with open(zip_path, 'wb') as f:
+            f.write(zip_contents)
 
         # respond with download of ZIP file
         return static_file(zip_filename, root=root_path, download=True)

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -218,11 +218,10 @@ def pgtcwl_get():
 
         # get paths used while creating the CWL files
         root_path = pgt_path("")
-        cwl_path = pgt_path(cwl_filename)
         zip_path = pgt_path(zip_filename)
 
         # create the CWL workflow
-        zip_contents = create_workflow(pgtp.drops, root_path, cwl_path);
+        zip_contents = create_workflow(pgtp.drops, cwl_filename);
 
         # maybe eventually we don't need to write to file
         with open(zip_path, 'wb') as f:

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -299,7 +299,7 @@ def cwl(parser, args):
 
     # create the CWL workflow
     from ..dropmake.cwl import create_workflow
-    zip_contents = create_workflow(pgt, "", "workflow.cwl")
+    zip_contents = create_workflow(pgt, "workflow.cwl")
 
     # write output
     with _open_o(opts.output) as f:

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -302,7 +302,7 @@ def cwl(parser, args):
     zip_contents = create_workflow(pgt, "workflow.cwl")
 
     # write output
-    with _open_o(opts.output) as f:
+    with _open_o(opts.output, "wb") as f:
         f.write(zip_contents)
 
 def register_commands():

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -299,7 +299,11 @@ def cwl(parser, args):
 
     # create the CWL workflow
     from ..dropmake.cwl import create_workflow
-    create_workflow(pgt, "", "workflow.cwl", opts.output)
+    zip_contents = create_workflow(pgt, "", "workflow.cwl")
+
+    # write output
+    with _open_o(opts.output) as f:
+        f.write(zip_contents)
 
 def register_commands():
     tool.cmdwrap('lgweb', 'A Web server for the Logical Graph Editor', 'dlg.dropmake.web.lg_web:run')

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -299,13 +299,10 @@ def cwl(parser, args):
 
     # create the CWL workflow
     from ..dropmake.cwl import create_workflow
-    import io
-    buffer = io.BytesIO()
-    create_workflow(pgt, "workflow.cwl", buffer)
 
     # write to file
     with _open_o(opts.output, "wb") as f:
-        f.write(buffer.getvalue())
+        create_workflow(pgt, "workflow.cwl", f)
 
 def register_commands():
     tool.cmdwrap('lgweb', 'A Web server for the Logical Graph Editor', 'dlg.dropmake.web.lg_web:run')

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -299,11 +299,13 @@ def cwl(parser, args):
 
     # create the CWL workflow
     from ..dropmake.cwl import create_workflow
-    zip_contents = create_workflow(pgt, "workflow.cwl")
+    import io
+    buffer = io.BytesIO()
+    create_workflow(pgt, "workflow.cwl", buffer)
 
-    # write output
+    # write to file
     with _open_o(opts.output, "wb") as f:
-        f.write(zip_contents)
+        f.write(buffer.getvalue())
 
 def register_commands():
     tool.cmdwrap('lgweb', 'A Web server for the Logical Graph Editor', 'dlg.dropmake.web.lg_web:run')

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -205,9 +205,15 @@ class TestPGGen(unittest.TestCase):
                 cwl_out_zip = cwl_output_dir + '/workflow.zip'
                 output_list.append((cwl_out, cwl_out_zip))
 
-                create_workflow(pgt, "", cwl_out, cwl_out_zip)
+                #create_workflow(pgt, "", cwl_out, cwl_out_zip)
+                cwl_contents = create_workflow(pgt, 'workflow.cwl')
+
+                # write output
+                with open(cwl_out_zip, 'w') as f:
+                    f.write(cwl_contents)
 
         for out, zip in output_list:
+            print("Testing. out:" + out + " zip:" + zip)
             zip_ref = zipfile.ZipFile(zip)
             zip_ref.extractall(os.path.dirname(zip))
             zip_ref.close()

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -205,7 +205,6 @@ class TestPGGen(unittest.TestCase):
                 cwl_out_zip = cwl_output_dir + '/workflow.zip'
                 output_list.append((cwl_out, cwl_out_zip))
 
-                #create_workflow(pgt, "", cwl_out, cwl_out_zip)
                 cwl_contents = create_workflow(pgt, 'workflow.cwl')
 
                 # write output
@@ -213,7 +212,6 @@ class TestPGGen(unittest.TestCase):
                     f.write(cwl_contents)
 
         for out, zip in output_list:
-            print("Testing. out:" + out + " zip:" + zip)
             zip_ref = zipfile.ZipFile(zip)
             zip_ref.extractall(os.path.dirname(zip))
             zip_ref.close()

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -168,6 +168,7 @@ class TestPGGen(unittest.TestCase):
 
     def test_cwl_translate(self):
         import git
+        import io
         import os
         import shutil
         import uuid
@@ -205,11 +206,12 @@ class TestPGGen(unittest.TestCase):
                 cwl_out_zip = cwl_output_dir + '/workflow.zip'
                 output_list.append((cwl_out, cwl_out_zip))
 
-                cwl_contents = create_workflow(pgt, 'workflow.cwl')
+                buffer = io.BytesIO()
+                create_workflow(pgt, 'workflow.cwl', buffer)
 
                 # write output
                 with open(cwl_out_zip, 'wb') as f:
-                    f.write(cwl_contents)
+                    f.write(buffer.getvalue())
 
         for out, zip in output_list:
             zip_ref = zipfile.ZipFile(zip)

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -209,7 +209,7 @@ class TestPGGen(unittest.TestCase):
                 cwl_contents = create_workflow(pgt, 'workflow.cwl')
 
                 # write output
-                with open(cwl_out_zip, 'w') as f:
+                with open(cwl_out_zip, 'wb') as f:
                     f.write(cwl_contents)
 
         for out, zip in output_list:

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -168,7 +168,6 @@ class TestPGGen(unittest.TestCase):
 
     def test_cwl_translate(self):
         import git
-        import io
         import os
         import shutil
         import uuid
@@ -206,12 +205,9 @@ class TestPGGen(unittest.TestCase):
                 cwl_out_zip = cwl_output_dir + '/workflow.zip'
                 output_list.append((cwl_out, cwl_out_zip))
 
-                buffer = io.BytesIO()
-                create_workflow(pgt, 'workflow.cwl', buffer)
-
                 # write output
                 with open(cwl_out_zip, 'wb') as f:
-                    f.write(buffer.getvalue())
+                    create_workflow(pgt, 'workflow.cwl', f)
 
         for out, zip in output_list:
             zip_ref = zipfile.ZipFile(zip)


### PR DESCRIPTION
Make the "dlg cwl" command output a zip file to stdout when no output file is specified by the user.

The main change is in tool_commands.py, where the cwl command now uses _open_o() with opts.output to send output to stdout.

Other changes are:
- modified input parameters to create_workflow() and create_command_line_tool(). Previously, these methods wrote the intermediate workflow and step files to disk, before combining the files into a zip file for output. Now the contents of the workflow and steps are held in strings, used to create io.BytesIO objects, and the zip file is built in memory.
- added a common.s2b() method, since the io.BytesIO() method requires "byte-like" input in Python 3. I'd be interested in feedback on this approach.
