### PR TITLE
Yan 425

### DIFF
--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -28,7 +28,10 @@ from zipfile import ZipFile
 import cwlgen
 
 from dlg import common
+from dlg.common import Categories
 
+# the following node categories are not supported by the CWL translator
+UNSUPPORTED_DATA_TYPES = [Categories.COMPONENT, Categories.MPI, Categories.DYNLIB_APP, Categories.DYNLIB_PROC_APP, Categories.DOCKER]
 
 #from ..common import dropdict, get_roots
 logger = logging.getLogger(__name__)
@@ -46,6 +49,14 @@ def create_workflow(drops, cwl_filename, buffer):
     NOTE: CWL only supports workflow steps that are bash shell applications
           Non-BashShellApp nodes are unable to be implemented in CWL
     """
+
+    # search the drops for non-BashShellApp drops,
+    # if found, the graph cannot be translated into CWL
+    for index, node in enumerate(drops):
+        dataType = node.get('dt', '')
+        if dataType in UNSUPPORTED_DATA_TYPES:
+            print("create_workflow(): Found unsupported data type:" + dataType)
+            raise Exception('Node {0} has an unsupported dataType: {1}'.format(index, dataType))
 
     # create list for command line tool description files
     step_files = []

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -55,7 +55,6 @@ def create_workflow(drops, cwl_filename, buffer):
     for index, node in enumerate(drops):
         dataType = node.get('dt', '')
         if dataType in UNSUPPORTED_DATA_TYPES:
-            print("create_workflow(): Found unsupported data type:" + dataType)
             raise Exception('Node {0} has an unsupported dataType: {1}'.format(index, dataType))
 
     # create list for command line tool description files

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -31,7 +31,7 @@ from dlg import common
 from dlg.common import Categories
 
 # the following node categories are not supported by the CWL translator
-UNSUPPORTED_DATA_TYPES = [Categories.COMPONENT, Categories.MPI, Categories.DYNLIB_APP, Categories.DYNLIB_PROC_APP, Categories.DOCKER]
+UNSUPPORTED_CATEGORIES = [Categories.COMPONENT, Categories.MPI, Categories.DYNLIB_APP, Categories.DYNLIB_PROC_APP, Categories.DOCKER]
 
 #from ..common import dropdict, get_roots
 logger = logging.getLogger(__name__)
@@ -54,8 +54,8 @@ def create_workflow(drops, cwl_filename, buffer):
     # if found, the graph cannot be translated into CWL
     for index, node in enumerate(drops):
         dataType = node.get('dt', '')
-        if dataType in UNSUPPORTED_DATA_TYPES:
-            raise Exception('Node {0} has an unsupported dataType: {1}'.format(index, dataType))
+        if dataType in UNSUPPORTED_CATEGORIES:
+            raise Exception('Node {0} has an unsupported category: {1}'.format(index, dataType))
 
     # create list for command line tool description files
     step_files = []

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -30,8 +30,8 @@ import cwlgen
 from dlg import common
 from dlg.common import Categories
 
-# the following node categories are not supported by the CWL translator
-UNSUPPORTED_CATEGORIES = [Categories.COMPONENT, Categories.MPI, Categories.DYNLIB_APP, Categories.DYNLIB_PROC_APP, Categories.DOCKER]
+# the following node categories are supported by the CWL translator
+SUPPORTED_CATEGORIES = [Categories.BASH_SHELL_APP, Categories.FILE]
 
 #from ..common import dropdict, get_roots
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ def create_workflow(drops, cwl_filename, buffer):
     # if found, the graph cannot be translated into CWL
     for index, node in enumerate(drops):
         dataType = node.get('dt', '')
-        if dataType in UNSUPPORTED_CATEGORIES:
+        if dataType not in SUPPORTED_CATEGORIES:
             raise Exception('Node {0} has an unsupported category: {1}'.format(index, dataType))
 
     # create list for command line tool description files

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -221,7 +221,6 @@ def pgtcwl_get():
         try:
             create_workflow(pgtp.drops, cwl_filename, buffer)
         except Exception as e:
-            print("pgt_cwl(): caught exception during create_workflow")
             response.status = 400 # HTTP 400 Bad Request
             return e
 
@@ -231,7 +230,6 @@ def pgtcwl_get():
         return buffer.getvalue()
 
     else:
-        print("pgt_cwl(): not found")
         response.status = 404
         return "{0}: JSON graph {1} not found\n".format(err_prefix, pgt_name)
 

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -204,8 +204,6 @@ def pgtcwl_get():
     Return CWL representation of the logical graph
     """
     pgt_name = request.query.get("pgt_name")
-    print("pgt_name:!" + pgt_name + "!")
-    print("pgt_exists:" + str(pgt_exists(pgt_name)))
 
     if pgt_exists(pgt_name):
         # get PGT from manager

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -204,6 +204,8 @@ def pgtcwl_get():
     Return CWL representation of the logical graph
     """
     pgt_name = request.query.get("pgt_name")
+    print("pgt_name:!" + pgt_name + "!")
+    print("pgt_exists:" + str(pgt_exists(pgt_name)))
 
     if pgt_exists(pgt_name):
         # get PGT from manager
@@ -216,7 +218,12 @@ def pgtcwl_get():
         # create the workflow
         import io
         buffer = io.BytesIO()
-        create_workflow(pgtp.drops, cwl_filename, buffer)
+        try:
+            create_workflow(pgtp.drops, cwl_filename, buffer)
+        except Exception as e:
+            print("pgt_cwl(): caught exception during create_workflow")
+            response.status = 400 # HTTP 400 Bad Request
+            return e
 
         # respond with download of ZIP file
         response.content_type = 'application/zip'
@@ -224,6 +231,7 @@ def pgtcwl_get():
         return buffer.getvalue()
 
     else:
+        print("pgt_cwl(): not found")
         response.status = 404
         return "{0}: JSON graph {1} not found\n".format(err_prefix, pgt_name)
 

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -481,25 +481,41 @@
     }
   }
 
-  function makeCWL() {
-    //given a logical graph name, get its CWL from the server
-    $.ajax({
-        url: "/pgt_cwl?pgt_name={{pgt_view_json_name}}",
-        type: 'get',
-        error: function(XMLHttpRequest, textStatus, errorThrown) {
-            console.log("makeCWL() : error")
-            if (404 == XMLHttpRequest.status) {
-              console.error('Server cannot locate physical graph file {{pgt_view_json_name}}');
-              return;
-            }
-            if (400 == XMLHttpRequest.status) {
-              alert(XMLHttpRequest.responseText);
-              return;
-            }
+  function getCWLZipFilenameFromResponseURL(url){
+      const FILE_NAME_PREFIX = "pgt_name=";
+      return url.substring(url.lastIndexOf(FILE_NAME_PREFIX) + FILE_NAME_PREFIX.length, url.lastIndexOf('.graph')) + ".zip";
+  }
 
-            console.error('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
+  function makeCWL() {
+    var fileName = "";
+    var error = "";
+
+    fetch('/pgt_cwl?pgt_name={{pgt_view_json_name}}')
+      .then(async resp => {
+
+        // if fetch was not successful, await the error message in the body of the response
+        if (resp.status !== 200){
+            error = await resp.text();
+            return;
         }
-    });
+
+        // otherwise, re-generate a filename for the download
+        filename = getCWLZipFilenameFromResponseURL(resp.url);
+
+        return resp.blob();
+      })
+      .then(blob => {
+        // build an object URL from the response and 'download' it
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.style.display = 'none';
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(url);
+      })
+      .catch(() => alert(error)); // present error, if it occurred
   }
 
   function zoomToFit() {

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -589,7 +589,6 @@
     <button id="gantt_button" class="button" onclick="genGanttChart()">Produce Gantt Chart</button>
     <button id="schedule_button" class="button" onclick="genScheduleChart()">Produce Schedule Matrix</button>
     <button id="png_button" class="button" onclick="makePNG()">Export to PNG</button>
-    <!--<button id="cwl_button" class="button" onclick="window.location.href='/pgt_cwl?pgt_name={{pgt_view_json_name}}'">Export to CWL</button>-->
     <button id="cwl_button" class="button" onclick="makeCWL()">Export to CWL</button>
     <button id="zoom_button" class="button" onclick="zoomToFit()">Zoom to Fit</button>
   </div>

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -487,14 +487,17 @@
         url: "/pgt_cwl?pgt_name={{pgt_view_json_name}}",
         type: 'get',
         error: function(XMLHttpRequest, textStatus, errorThrown) {
+            console.log("makeCWL() : error")
             if (404 == XMLHttpRequest.status) {
               console.error('Server cannot locate physical graph file {{pgt_view_json_name}}');
-            } else {
-              console.error('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
+              return;
             }
-        },
-        success: function(data){
-          console.log("success", data);
+            if (400 == XMLHttpRequest.status) {
+              alert(XMLHttpRequest.responseText);
+              return;
+            }
+
+            console.error('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
         }
     });
   }
@@ -570,7 +573,8 @@
     <button id="gantt_button" class="button" onclick="genGanttChart()">Produce Gantt Chart</button>
     <button id="schedule_button" class="button" onclick="genScheduleChart()">Produce Schedule Matrix</button>
     <button id="png_button" class="button" onclick="makePNG()">Export to PNG</button>
-    <button id="cwl_button" class="button" onclick="window.location.href='/pgt_cwl?pgt_name={{pgt_view_json_name}}'">Export to CWL</button>
+    <!--<button id="cwl_button" class="button" onclick="window.location.href='/pgt_cwl?pgt_name={{pgt_view_json_name}}'">Export to CWL</button>-->
+    <button id="cwl_button" class="button" onclick="makeCWL()">Export to CWL</button>
     <button id="zoom_button" class="button" onclick="zoomToFit()">Zoom to Fit</button>
   </div>
 </div>

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -301,11 +301,8 @@ def cwl(parser, args):
     from ..dropmake.cwl import create_workflow
 
     # write to file
-    try:
-        with _open_o(opts.output, "wb") as f:
-            create_workflow(pgt, "workflow.cwl", f)
-    except Exception as e:
-        logger.error(e)
+    with _open_o(opts.output, "wb") as f:
+        create_workflow(pgt, "workflow.cwl", f)
 
 def register_commands():
     tool.cmdwrap('lgweb', 'A Web server for the Logical Graph Editor', 'dlg.dropmake.web.lg_web:run')

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -301,8 +301,11 @@ def cwl(parser, args):
     from ..dropmake.cwl import create_workflow
 
     # write to file
-    with _open_o(opts.output, "wb") as f:
-        create_workflow(pgt, "workflow.cwl", f)
+    try:
+        with _open_o(opts.output, "wb") as f:
+            create_workflow(pgt, "workflow.cwl", f)
+    except Exception as e:
+        logger.error(e)
 
 def register_commands():
     tool.cmdwrap('lgweb', 'A Web server for the Logical Graph Editor', 'dlg.dropmake.web.lg_web:run')


### PR DESCRIPTION
The purpose of this change is to provide feedback to the user when the translation of a physical graph into a CWL workflow fails. I've been using these two files as examples of succeeding and failing graphs (respectively):

- ICRAR/EAGLE_test_repo /SP-602/YAN-251-001.graph
- ICRAR/EAGLE_test_repo /YAN-425/DynlibApp.graph

The main change is to cwl.py create_workflow(), where an Exception is raised if a node with an unsupported category is found.

If create_workflow() was run from the command line, the error is logged.
If create_workflow() was run in response to a request to lgweb, then lgweb responds with a HTTP 400 Bad Request, and the client-side (pg_viewer.html) displays an alert() message with the error.