### PR TITLE
Python3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ matrix:
     # - python: "3.8"
     #   env: TEST_OPENAPI=1
     - python: "3.7"
-    - python: "3.6"
-    - python: "3.5"
     - name: doxygen
       if: branch = master
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
     - python: "3.7"
     - python: "3.6"
     - python: "3.5"
-    - python: "2.7"
     - name: doxygen
       if: branch = master
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
     - python: "3.5"
     - python: "2.7"
     - name: doxygen
-      if: branch = master   
+      if: branch = master
       before_install:
       install:
         - sudo apt-get update && sudo apt-get install -y doxygen && sudo apt-get install -y xsltproc
       script:
         - GIT_REPO=$(git config --get remote.origin.url) PROJECT_VERSION=$(git rev-parse --short HEAD) doxygen
-      after_success:  
+      after_success:
         - cd DALIUGE/xml
         - xsltproc combine.xslt index.xml >daliuge.xml
         - wget https://raw.githubusercontent.com/james-strauss-uwa/xml2palette/master/xml2palette.py

--- a/daliuge-common/dlg/clients.py
+++ b/daliuge-common/dlg/clients.py
@@ -21,8 +21,7 @@
 #
 import logging
 import os
-
-from six.moves import urllib_parse as urllib  # @UnresolvedImport
+import urllib.parse
 
 from . import constants
 from .restutils import RestClient
@@ -30,6 +29,8 @@ from .restutils import RestClient
 
 logger = logging.getLogger(__name__)
 compress = os.environ.get('DALIUGE_COMPRESSED_JSON', True)
+
+quote = urllib.parse.quote
 
 class BaseDROPManagerClient(RestClient):
     """
@@ -47,7 +48,7 @@ class BaseDROPManagerClient(RestClient):
         self._POST('/stop')
 
     def cancelSession(self, sessionId):
-        self._POST('/sessions/%s/cancel' % urllib.quote(sessionId))
+        self._POST('/sessions/%s/cancel' % quote(sessionId))
 
     def create_session(self, sessionId):
         """
@@ -64,7 +65,7 @@ class BaseDROPManagerClient(RestClient):
         content = None
         if completed_uids:
             content = {'completed': ','.join(completed_uids)}
-        self._post_form('/sessions/%s/deploy' % (urllib.quote(sessionId),), content)
+        self._post_form('/sessions/%s/deploy' % (quote(sessionId),), content)
         logger.debug('Successfully deployed session %s on %s:%s', sessionId, self.host, self.port)
 
     def append_graph(self, sessionId, graphSpec):
@@ -72,14 +73,14 @@ class BaseDROPManagerClient(RestClient):
         Appends a graph to session `sessionId`, without creating its DROPs yet,
         but checking that the graph looks correct
         """
-        self._post_json('/sessions/%s/graph/append' % (urllib.quote(sessionId),), graphSpec, compress=compress)
+        self._post_json('/sessions/%s/graph/append' % (quote(sessionId),), graphSpec, compress=compress)
         logger.debug('Successfully appended graph to session %s on %s:%s', sessionId, self.host, self.port)
 
     def destroy_session(self, sessionId):
         """
         Destroys session `sessionId`
         """
-        self._DELETE('/sessions/%s' % (urllib.quote(sessionId),))
+        self._DELETE('/sessions/%s' % (quote(sessionId),))
         logger.debug('Successfully deleted session %s on %s:%s', sessionId, self.host, self.port)
 
     def graph_status(self, sessionId):
@@ -87,7 +88,7 @@ class BaseDROPManagerClient(RestClient):
         Returns a dictionary where the keys are DROP UIDs and the values are
         their corresponding status.
         """
-        ret = self._get_json('/sessions/%s/graph/status' % (urllib.quote(sessionId),))
+        ret = self._get_json('/sessions/%s/graph/status' % (quote(sessionId),))
         logger.debug('Successfully read graph status from session %s on %s:%s', sessionId, self.host, self.port)
         return ret
 
@@ -96,7 +97,7 @@ class BaseDROPManagerClient(RestClient):
         Returns a dictionary where the key are the DROP UIDs, and the values are
         the DROP specifications.
         """
-        graph = self._get_json('/sessions/%s/graph' % (urllib.quote(sessionId),))
+        graph = self._get_json('/sessions/%s/graph' % (quote(sessionId),))
         logger.debug('Successfully read graph (%d nodes) from session %s on %s:%s', len(graph), sessionId, self.host, self.port)
         return graph
 
@@ -112,7 +113,7 @@ class BaseDROPManagerClient(RestClient):
         """
         Returns the details of sessions `sessionId`
         """
-        session = self._get_json('/sessions/%s' % (urllib.quote(sessionId),))
+        session = self._get_json('/sessions/%s' % (quote(sessionId),))
         logger.debug('Successfully read session %s from %s:%s', sessionId, self.host, self.port)
         return session
 
@@ -120,7 +121,7 @@ class BaseDROPManagerClient(RestClient):
         """
         Returns the status of session `sessionId`
         """
-        status = self._get_json('/sessions/%s/status' % (urllib.quote(sessionId),))
+        status = self._get_json('/sessions/%s/status' % (quote(sessionId),))
         logger.debug('Successfully read session %s status (%s) from %s:%s', sessionId, status, self.host, self.port)
         return status
 
@@ -128,7 +129,7 @@ class BaseDROPManagerClient(RestClient):
         """
         Returns the size of the graph of session `sessionId`
         """
-        count = self._get_json('/sessions/%s/graph/size' % (urllib.quote(sessionId)))
+        count = self._get_json('/sessions/%s/graph/size' % (quote(sessionId)))
         logger.debug('Successfully read session %s graph size (%d) from %s:%s', sessionId, count, self.host, self.port)
         return count
 
@@ -150,10 +151,10 @@ class NodeManagerClient(BaseDROPManagerClient):
         super(NodeManagerClient, self).__init__(host=host, port=port, timeout=timeout)
 
     def add_node_subscriptions(self, sessionId, node_subscriptions):
-        self._post_json('/sessions/%s/subscriptions' % (urllib.quote(sessionId),), node_subscriptions)
+        self._post_json('/sessions/%s/subscriptions' % (quote(sessionId),), node_subscriptions)
 
     def trigger_drops(self, sessionId, drop_uids):
-        self._post_json('/sessions/%s/trigger' % (urllib.quote(sessionId),), drop_uids)
+        self._post_json('/sessions/%s/trigger' % (quote(sessionId),), drop_uids)
 
     def shutdown_node_manager(self):
         self._GET('/shutdown')
@@ -184,4 +185,4 @@ class MasterManagerClient(CompositeManagerClient):
         super(MasterManagerClient, self).__init__(host=host, port=port, timeout=timeout)
 
     def create_island(self, island_host, nodes):
-        self._post_json('/managers/%s/dataisland' % (urllib.quote(island_host)), {'nodes': nodes})
+        self._post_json('/managers/%s/dataisland' % (quote(island_host)), {'nodes': nodes})

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -20,8 +20,6 @@
 #    MA 02111-1307  USA
 #
 """Common utilities used by daliuge packages"""
-import sys
-
 from .osutils import terminate_or_kill, wait_or_kill
 from .network import check_port, connect_to, portIsClosed, portIsOpen, write_to
 from .streams import ZlibCompressedStream, JSONStream
@@ -76,18 +74,9 @@ APP_DROP_TYPES = [
     Categories.DYNLIB_PROC_APP,
 ]
 
-if sys.version_info[0] > 2:
-    def b2s(b, enc='utf8'):
-        return b.decode(enc)
-    def u2s(u):
-        return u
-else:
-    def b2s(b, enc='utf8'):
-        return b
-    def u2s(u, enc='utf-8'):
-        return u.encode(enc)
-b2s.__doc__ = "Converts bytes into a string"
-u2s.__doc__ = 'Converts text into a string'
+def b2s(b, enc='utf8'):
+    "Converts bytes into a string"
+    return b.decode(enc)
 
 
 class dropdict(dict):

--- a/daliuge-common/setup.py
+++ b/daliuge-common/setup.py
@@ -45,11 +45,6 @@ def do_versioning():
     exec(code, _globals)
     return _globals['write_version_info'](VERSION, VERSION_FILE, RELEASE)
 
-install_requires = [
-    # 1.10 contains an important race-condition fix on lazy-loaded modules
-    "six>=1.10",
-]
-
 setup(
     name="daliuge-common",
     version=do_versioning(),
@@ -60,7 +55,6 @@ setup(
     url="https://github.com/ICRAR/daliuge",
     license="LGPLv2+",
     packages=find_packages(),
-    install_requires=install_requires,
     test_suite="test",
     entry_points={"console_scripts": ["dlg=dlg.common.tool:run"]},  # One tool to rule them all
 )

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -38,7 +38,6 @@ import tempfile
 import threading
 import time
 import types
-import six
 
 from .. import droputils, utils
 from ..ddap_protocol import AppDROPStates, DROPStates
@@ -88,7 +87,7 @@ def prepare_output_channel(this_node, out_drop):
         # the pipe needs to be opened after the data is sent to the other
         # application because open() blocks until the other end is also
         # opened
-        data = six.b("pipe://%s" % (pipe_name,))
+        data = ("pipe://%s" % (pipe_name,)).encode('utf8')
         out_drop.write(data)
         return open(pipe_name, 'wb')
 
@@ -102,7 +101,7 @@ def prepare_output_channel(this_node, out_drop):
 
         # to get a connection from the other side we have to write the data
         # into the output drop first so the other side connects to us
-        out_drop.write(six.b("tcp://%s:%d" % (host, port)))
+        out_drop.write(("tcp://%s:%d" % (host, port)).encode('utf8'))
         with contextlib.closing(sock):
             csock, csockaddr = sock.accept()
             csock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 1000))

--- a/daliuge-engine/dlg/apps/crc.py
+++ b/daliuge-engine/dlg/apps/crc.py
@@ -23,8 +23,6 @@
 Module containing an example application that calculates a CRC value
 """
 
-import six
-
 from ..drop import BarrierAppDROP, AppDROP
 from dlg.ddap_protocol import AppDROPStates
 from ..meta import dlg_component, dlg_batch_input, dlg_batch_output, dlg_streaming_input
@@ -68,7 +66,7 @@ class CRCApp(BarrierAppDROP):
 
         # Rely on whatever implementation we decide to use
         # for storing our data
-        outputDrop.write(six.b(str(crc)))
+        outputDrop.write(str(crc).encode('utf8'))
 
 
 class CRCStreamApp(AppDROP):
@@ -91,6 +89,6 @@ class CRCStreamApp(AppDROP):
 
     def dropCompleted(self, uid, status):
         outputDrop = self.outputs[0]
-        outputDrop.write(six.b(str(self._crc)))
+        outputDrop.write(str(self._crc).encode('utf8'))
         self.execStatus = AppDROPStates.FINISHED
         self._notifyAppIsFinished()

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -20,12 +20,12 @@
 #    MA 02111-1307  USA
 #
 """Applications used as examples, for testing, or in simple situations"""
+import pickle
+import urllib.error
+import urllib.request
 
 import time
 import numpy as np
-import six
-import six.moves.cPickle as pickle
-import six.moves.urllib as urllib
 
 from .. import droputils, utils
 from ..drop import BarrierAppDROP, ContainerDROP

--- a/daliuge-engine/dlg/dask_emulation.py
+++ b/daliuge-engine/dlg/dask_emulation.py
@@ -24,11 +24,10 @@
 import base64
 import contextlib
 import logging
+import pickle
 import socket
 import struct
 import time
-
-import six.moves.cPickle as pickle  # @UnresolvedImport
 
 from . import utils, droputils
 from .apps import pyfunc

--- a/daliuge-engine/dlg/deploy/pawsey/dfms_proxy.py
+++ b/daliuge-engine/dlg/deploy/pawsey/dfms_proxy.py
@@ -42,8 +42,6 @@ import struct
 import sys, logging
 import time
 
-import six
-
 from ...utils import b2s
 
 BUFF_SIZE = 16384
@@ -110,7 +108,7 @@ class ProxyServer:
     def connect_monitor_host(self):
         # After connecting we identify ourselves using our ID with the monitor
         the_socket = self.connect_to_host(self._monitor_host, self._monitor_port)
-        the_socket.sendall(b"%-80s" % six.b(self._proxy_id))
+        the_socket.sendall(b"%-80s" % self._proxy_id.encode('utf8'))
         logger.info('Identifying ourselves as %s with monitor', self._proxy_id)
         ok = int(recvall(the_socket, 1))
         if not ok:

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -24,12 +24,11 @@ Utility methods and classes to be used when interacting with DROPs
 '''
 
 import collections
+import io
 import logging
 import re
 import threading
 import traceback
-
-import six
 
 from .ddap_protocol import DROPStates
 from .drop import AppDROP
@@ -100,7 +99,7 @@ def allDropContents(drop, bufsize=4096):
     '''
     Returns all the data contained in a given DROP
     '''
-    buf = six.BytesIO()
+    buf = io.BytesIO()
     desc = drop.open()
     read = drop.read
 

--- a/daliuge-engine/dlg/io.py
+++ b/daliuge-engine/dlg/io.py
@@ -20,12 +20,10 @@
 #    MA 02111-1307  USA
 #
 from abc import abstractmethod, ABCMeta
+import io
 import logging
 import os
-
-from six import BytesIO
-import six.moves.urllib.parse as urlparse  # @UnresolvedImport
-import six.moves.urllib.request as urlrequest
+import urllib.parse
 
 from . import ngaslite
 
@@ -187,7 +185,7 @@ class MemoryIO(DataIO):
         if self._mode == OpenMode.OPEN_WRITE:
             return self._buf
         else:
-            return BytesIO(self._buf.getvalue())
+            return io.BytesIO(self._buf.getvalue())
 
     def _write(self, data, **kwargs):
         self._desc.write(data)
@@ -390,7 +388,7 @@ def IOForURL(url):
     Returns a DataIO instance that handles the given URL for reading. If no
     suitable DataIO class can be found to handle the URL, `None` is returned.
     """
-    url = urlparse.urlparse(url)
+    url = urllib.parse.urlparse(url)
     io = None
     if url.scheme == 'file':
         hostname = url.netloc

--- a/daliuge-engine/dlg/ngaslite.py
+++ b/daliuge-engine/dlg/ngaslite.py
@@ -28,9 +28,9 @@ still need to access NGAS from time to time.
 @author: rtobar
 '''
 
-import six.moves.http_client as httplib  # @UnresolvedImport
-import six.moves.urllib.request as urlrequest
+import http.client
 import logging
+import urllib.request
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +50,8 @@ def retrieve(host, fileId, port=7777, timeout=None):
     """
     url = 'http://%s:%d/RETRIEVE?file_id=%s' % (host, port, fileId)
     logger.debug("Issuing RETRIEVE request: %s" % (url))
-    conn = urlrequest.urlopen(url)
-    if conn.getcode() != httplib.OK:
+    conn = urllib.request.urlopen(url)
+    if conn.getcode() != http.HTTPStatus.OK:
         raise Exception("Error while RETRIEVE-ing %s from %s:%d: %d %s" % (fileId, host, port, conn.getcode(), conn.msg))
     return conn
 
@@ -66,7 +66,7 @@ def beginArchive(host, fileId, port=7777, timeout=0, length=-1, mimeType='applic
     should be invoked to check that all went well with the archiving.
     """
     logger.debug("Issuing ARCHIVE for file %s request to: http://%s:%d" % (fileId, host,port))
-    conn = httplib.HTTPConnection(host, port, timeout=timeout)
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
     conn.putrequest('POST', '/QARCHIVE?filename=' + fileId)
     conn.putheader('Content-Type', mimeType)
     if length is not None and length >= 0:
@@ -80,5 +80,5 @@ def finishArchive(conn, fileId):
     Checks that an archiving started by `beginArchive` went on successfully.
     """
     response = conn.getresponse()
-    if response.status != httplib.OK:
+    if response.status != http.HTTPStatus.OK:
         raise Exception("Error while QARCHIVE-ing %s to %s:%d: %d %s" % (fileId, conn.host, conn.port, response.status, response.msg))

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -28,12 +28,11 @@ technologies we support.
 
 import collections
 import logging
+import queue
 import threading
 
 import gevent
 import zerorpc
-
-from six.moves import queue as Queue  # @UnresolvedImport
 
 from . import utils
 
@@ -120,7 +119,7 @@ class ZeroRPCClient(RPCClientBase):
 
             # We start the new client on its own thread so it uses gevent, etc.
             # In this thread we create simply enqueue requests
-            req_queue = Queue.Queue()
+            req_queue = queue.Queue()
             tname_tpl, args = "zrpc(%s:%d)", (host, port)
             t = threading.Thread(target=self.run_zrpcclient, args=(host, port, req_queue),
                                  name=tname_tpl % args)
@@ -128,7 +127,7 @@ class ZeroRPCClient(RPCClientBase):
 
             class QueueingClient(object):
                 def __make_call(self, method, *args):
-                    res_queue = Queue.Queue()
+                    res_queue = queue.Queue()
                     req_queue.put(ZeroRPCClient.request(method, args, res_queue))
                     x = res_queue.get()
                     if x.is_exception:
@@ -160,7 +159,7 @@ class ZeroRPCClient(RPCClientBase):
             try:
                 req = req_queue.get_nowait()
                 gevent.spawn(self.queue_request, client, req)
-            except Queue.Empty:
+            except queue.Empty:
                 gevent.sleep(0.005)
 
     def process_response(self, req, async_response):

--- a/daliuge-engine/dlg/utils.py
+++ b/daliuge-engine/dlg/utils.py
@@ -26,6 +26,7 @@ Module containing miscellaneous utility classes and functions.
 import errno
 import functools
 import importlib
+import io
 import logging
 import os
 import signal
@@ -35,7 +36,6 @@ import time
 import zlib
 
 import netifaces
-import six
 
 from . import common
 
@@ -317,7 +317,7 @@ class ZlibUncompressedStream(object):
             return b''
 
         content = self.content
-        response = six.BytesIO()
+        response = io.BytesIO()
         decompressor = self.decompressor
 
         blocksize = 8192

--- a/daliuge-engine/pip/requirements.txt
+++ b/daliuge-engine/pip/requirements.txt
@@ -16,8 +16,6 @@ pyswarm
 python-daemon
 pyzmq
 scp
-# 1.10 contains an important race-condition fix on lazy-loaded modules
-six>=1.10
 twine
 # 0.6 brings python3 support plus other fixes
 zerorpc >= 0.6

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -129,24 +129,14 @@ install_requires = [
     "python-daemon",
     "pyzmq",
     "scp",
+    # 0.19.0 requires netifaces < 0.10.5, exactly the opposite of what *we* need
+    "zeroconf >= 0.19.1",
     # 0.6 brings python3 support plus other fixes
     "zerorpc >= 0.6",
     "pyarrow",
     "numpy"
 ]
 # Keep alpha-sorted PLEASE!
-
-# Python 2 support has been dropped in zeroconf 0.20.
-# Also, 0.19.0 requires netifaces < 0.10.5, exactly the opposite of what *we* need
-# Also, 0.21.0 erroneously tags 3.4 as supported, while in fact it isn't
-# (see https://github.com/jstasiak/python-zeroconf/issues/139 for details).
-# We provided a fix for that, so from 0.21.1 is already good.
-if sys.version_info[:2] == (2, 7):
-    install_requires.append("zeroconf == 0.19.1")
-elif sys.version_info[:2] <= (3, 4):
-    install_requires.append("zeroconf != 0.21.0")
-else:
-    install_requires.append("zeroconf >= 0.19.1")
 
 # Extra requirements that are not needed by your every day daliuge installation
 extra_requires = {

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -129,8 +129,6 @@ install_requires = [
     "python-daemon",
     "pyzmq",
     "scp",
-    # 1.10 contains an important race-condition fix on lazy-loaded modules
-    "six>=1.10",
     # 0.6 brings python3 support plus other fixes
     "zerorpc >= 0.6",
     "pyarrow",

--- a/daliuge-engine/test/apps/test_bash.py
+++ b/daliuge-engine/test/apps/test_bash.py
@@ -28,8 +28,6 @@ import shutil
 import tempfile
 import unittest
 
-import six
-
 from dlg import droputils
 from dlg.apps.bash_shell_app import BashShellApp, StreamingInputBashApp,\
     StreamingOutputBashApp, StreamingInputOutputBashApp
@@ -76,7 +74,7 @@ class BashAppTests(unittest.TestCase):
             a.addOutput(b)
             with DROPWaiterCtx(self, b, 100):
                 a.async_execute()
-            self.assertEqual(six.b(message), droputils.allDropContents(b))
+            self.assertEqual(message.encode('utf8'), droputils.allDropContents(b))
 
         msg = "This is a message with a single quote: '"
         assert_message_is_correct(msg, 'echo -n "{0}" > %o0'.format(msg))
@@ -101,7 +99,7 @@ class BashAppTests(unittest.TestCase):
             a.addOutput(b)
             with DROPWaiterCtx(self, b, 100):
                 a.async_execute()
-            self.assertEqual(six.b(value), droputils.allDropContents(b))
+            self.assertEqual(value.encode('utf8'), droputils.allDropContents(b))
 
         assert_envvar_is_there('DLG_UID', app_uid)
         assert_envvar_is_there('DLG_SESSION_ID', session_id)
@@ -144,7 +142,7 @@ class StreamingBashAppTests(unittest.TestCase):
         # The application executed, finished, and its output was recorded
         for drop in (a,b,c,d):
             self.assertEqual(DROPStates.COMPLETED, drop.status, "Drop %r not COMPLETED: %d" % (drop, drop.status))
-        self.assertEqual([5,4,3,2,1], [int(x) for x in droputils.allDropContents(d).split(six.b('\n'))])
+        self.assertEqual([5,4,3,2,1], [int(x) for x in droputils.allDropContents(d).split(b'\n')])
 
         # Clean up and go
         os.remove(output_fname)
@@ -190,7 +188,7 @@ class StreamingBashAppTests(unittest.TestCase):
         # The application executed, finished, and its output was recorded
         for drop in (a,b,c,d,e,f):
             self.assertEqual(DROPStates.COMPLETED, drop.status)
-        self.assertEqual([1,2,3,4,5], [int(x) for x in droputils.allDropContents(f).strip().split(six.b('\n'))])
+        self.assertEqual([1,2,3,4,5], [int(x) for x in droputils.allDropContents(f).strip().split(b'\n')])
 
         # Clean up and go
         os.remove(output_fname)

--- a/daliuge-engine/test/apps/test_crc.py
+++ b/daliuge-engine/test/apps/test_crc.py
@@ -26,8 +26,6 @@ Test the CRCApp application
 import os
 import unittest
 
-import six
-
 from dlg import droputils
 from dlg.apps.crc import CRCApp, crc32
 from dlg.apps.dynlib import DynlibApp
@@ -74,7 +72,7 @@ class CRCAppTests(unittest.TestCase):
 
         # The crc32 is the same used by the CRCApp, see the imports
         data = os.urandom(1024)
-        crc = six.b(str(crc32(data)))
+        crc = str(crc32(data)).encode('utf8')
 
         # Execute the graph and check results
         with droputils.DROPWaiterCtx(self, (e, h, j), 5):

--- a/daliuge-engine/test/apps/test_docker.py
+++ b/daliuge-engine/test/apps/test_docker.py
@@ -27,7 +27,6 @@ import unittest
 
 import configobj
 import docker
-import six
 
 from dlg import droputils, utils
 from dlg.apps.dockerapp import DockerApp
@@ -139,7 +138,7 @@ class DockerTests(unittest.TestCase):
             a.addOutput(b)
             with DROPWaiterCtx(self, b, 100):
                 a.execute()
-            self.assertEqual(six.b(msg), droputils.allDropContents(b))
+            self.assertEqual(msg.encode('utf8'), droputils.allDropContents(b))
 
         msg = "This is a message with a single quote: '"
         assertMsgIsCorrect(msg, 'echo -n "{0}" > %o0'.format(msg))
@@ -169,7 +168,7 @@ class DockerTests(unittest.TestCase):
         b.addOutput(c)
         with DROPWaiterCtx(self, c, 100):
             a.setCompleted()
-        self.assertEqual(six.b(a.dataURL), droputils.allDropContents(c))
+        self.assertEqual(a.dataURL.encode('utf8'), droputils.allDropContents(c))
 
 
     def test_additional_bindings(self):

--- a/daliuge-engine/test/apps/test_dynlib.py
+++ b/daliuge-engine/test/apps/test_dynlib.py
@@ -20,11 +20,10 @@
 #    MA 02111-1307  USA
 #
 import functools
+import io
 import os
 import time
 import unittest
-
-import six
 
 from .setp_up import build_shared_library
 from ..manager import test_dm
@@ -79,7 +78,7 @@ class DynlibAppTest(unittest.TestCase):
 
         # ~100 MBs of data should be copied over from a to c and d via b, etc
         data = os.urandom(1024 * 1024) * 100
-        reader = six.BytesIO(data)
+        reader = io.BytesIO(data)
         with droputils.DROPWaiterCtx(self, (c, d, f, g), 10):
             if streaming:
                 # Write the data in chunks so we actually exercise multiple calls

--- a/daliuge-engine/test/apps/test_dynlib2.py
+++ b/daliuge-engine/test/apps/test_dynlib2.py
@@ -20,11 +20,10 @@
 #    MA 02111-1307  USA
 #
 import functools
+import io
 import os
 import time
 import unittest
-
-import six
 
 from .setp_up import build_shared_library
 from ..manager import test_dm
@@ -81,7 +80,7 @@ class DynlibAppTest(unittest.TestCase):
 
         # ~100 MBs of data should be copied over from a to c and d via b, etc
         data = os.urandom(1024 * 1024) * 100
-        reader = six.BytesIO(data)
+        reader = io.BytesIO(data)
         with droputils.DROPWaiterCtx(self, (c, d, f, g), 10):
             if streaming:
                 # Write the data in chunks so we actually exercise multiple calls

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -22,11 +22,9 @@
 import base64
 import logging
 import os
+import pickle
 import random
 import unittest
-
-import six
-import six.moves.cPickle as pickle  # @UnresolvedImport
 
 from ..manager import test_dm
 from dlg import droputils
@@ -58,7 +56,7 @@ def func_with_defaults(a, b=10, c=20, x=30, y=40, z=50):
 def _PyFuncApp(oid, uid, f, **kwargs):
 
     fname = None
-    if isinstance(f, six.string_types):
+    if isinstance(f, str):
         fname = f = "test.apps.test_pyfunc." + f
 
     fcode, fdefaults = pyfunc.serialize_func(f)

--- a/daliuge-engine/test/apps/test_simple.py
+++ b/daliuge-engine/test/apps/test_simple.py
@@ -20,10 +20,9 @@
 #    MA 02111-1307  USA
 #
 import os
+import pickle
 import unittest
 from numpy import random, mean, array
-import six
-import six.moves.cPickle as pickle
 
 
 from dlg import droputils
@@ -133,7 +132,7 @@ class TestSimpleApps(unittest.TestCase):
         h.addOutput(b)
         b.addProducer(h)
         h.execute()
-        self.assertEqual(six.b(h.greeting), droputils.allDropContents(b))
+        self.assertEqual(h.greeting.encode('utf8'), droputils.allDropContents(b))
 
     def test_ngasio(self):
         nd_in = NgasDROP('HelloWorld.txt', 'HelloWorld.txt')
@@ -148,7 +147,7 @@ class TestSimpleApps(unittest.TestCase):
         i.addProducer(b)
         b.addOutput(i)
         self._test_graph_runs((nd_in,b,i,nd_out),nd_in, nd_out, timeout=4)
-        self.assertEqual(six.b("Hello World"), droputils.allDropContents(i))
+        self.assertEqual(b"Hello World", droputils.allDropContents(i))
 
 
 

--- a/daliuge-engine/test/manager/test_daemon.py
+++ b/daliuge-engine/test/manager/test_daemon.py
@@ -19,12 +19,11 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
+import http.client#
 import json
 import threading
 import time
 import unittest
-
-from six.moves import http_client as httplib  # @UnresolvedImport
 
 from dlg import utils, restutils
 from dlg.manager import constants
@@ -96,7 +95,7 @@ class TestDaemon(unittest.TestCase):
         self.create_daemon(master=False, noNM=False, disable_zeroconf=True)
 
         # Check that the master starts
-        self._start('master', httplib.OK)
+        self._start('master', http.HTTPStatus.OK)
         self.assertTrue(utils.portIsOpen('localhost', constants.MASTER_DEFAULT_REST_PORT, _TIMEOUT), 'The MM did not start successfully')
 
     def test_zeroconf_discovery(self):
@@ -122,11 +121,11 @@ class TestDaemon(unittest.TestCase):
         self.assertEqual(1, len(nodes), "MasterManager didn't find the NodeManager running on the same node")
 
         # Check that the DataIsland starts with the given nodes
-        self._start('dataisland', httplib.OK, {'nodes': nodes})
+        self._start('dataisland', http.HTTPStatus.OK, {'nodes': nodes})
         self.assertTrue(utils.portIsOpen('localhost', constants.ISLAND_DEFAULT_REST_PORT, _TIMEOUT), 'The DIM did not start successfully')
 
     def _start(self, manager_name, expected_code, payload=None):
-        conn = httplib.HTTPConnection('localhost', 9000)
+        conn = http.client.HTTPConnection('localhost', 9000)
         headers = {}
         if payload:
             payload = json.dumps(payload)

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -24,8 +24,6 @@ import os
 import threading
 import unittest
 
-import six
-
 from dlg import droputils
 from dlg.ddap_protocol import DROPStates, DROPRel, DROPLinkType
 from dlg.common import dropdict, Categories
@@ -205,7 +203,7 @@ class TestDM(NMTestsMixIn, unittest.TestCase):
         ]
         rels = [DROPRel("B", DROPLinkType.CONSUMER, "A")]
         a_data = os.urandom(32)
-        c_data = six.b(str(crc32(a_data, 0)))
+        c_data = str(crc32(a_data, 0)).encode('utf8')
         node_managers = [self._start_dm() for _ in range(2)]
         for n in range(repeats):
             sessionId = 's%d' % n
@@ -543,7 +541,7 @@ class TestDM(NMTestsMixIn, unittest.TestCase):
         ]
         rels = [DROPRel("C", DROPLinkType.STREAMING_INPUT, "D")]
         a_data = os.urandom(32)
-        e_data = six.b(str(crc32(a_data, 0)))
+        e_data = str(crc32(a_data, 0)).encode('utf8')
         self._test_runGraphInTwoNMs(g1, g2, rels, a_data, e_data, leaf_oid="E")
 
     def test_run_streaming_consumer_remotely2(self):
@@ -573,5 +571,5 @@ class TestDM(NMTestsMixIn, unittest.TestCase):
         ]
         rels = [DROPRel("C", DROPLinkType.OUTPUT, "B")]
         a_data = os.urandom(32)
-        e_data = six.b(str(crc32(a_data, 0)))
+        e_data = str(crc32(a_data, 0)).encode('utf8')
         self._test_runGraphInTwoNMs(g1, g2, rels, a_data, e_data, leaf_oid="E")

--- a/daliuge-engine/test/manager/testutils.py
+++ b/daliuge-engine/test/manager/testutils.py
@@ -19,37 +19,36 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
+import http.client
 import json
-
-import six.moves.http_client as httplib  # @UnresolvedImport
 
 from dlg import utils
 import codecs
 
 
 def get(test, url, port):
-    conn = httplib.HTTPConnection('localhost', port, timeout=3)
+    conn = http.client.HTTPConnection('localhost', port, timeout=3)
     conn.request('GET', '/api' + url)
     res = conn.getresponse()
-    test.assertEqual(httplib.OK, res.status)
+    test.assertEqual(http.HTTPStatus.OK, res.status)
     jsonRes = json.load(codecs.getreader('utf-8')(res))
     res.close()
     conn.close()
     return jsonRes
 
 def post(test, url, port, content=None, mimeType=None):
-    conn = httplib.HTTPConnection('localhost', port, timeout=3)
+    conn = http.client.HTTPConnection('localhost', port, timeout=3)
     headers = {mimeType or 'Content-Type': 'application/json'} if content else {}
     conn.request('POST', '/api' + url, content, headers)
     res = conn.getresponse()
-    test.assertEqual(httplib.OK, res.status)
+    test.assertEqual(http.HTTPStatus.OK, res.status)
     conn.close()
 
 def delete(test, url, port):
-    conn = httplib.HTTPConnection('localhost', port, timeout=3)
+    conn = http.client.HTTPConnection('localhost', port, timeout=3)
     conn.request('DELETE', '/api' + url)
     res = conn.getresponse()
-    test.assertEqual(httplib.OK, res.status)
+    test.assertEqual(http.HTTPStatus.OK, res.status)
     conn.close()
 
 class terminating(object):

--- a/daliuge-engine/test/test_dask_emulation.py
+++ b/daliuge-engine/test/test_dask_emulation.py
@@ -19,12 +19,12 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
+import functools
 import json
 import os
 import unittest
 
 import numpy as np
-from six.moves import reduce  # @UnresolvedImport
 
 from dlg.dask_emulation import delayed as dlg_delayed
 from dlg.dask_emulation import compute as dlg_compute
@@ -42,13 +42,13 @@ def add(x, y):
     return x + y
 
 def add_list(numbers):
-    return reduce(add, numbers)
+    return functools.reduce(add, numbers)
 
 def subtract(x, y):
     return x - y
 
 def subtract_list(numbers):
-    return reduce(subtract, numbers)
+    return functools.reduce(subtract, numbers)
 
 def multiply(x, y):
     return x * y

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -21,14 +21,12 @@
 #
 
 import contextlib
+import io
 import os, unittest
 import random
 import shutil
 import sqlite3
 import tempfile
-
-import six
-from six import BytesIO
 
 from dlg import droputils
 from dlg.ddap_protocol import DROPStates, ExecutionMode, AppDROPStates
@@ -71,7 +69,7 @@ class SumupContainerChecksum(BarrierAppDROP):
             if inputDrop.status == DROPStates.COMPLETED:
                 crcSum += inputDrop.checksum
         outputDrop = self.outputs[0]
-        outputDrop.write(six.b(str(crcSum)))
+        outputDrop.write(str(crcSum).encode('utf8'))
 
 class TestDROP(unittest.TestCase):
 
@@ -149,7 +147,7 @@ class TestDROP(unittest.TestCase):
             def run(self):
                 drop = self.inputs[0]
                 output = self.outputs[0]
-                allLines = BytesIO(droputils.allDropContents(drop)).readlines()
+                allLines = io.BytesIO(droputils.allDropContents(drop)).readlines()
                 for line in allLines:
                     if self._substring in line:
                         output.write(line)
@@ -158,7 +156,7 @@ class TestDROP(unittest.TestCase):
             def run(self):
                 drop = self.inputs[0]
                 output = self.outputs[0]
-                sortedLines = BytesIO(droputils.allDropContents(drop)).readlines()
+                sortedLines = io.BytesIO(droputils.allDropContents(drop)).readlines()
                 sortedLines.sort()
                 for line in sortedLines:
                     output.write(line)
@@ -168,14 +166,14 @@ class TestDROP(unittest.TestCase):
                 drop = self.inputs[0]
                 output = self.outputs[0]
                 allbytes = droputils.allDropContents(drop)
-                buf = BytesIO()
-                for c in six.iterbytes(allbytes):
-                    if c == six.byte2int(b' ') or c == six.byte2int(b'\n'):
+                buf = io.BytesIO()
+                for c in allbytes:
+                    if c == b' ' or c == b'\n':
                         output.write(buf.getvalue()[::-1])
-                        output.write(six.int2byte(c))
-                        buf = BytesIO()
+                        output.write(bytes([c]))
+                        buf = io.BytesIO()
                     else:
-                        buf.write(six.int2byte(c))
+                        buf.write(bytes([c]))
 
         a = InMemoryDROP('oid:A', 'uid:A')
         b = GrepResult('oid:B', 'uid:B', substring=b"a")
@@ -397,7 +395,7 @@ class TestDROP(unittest.TestCase):
                 output = self.outputs[0]
                 howMany = int(droputils.allDropContents(inputDrop))
                 for i in range(howMany):
-                    output.write(six.b(str(i)) + b" ")
+                    output.write(str(i).encode('utf8') + b" ")
 
         # This is used as "D"
         class OddAndEvenContainerApp(BarrierAppDROP):

--- a/daliuge-engine/test/test_droputils.py
+++ b/daliuge-engine/test/test_droputils.py
@@ -27,8 +27,6 @@ Created on 20 Jul 2015
 
 import unittest
 
-import six
-
 from dlg import droputils
 from dlg.common import dropdict, Categories
 from dlg.drop import InMemoryDROP, FileDROP, BarrierAppDROP

--- a/daliuge-engine/test/test_utils.py
+++ b/daliuge-engine/test/test_utils.py
@@ -20,13 +20,12 @@
 #    MA 02111-1307  USA
 #
 import functools
+import io
 import json
 import os
 import tempfile
 import unittest
 import zlib
-
-import six
 
 from dlg import utils
 
@@ -62,7 +61,7 @@ class TestUtils(unittest.TestCase):
             compressed_bytes = zlib.compress(original_bytes)
 
             # Try first with whole reads
-            compressed_stream = six.BytesIO(compressed_bytes)
+            compressed_stream = io.BytesIO(compressed_bytes)
             uncompressed_stream = utils.ZlibUncompressedStream(compressed_stream)
             b = uncompressed_stream.read()
             self.assertEqual(size, len(b))
@@ -71,7 +70,7 @@ class TestUtils(unittest.TestCase):
             # Now read little by little
             read_size = min(size//4, 1024);
             b = b''
-            compressed_stream = six.BytesIO(compressed_bytes)
+            compressed_stream = io.BytesIO(compressed_bytes)
             uncompressed_stream = utils.ZlibUncompressedStream(compressed_stream)
             for u in iter(functools.partial(uncompressed_stream.read, read_size), b''):
                 b += u
@@ -85,7 +84,7 @@ class TestUtils(unittest.TestCase):
 
         # Read parts from the beginning
         for x in range(1, len(compressed_ref)):
-            bytesio = six.BytesIO(b'abcd')
+            bytesio = io.BytesIO(b'abcd')
             s = utils.ZlibCompressedStream(bytesio)
             compressed = s.read(x)
             self.assertEqual(x, len(compressed))
@@ -98,7 +97,7 @@ class TestUtils(unittest.TestCase):
             compressed_bytes = zlib.compress(original_bytes)
 
             # Try first with whole reads
-            uncompressed_stream = six.BytesIO(original_bytes)
+            uncompressed_stream = io.BytesIO(original_bytes)
             compressed_stream = utils.ZlibCompressedStream(uncompressed_stream)
             b = compressed_stream.read()
             self.assertEqual(len(compressed_bytes), len(b), "Incorrect size when compressing %d bytes" % (size))
@@ -106,7 +105,7 @@ class TestUtils(unittest.TestCase):
 
             # Now read little by little
             read_size = min(size//4, 1024)
-            uncompressed_stream = six.BytesIO(original_bytes)
+            uncompressed_stream = io.BytesIO(original_bytes)
             compressed_stream = utils.ZlibCompressedStream(uncompressed_stream)
             b = b''
             for c in iter(functools.partial(compressed_stream.read, read_size), b''):
@@ -128,7 +127,7 @@ class TestUtils(unittest.TestCase):
             original_bytes = gen_bytes(size)
 
             # Read the whole thing
-            original_stream = six.BytesIO(original_bytes)
+            original_stream = io.BytesIO(original_bytes)
             compressed_stream = utils.ZlibCompressedStream(original_stream)
             uncompressed_stream = utils.ZlibUncompressedStream(compressed_stream)
             b = uncompressed_stream.read()
@@ -144,7 +143,7 @@ class TestUtils(unittest.TestCase):
 
                 these_bytes = original_bytes[0:n]
 
-                original_stream = six.BytesIO(these_bytes)
+                original_stream = io.BytesIO(these_bytes)
                 compressed_stream = utils.ZlibCompressedStream(original_stream)
                 uncompressed_stream = utils.ZlibUncompressedStream(compressed_stream)
 

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -131,10 +131,9 @@ def create_command_line_tool(node):
 
     # TODO: find a better way of specifying command line program + arguments
     base_command = base_command[:base_command.index(" ")]
-    base_command = common.u2s(base_command)
 
     # cwlgen's Serializer class doesn't support python 2.7's unicode types
-    cwl_tool = cwlgen.CommandLineTool(tool_id=common.u2s(node['app']), label=common.u2s(node['nm']), base_command=base_command, cwl_version='v1.0')
+    cwl_tool = cwlgen.CommandLineTool(tool_id=node['app'], label=node['nm'], base_command=base_command, cwl_version='v1.0')
 
     # add inputs
     for index, input in enumerate(inputs):

--- a/daliuge-translator/dlg/dropmake/cwl.py
+++ b/daliuge-translator/dlg/dropmake/cwl.py
@@ -22,7 +22,6 @@
 
 import logging
 import os
-import six
 from zipfile import ZipFile
 
 import cwlgen
@@ -109,8 +108,8 @@ def create_workflow(drops, cwl_filename, buffer):
     # put workflow and command line tool description files all together in a zip
     zipObj = ZipFile(buffer, 'w')
     for step_file in step_files:
-        zipObj.writestr(step_file["filename"], six.b(step_file["contents"]))
-    zipObj.writestr(cwl_filename, six.b(cwl_workflow.export_string()))
+        zipObj.writestr(step_file["filename"], step_file["contents"].encode('utf8'))
+    zipObj.writestr(cwl_filename, cwl_workflow.export_string().encode('utf8'))
     zipObj.close()
 
 

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -42,7 +42,6 @@ from itertools import product
 
 import networkx as nx
 import numpy as np
-import six
 
 from .scheduler import MySarkarScheduler, DAGUtil, MinNumPartsScheduler, PSOScheduler
 from .utils.bash_parameter import BashCommand
@@ -1846,7 +1845,7 @@ class LG:
         parse JSON into LG object graph first
         """
         self._g_var = []
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             if not os.path.exists(f):
                 raise GraphException("Logical graph {0} not found".format(f))
             with open(f) as f:
@@ -2592,7 +2591,7 @@ def fill(lg, params):
     flat_params = _flatten_dict(params)
     if hasattr(lg, "read"):
         lg = lg.read()
-    elif not isinstance(lg, six.string_types):
+    elif not isinstance(lg, str):
         lg = json.dumps(lg)
     lg = _LGTemplate(lg).substitute(flat_params)
     return json.loads(lg)
@@ -2641,7 +2640,7 @@ _known_algos = {
 
 
 def known_algorithms():
-    return [x for x in _known_algos.keys() if isinstance(x, six.string_types)]
+    return [x for x in _known_algos.keys() if isinstance(x, str)]
 
 
 def partition(
@@ -2655,7 +2654,7 @@ def partition(
 ):
     """Partitions a Physical Graph Template"""
 
-    if isinstance(algo, six.string_types):
+    if isinstance(algo, str):
         if algo not in _known_algos:
             raise ValueError(
                 "Unknown partitioning algorithm: %s. Known algorithms are: %r"

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -106,8 +106,6 @@ install_requires = [
     "psutil",
     "pyswarm",
     "ruamel.yaml.clib<=0.2.2",
-    # 1.10 contains an important race-condition fix on lazy-loaded modules
-    "six>=1.10",
 ]
 
 setup(

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -98,10 +98,8 @@ install_requires = [
     "cwlgen",
     "daliuge-common==%s" % (VERSION,),
     "metis>=0.2a3",
-    # Python 3.6 is only supported in NetworkX 2 and above
-    # But we are not compatible with 2.4 yet, so we need to constrain that
-    "networkx<2.4; python_version<'3.6'",
-    "networkx<2.4,>= 2.0; python_version>='3.6.0'",
+    # We are not compatible with networkx 2.4 yet, so we need to constrain that
+    "networkx<2.4",
     "numpy",
     "psutil",
     "pyswarm",

--- a/daliuge-translator/test/dropmake/test_lgweb.py
+++ b/daliuge-translator/test/dropmake/test_lgweb.py
@@ -23,12 +23,11 @@
 import os
 import shutil
 import tempfile
+import urllib.parse
 import unittest
 import json
 
 import pkg_resources
-
-import six.moves.urllib_parse as urllib  # @UnresolvedImport
 
 from dlg import common
 from dlg.common import tool
@@ -144,7 +143,7 @@ class TestLGWeb(unittest.TestCase):
 
         # POST form to /gen_pgt
         try:
-            content = urllib.urlencode(form_data)
+            content = urllib.parse.urlencode(form_data)
             c._POST('/gen_pgt', content, content_type='application/x-www-form-urlencoded')
         except RestClientException as e:
             self.fail(e)
@@ -175,7 +174,7 @@ class TestLGWeb(unittest.TestCase):
 
         # POST form to /gen_pgt
         try:
-            content = urllib.urlencode(form_data)
+            content = urllib.parse.urlencode(form_data)
             c._POST('/gen_pgt', content,
                     content_type='application/x-www-form-urlencoded')
         except RestClientException as e:
@@ -206,7 +205,7 @@ class TestLGWeb(unittest.TestCase):
 
         # POST form to /gen_pgt
         try:
-            content = urllib.urlencode(form_data)
+            content = urllib.parse.urlencode(form_data)
             c._POST('/gen_pgt', content,
                     content_type='application/x-www-form-urlencoded')
         except RestClientException as e:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -68,6 +68,8 @@ installed on the system:
 Installing
 ##########
 
+|daliuge| requires python 3.
+
 |daliuge| is based on setuptools, and thus it follows the standard python installation
 procedures.
 The preferred way of installing the latest stable version of |daliuge|

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -68,7 +68,7 @@ installed on the system:
 Installing
 ##########
 
-|daliuge| requires python 3.
+|daliuge| requires python 3.7 or later.
 
 |daliuge| is based on setuptools, and thus it follows the standard python installation
 procedures.


### PR DESCRIPTION
This set of commits incrementally move the minimum supported python version from 2.7 up to 3.7. First, python 2.7 support is removed, then all usage of `six` is removed and changed for the corresponding python 3 code. Additional code within daliuge to deal differently with python 2/3 was also adjusted/removed. Later on the minimum supported version is moved up again to python 3.7, which finally allows us to simplify our dependency management a bit.