### PR TITLE
Reference dimUrl only when available

### DIFF
--- a/daliuge-engine/dlg/manager/web/dm.html
+++ b/daliuge-engine/dlg/manager/web/dm.html
@@ -73,10 +73,10 @@ var resetBtn = d3.select('#resetBtn');
 
 var dimUrlQuery = new URL(window.location.href);
 var dimUrl = dimUrlQuery.searchParams.get("dim_url");
-var dimIP = dimUrl.split("//").pop().split(":").shift();
 var nodeIP = window.location.href.split("http://").slice(1).join('http://').split(":").shift(1);
 
 if(dimUrl){
+	var dimIP = dimUrl.split("//").pop().split(":").shift();
 	d3.select('#islandDisplay').html("<a href="+dimUrl+">DIM: " + dimIP+"</a>");
 		d3.select('#nodeDisplay').text("/ Node: " + nodeIP);
 }


### PR DESCRIPTION
Calculating dimIP should only happen when needed, but more importantly
only when possible. Doing it outside the `if` statement crashes the
script that runs when the node manager UI (which doesn't have a dim_url
parameter) loads, crippling its functionality.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>