### PR TITLE
LIU-96 Add initial support for Branch drops

### DIFF
--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -28,7 +28,7 @@ import time
 import numpy as np
 
 from .. import droputils, utils
-from ..drop import BarrierAppDROP, ContainerDROP
+from ..drop import BarrierAppDROP, BranchAppDrop, ContainerDROP
 from ..meta import dlg_float_param, dlg_string_param
 from ..meta import dlg_bool_param, dlg_int_param
 from ..meta import dlg_component, dlg_batch_input
@@ -373,3 +373,16 @@ class UrlRetrieveApp(BarrierAppDROP):
         for o in outs:
             o.len = len(content)
             o.write(content)  # send content to all outputs
+
+class SimpleBranch(BranchAppDrop, NullBarrierApp):
+    """Simple branch app that is told the result of its condition"""
+
+    def initialize(self, **kwargs):
+        self.result = self._getArg(kwargs, 'result', True)
+        BranchAppDrop.initialize(self, **kwargs)
+
+    def run(self):
+        pass
+
+    def condition(self):
+        return self.result

--- a/daliuge-engine/dlg/ddap_protocol.py
+++ b/daliuge-engine/dlg/ddap_protocol.py
@@ -44,7 +44,7 @@ class DROPStates:
     COMPLETED. Later, they transition through EXPIRED, eventually arriving to
     DELETED.
     """
-    INITIALIZED, WRITING, COMPLETED, ERROR, EXPIRED, DELETED, CANCELLED = range(7)
+    INITIALIZED, WRITING, COMPLETED, ERROR, EXPIRED, DELETED, CANCELLED, SKIPPED = range(8)
 
 
 class AppDROPStates:
@@ -54,7 +54,7 @@ class AppDROPStates:
     are started. Depending on the execution result they eventually move to the
     FINISHED or ERROR state.
     """
-    NOT_RUN, RUNNING, FINISHED, ERROR, CANCELLED = range(5)
+    NOT_RUN, RUNNING, FINISHED, ERROR, CANCELLED, SKIPPED = range(6)
 
 
 class DROPPhases:

--- a/daliuge-engine/dlg/manager/web/session.html
+++ b/daliuge-engine/dlg/manager/web/session.html
@@ -96,11 +96,13 @@ function view_as_progress_bar(sessionId, selectedNode, serverUrl) {
 
 	var status_update_handler = function(statuses)
 	{
-
+		// This is the order in which blocks are drawn in the progress bar,
+		// so we want "done" states first and "nothing happened yet" states
+		// towards the end
 		var states = ['completed', 'finished',
 		              'running', 'writing',
 		              'error', 'expired', 'deleted',
-		              'cancelled',
+		              'cancelled', 'skipped',
 		              'not_run', 'initialized'];
 		var states_idx = d3.scale.ordinal().domain(states).rangePoints([0, states.length - 1]);
 
@@ -110,7 +112,7 @@ function view_as_progress_bar(sessionId, selectedNode, serverUrl) {
 
 		/* Get total and per-status counts, then normalize to 0-100% */
 		var total = statuses.length;
-		var status_counts = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		var status_counts = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 		statuses.reduce(function(status_counts, s) {
 			var idx = states_idx(get_status_name(s));
 			status_counts[idx] = status_counts[idx] + 1;

--- a/daliuge-engine/dlg/manager/web/static/css/session.css
+++ b/daliuge-engine/dlg/manager/web/static/css/session.css
@@ -82,6 +82,10 @@ svg {
   color: #700000;
 }
 
+.node.skipped :first-child, rect.skipped {
+  fill: #53c4f6;
+}
+
 /* AppDROP states */
 .node.not_run :first-child, rect.not_run {
   fill: #ffe;

--- a/daliuge-engine/dlg/manager/web/static/js/dm.js
+++ b/daliuge-engine/dlg/manager/web/static/js/dm.js
@@ -21,8 +21,8 @@
 //
 
 var SESSION_STATUS     = ['Pristine', 'Building', 'Deploying', 'Running', 'Finished', 'Cancelled']
-var STATUS_CLASSES     = ['initialized', 'writing', 'completed', 'error', 'expired', 'deleted', 'cancelled']
-var EXECSTATUS_CLASSES = ['not_run', 'running', 'finished', 'error', 'cancelled']
+var STATUS_CLASSES     = ['initialized', 'writing', 'completed', 'error', 'expired', 'deleted', 'cancelled', 'skipped']
+var EXECSTATUS_CLASSES = ['not_run', 'running', 'finished', 'error', 'cancelled', 'skipped']
 var TYPE_CLASSES       = ['app', 'container', 'socket', 'plain']
 var TYPE_SHAPES        = {app:'rect', container:'parallelogram', socket:'parallelogram', plain:'parallelogram'}
 
@@ -485,7 +485,7 @@ function startGraphStatusUpdates(serverUrl, sessionId, selectedNode, delay,
 
 			var allCompleted = statuses.reduce(function(prevVal, curVal, idx, arr) {
 				var cur_status = get_status_name(curVal);
-				return prevVal && (cur_status == 'completed' || cur_status == 'finished' || cur_status == 'error' || cur_status == 'cancelled');
+				return prevVal && (cur_status == 'completed' || cur_status == 'finished' || cur_status == 'error' || cur_status == 'cancelled' || cur_status == 'skipped');
 			}, true);
 			if (!allCompleted) {
 				d3.timer(updateStates, delay);


### PR DESCRIPTION
Branch drops are a special type of application drops that must implement
an additional condition function, returning true or false, and thus
triggering one branch of execution down the rest of the graph, or the
other. The current implementation requires these applications
to have exactly two outputs, mainly because the information of which
branch should continue executing is transmitted through the output drop
onto its corresponding consumers instead of trying to contact the
consumers directly.

To support this new functionality we require a new SKIPPED state, which
automatically propagates through the graph. Unit tests check that this
propagation works through multiple levels, both for data and application
drops, such that their respective states change correctly (which is
important for the UI to display them correctly too).

The Web UI has also been updated to display skipped branches of
execution with a different color. Examples of these can be found in https://icrar.atlassian.net/browse/LIU-96

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>