### PR TITLE
Correctly update the "status" text on the DIM session view 

### DIFF
--- a/daliuge-engine/dlg/manager/web/static/js/dm.js
+++ b/daliuge-engine/dlg/manager/web/static/js/dm.js
@@ -307,7 +307,6 @@ function startStatusQuery(serverUrl, sessionId, selectedNode, graph_update_handl
 	url += '/sessions/' + sessionId;
 
 	function updateGraph() {
-
 		d3.json(url, function(error, sessionInfo) {
 
 			if (error) {
@@ -440,7 +439,7 @@ function startGraphStatusUpdates(serverUrl, sessionId, selectedNode, delay,
 
 			var allCompleted = statuses.reduce(function(prevVal, curVal, idx, arr) {
 				var cur_status = get_status_name(curVal);
-				return prevVal && (cur_status == 'completed' || cur_status == 'error' || cur_status == 'cancelled');
+				return prevVal && (cur_status == 'completed' || cur_status == 'finished' || cur_status == 'error' || cur_status == 'cancelled');
 			}, true);
 			if (!allCompleted) {
 				d3.timer(updateStates, delay);


### PR DESCRIPTION
The client-side javascript repeatedly calls the updateGraph function to fetch the status of all nodes in graph. Upon receiving a reply, updateGraph determines whether all the nodes are complete using a reduce() function and stores the result in a variable called 'allCompleted'.

Once the value of allCompleted becomes true, the status of the whole session is queried and the result, which should be 'finished' is added to the HTML to be visible to the user.

Previously, the reduce function would only consider nodes as complete if their status was 'completed', 'error' or 'cancelled'. However, since some nodes only achieve the 'finished' state, allCompleted would never become true, and therefore the session state would not progress past 'running' (until the page was reloaded, or a different display type was requested).

This change modifies the reduce function to consider nodes which are 'finished' as completed. Meaning that allCompleted can become true, and therefore the session status will be updated as expected.