### PR TITLE
Updated unroll_and_partition_with_params() to look for an incoming 'test' parameter

### DIFF
--- a/OpenAPI/translator.yaml
+++ b/OpenAPI/translator.yaml
@@ -30,6 +30,8 @@ paths:
                   type: string
                 algo:
                   type: string
+                test:
+                  type: string
                 num_par:
                   type: integer
                 num_islands:

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -431,8 +431,16 @@ def gen_pgt_post():
 
 
 def unroll_and_partition_with_params(lg_path, algo_params_source):
+    # Get the 'test' parameter
+    # NB: the test parameter is a string, so convert to boolean
+    test = algo_params_source.get("test", "false")
+    test = test.lower() == "true"
+
+    # Based on 'test' parameter, decide whether to use a replacement app
+    app = "dlg.apps.simple.SleepApp" if test else None
+
     # Unrolling LG to PGT.
-    pgt = unroll(lg_path)
+    pgt = unroll(lg_path, app=app)
 
     # Define partitioning parameters.
     algo = algo_params_source.get("algo", "none")


### PR DESCRIPTION
Updated the method to look for a 'test' parameter.

If found, it uses the existing functionality in unroll() to replace all apps with dlg.apps.simple.SleepApp. If not found, we pass app=None to unroll(), which leaves the original apps unchanged.