### PR TITLE
Eagle 121

### DIFF
--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -683,6 +683,8 @@ class LGNode:
                 v = self.jd[k]
                 if v is not None and len(str(v)) > 0:
                     cmds.append(str(v))
+            # add more arguments - this is the new method of adding arguments in EAGLE
+            # the method above (Arg**) is retained for compatibility, but eventually should be removed
             for k in ["command", "input_redirection", "output_redirection", "command_line_arguments"]:
                 if k in self.jd:
                     cmds.append(self.jd[k])

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -309,7 +309,7 @@ class LGNode:
             elif type(gs) in [type(1), type(1.)]:
                 result = (1 == gs)
             elif type(gs) == type("s"):
-                result = gs.lower() in ("true", "1")        
+                result = gs.lower() in ("true", "1")
         return result
 
 
@@ -325,7 +325,7 @@ class LGNode:
             elif type(ge) == type("s"):
                 result = ge.lower() in ("true", "1")
         return result
-    
+
     def is_group(self):
         return self._isgrp
 
@@ -683,6 +683,9 @@ class LGNode:
                 v = self.jd[k]
                 if v is not None and len(str(v)) > 0:
                     cmds.append(str(v))
+            for k in ["command", "input_redirection", "output_redirection", "command_line_arguments"]:
+                if k in self.jd:
+                    cmds.append(self.jd[k])
             # kwargs['command'] = ' '.join(cmds)
             kwargs["command"] = BashCommand(cmds)
             kwargs["num_cpus"] = int(self.jd.get("num_cpus", 1))
@@ -980,7 +983,7 @@ class PGT(object):
         """
         if tpl_nodes_len > 0:  # generate pg_spec template
             node_list = range(tpl_nodes_len)  # create a fake list for now
-            # TODO proper 
+            # TODO proper
             # Looks like we don't need too much anymore
 
         if node_list is None or 0 == len(node_list):
@@ -2156,8 +2159,8 @@ class LG:
 
     def _is_stream_link(self, s_type, t_type):
         return s_type in [
-            Categories.COMPONENT, 
-            Categories.DYNLIB_APP, 
+            Categories.COMPONENT,
+            Categories.DYNLIB_APP,
             Categories.DYNLIB_PROC_APP,
             Categories.PYTHON_APP] and t_type in [
                 Categories.COMPONENT,


### PR DESCRIPTION
Prior to EAGLE-121, the command line for a BashShellApp was specified using a set of parameters beginning with Arg. For example:

- Arg01 = "cat"
- Arg02 = "%i[-9] %i[-10] > %o[-11]"

However, this caused issues when attempting to determine which arguments specified the command itself, the input redirection and the output redirection.

Some workflow systems (for example CWL) require these parts to be specified separately.

EAGLE-121 introduced default parameters in the BashShellApp for each part of the command line. This change to DALiuGE supports that change. The contents of additional named parameters is added to the final command line.

I've left the existing method (using Arg01, Arg02, etc) in the code. Since it is likely that only one of the two methods would be used. We have a large number of graphs that use the old method.