### PR TITLE
LIU-117 Add PlasmaFlight Drops

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -35,6 +35,7 @@ class Categories:
     JSON = 'json'
     S3 = 'S3'
     PLASMA = 'Plasma'
+    PLASMAFLIGHT = 'PlasmaFlight'
 
     MKN = 'MKN'
     SCATTER = 'Scatter'
@@ -62,7 +63,8 @@ STORAGE_TYPES = {
                  Categories.NGAS, 
                  Categories.NULL, 
                  Categories.JSON, 
-                 Categories.PLASMA
+                 Categories.PLASMA,
+                 Categories.PLASMAFLIGHT
                 }
 APP_DROP_TYPES = [
     Categories.COMPONENT,

--- a/daliuge-common/dlg/restutils.py
+++ b/daliuge-common/dlg/restutils.py
@@ -179,25 +179,20 @@ class RestClient(object):
             msg = 'Error on remote %s@%s:%s%s (status %d): ' % \
                   (method, self.host, self.port, url, self._resp.status)
 
-            try:
-                error = json.loads(self._resp.read().decode('utf-8'))
-                etype = getattr(exceptions, error['type'])
-                eargs = error['args']
+            error = json.loads(self._resp.read().decode('utf-8'))
+            etype = getattr(exceptions, error['type'])
+            eargs = error['args']
 
-                if etype == SubManagerException:
-                    for host,args in eargs.items():
-                        subetype = getattr(exceptions, args['type'])
-                        subargs = args['args']
-                        eargs[host] = subetype(*subargs)
-                    ex = etype(eargs)
-                else:
-                    ex = etype(*eargs)
-                if hasattr(ex, 'msg'):
-                    ex.msg = msg + ex.msg
-            except Exception:
-                ex = RestClientException(msg + "Unknown")
-
-            raise ex
+            if etype == SubManagerException:
+                for host,args in eargs.items():
+                    subetype = getattr(exceptions, args['type'])
+                    subargs = args['args']
+                    eargs[host] = subetype(*subargs)
+                ex = etype(eargs)
+            else:
+                ex = etype(*eargs)
+            if hasattr(ex, 'msg'):
+                ex.msg = msg + ex.msg
 
         if not self._resp.length:
             return None, None

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -221,6 +221,11 @@ class DockerApp(BarrierAppDROP):
         # handle, but for the time being we do it here
         self._removeContainer = self._getArg(kwargs, 'removeContainer', True)
 
+        # Ports - a comma seperated list of the host port mappings of form:
+        # "hostport1:containerport1, hostport2:containerport2"
+        self._portMappings = self._getArg(kwargs, 'portMappings', "")
+        logger.info(f"portMappings: {self._portMappings}")
+
         # Additional volume bindings can be specified for existing files/dirs
         # on the host system. They are given either as a list or as a
         # comma-separated string
@@ -318,6 +323,20 @@ class DockerApp(BarrierAppDROP):
         binds = list(set(binds))   # make this a unique list else docker complains
         logger.debug("Volume bindings: %r", binds)
 
+        portMappings = {}  # = {'5005/tcp': 5005, '5006/tcp': 5006}
+        for mapping in self._portMappings.split(','):
+            if mapping:
+                if mapping.find(':') == -1:
+                    host_port = container_port = mapping
+                else:
+                    host_port, container_port = mapping.split(':')
+                if host_port not in portMappings:
+                    logger.debug(f"mapping port {host_port} -> {container_port}")
+                    portMappings[host_port] = int(container_port)
+                else:
+                    raise Exception(f"Duplicate port {host_port} in container port mappings")
+        logger.debug(f"port mappings: {portMappings}")
+
         # Wait until the DockerApps this application runtime depends on have
         # started, and replace their IP placeholders by the real IPs
         for waiter in self._waiters:
@@ -364,8 +383,10 @@ class DockerApp(BarrierAppDROP):
         container = c.containers.create(
                 self._image,
                 cmd,
-                #name=name, # TODO: use container name
+                # name=name, # TODO: use container name
                 volumes=binds,
+                ports=portMappings,
+                # network_mode="host",
                 user=user,
                 environment=env,
                 working_dir=self.workdir,

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -201,6 +201,9 @@ class DockerApp(BarrierAppDROP):
             raise InvalidDropException(
                 self, "No command specified, cannot create DockerApp")
 
+        # The container name
+        self._name = self._getArg(kwargs, 'name', None)
+
         # The user used to run the process in the docker container
         # By default docker containers run as root, but we don't want to run
         # a process using a different user because otherwise anything that that
@@ -354,16 +357,19 @@ class DockerApp(BarrierAppDROP):
         # (used below)
         def rm(container):
             if self._removeContainer:
-                container.remove()
+                container.stop()
+                container.remove(force=True)
 
         # Create container
         container = c.containers.create(
                 self._image,
                 cmd,
+                #name=name, # TODO: use container name
                 volumes=binds,
                 user=user,
                 environment=env,
-                working_dir=self.workdir
+                working_dir=self.workdir,
+                auto_remove=self._removeContainer
         )
         self._containerId = cId = container.id
         logger.info("Created container %s for %r", cId, self)

--- a/daliuge-engine/dlg/apps/plasma.py
+++ b/daliuge-engine/dlg/apps/plasma.py
@@ -191,7 +191,7 @@ class MSStreamingPlasmaProducer(BarrierAppDROP):
 
 ##
 # @brief MSPlasmaReader\n
-# @details Batch read entire Measurement Set from Plamsa.
+# @details Batch read entire Measurement Set from Plasma.
 # @par EAGLE_START
 # @param category PythonApp
 # @param[in] port/plasma_ms_input

--- a/daliuge-engine/dlg/apps/plasmaflight.py
+++ b/daliuge-engine/dlg/apps/plasmaflight.py
@@ -1,0 +1,94 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2015
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+import hashlib
+from io import BytesIO
+from typing import Optional
+
+import pyarrow
+import pyarrow.flight as paf
+import pyarrow.plasma as plasma
+
+
+def generate_sha1_object_id(path: bytes) -> plasma.ObjectID:
+    m = hashlib.sha1()
+    m.update(path)
+    id = m.digest()[0:20]
+    return plasma.ObjectID(id)
+
+
+class PlasmaFlightClient():
+    def __init__(self, socket: str, scheme: str = "grpc+tcp", connection_args={}):
+        """
+        Args:
+            socket (str): The socket of the local plasma store
+            scheme (str, optional): [description]. Defaults to "grpc+tcp".
+            connection_args (dict, optional): [description]. Defaults to {}.
+        """
+        self.plasma_client = plasma.connect(socket)
+        self._scheme = scheme
+        self._connection_args = connection_args
+
+    def list_flights(self, location: str):
+        flight_client = paf.FlightClient(
+            f"{self._scheme}://{location}", **self._connection_args)
+        return flight_client.list_flights()
+
+    def get_flight(self, object_id: plasma.ObjectID, location: Optional[str]) -> paf.FlightStreamReader:
+        descriptor = paf.FlightDescriptor.for_path(object_id.binary().hex().encode('utf-8'))
+        if location is not None:
+            flight_client = paf.FlightClient(f"{self._scheme}://{location}", **self._connection_args)
+            info = flight_client.get_flight_info(descriptor)
+            for endpoint in info.endpoints:
+                for location in endpoint.locations:
+                    return flight_client.do_get(endpoint.ticket)
+        else:
+            raise Exception()
+
+    def put(self, data: memoryview, object_id: plasma.ObjectID):
+        self.plasma_client.put_raw_buffer(data, object_id)
+
+    def get(self, object_id: plasma.ObjectID, owner: Optional[str] = None) -> memoryview:
+        if self.plasma_client.contains(object_id):
+            # first check if the local store contains the object
+            [buf] = self.plasma_client.get_buffers([object_id])
+            return memoryview(buf)
+        elif owner is not None:
+            # fetch from the specified owner
+            reader = self.get_flight(object_id, owner)
+            table = reader.read_all()
+            output = BytesIO(table.column(0)[0].as_py()).getbuffer()
+            #cache output
+            self.put(output, object_id)
+            return output
+        else:
+            raise KeyError("ObjectID not found", object_id)
+
+    def exists(self, object_id: plasma.ObjectID, owner: Optional[str] = None) -> bool:
+        if self.plasma_client.contains(object_id): return True
+        if owner is not None:
+            client = paf.FlightClient(f"{self._scheme}://{owner}", **self._connection_args)
+            try:
+                info = client.get_flight_info(paf.FlightDescriptor.for_path(object_id.binary().hex().encode('utf-8')))
+                return True
+            except:
+                return False
+        return False

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1808,6 +1808,7 @@ class PlasmaFlightDROP(AbstractDROP):
     '''
     object_id = dlg_string_param('object_id', None)
     plasma_path = dlg_string_param('plasma_path', '/tmp/plasma')
+    flight_path = dlg_string_param('flight_path', None)
 
     def initialize(self, **kwargs):
         object_id = self.uid
@@ -1817,7 +1818,14 @@ class PlasmaFlightDROP(AbstractDROP):
            self.object_id = object_id
 
     def getIO(self):
-        return PlasmaFlightIO(plasma.ObjectID(self.object_id), self.plasma_path)
+        if isinstance(self.object_id, str):
+            object_id = plasma.ObjectID(self.object_id.encode('ascii'))
+        elif isinstance(self.object_id, bytes):
+            object_id = plasma.ObjectID(self.object_id)
+        else:
+            raise Exception("Invalid argument " + str(self.object_id) + " expected str, got" + str(type(self.object_id)))
+        logger.debug(f"object_id {object_id}")
+        return PlasmaFlightIO(object_id, self.plasma_path, flight_path=self.flight_path)
 
     @property
     def dataURL(self):

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -33,7 +33,7 @@ from .apps.socket_listener import SocketListenerApp
 from .ddap_protocol import DROPRel, DROPLinkType
 from .drop import ContainerDROP, InMemoryDROP, \
     FileDROP, NgasDROP, LINKTYPE_NTO1_PROPERTY, \
-    LINKTYPE_1TON_APPEND_METHOD, NullDROP, PlasmaDROP
+    LINKTYPE_1TON_APPEND_METHOD, NullDROP, PlasmaDROP, PlasmaFlightDROP
 from .exceptions import InvalidGraphException
 from .json_drop import JsonDROP
 from .common import Categories
@@ -41,11 +41,12 @@ from .common import Categories
 
 STORAGE_TYPES = {
     Categories.MEMORY: InMemoryDROP,
-    Categories.FILE  : FileDROP,
-    Categories.NGAS  : NgasDROP,
-    Categories.NULL  : NullDROP,
-    Categories.JSON  : JsonDROP,
+    Categories.FILE: FileDROP,
+    Categories.NGAS: NgasDROP,
+    Categories.NULL: NullDROP,
+    Categories.JSON: JsonDROP,
     Categories.PLASMA: PlasmaDROP,
+    Categories.PLASMAFLIGHT: PlasmaFlightDROP
 }
 
 try:

--- a/daliuge-engine/dlg/io.py
+++ b/daliuge-engine/dlg/io.py
@@ -459,7 +459,7 @@ class PlasmaIO(DataIO):
 
 class PlasmaFlightIO(DataIO):
 
-    def __init__(self, object_id, plasma_path='/tmp/plasma', flight_path: Optional[str] = None):
+    def __init__(self, object_id: plasma.ObjectID, plasma_path='/tmp/plasma', flight_path: Optional[str] = None):
         super(PlasmaFlightIO, self).__init__()
         self._object_id = object_id
         self._plasma_path = plasma_path

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -713,12 +713,9 @@ class LGNode:
             kwargs["image"] = image
             kwargs["command"] = command
             kwargs["user"] = str(self.jd.get("user", ""))
-            kwargs["ensureUserAndSwitch"] = self.str_to_bool(
-                str(self.jd.get("ensureUserAndSwitch", "0"))
-            )
-            kwargs["removeContainer"] = self.str_to_bool(
-                str(self.jd.get("removeContainer", "1"))
-            )
+            kwargs["ensureUserAndSwitch"] = self.str_to_bool(str(self.jd.get("ensureUserAndSwitch", "0")))
+            kwargs["removeContainer"] = self.str_to_bool(str(self.jd.get("removeContainer", "1")))
+            kwargs["portMappings"] = str(self.jd.get("portMappings", ""))
             kwargs["additionalBindings"] = str(self.jd.get("additionalBindings", ""))
             drop_spec.update(kwargs)
 


### PR DESCRIPTION
Summary:
One of the problems of using plasma drops is data not being available to ports located on a different compute node due to plasma only being shared system memory store. Here a new PlasmaFlight drop has been made that uses a fallback machanism to a flight server-client whenever a plasma object does not exist locally.

The flight server uses plasma object IDs as ticket identifiers, plus only reads and writes raw binary data to plasma and the server container is maintained separately at https://github.com/ICRAR/plasmaflight

Demos:
To demonstrate the functionality the first graph shows the compatibility of the new drops with simple plasma drops and how the flight container can connect to a plasma_store container:
![image](https://user-images.githubusercontent.com/7478405/128828798-f8227fd8-9fed-4a89-b995-d286998a9466.png)

In the second data is not copied into `PlasmaFlight 5006` and forces the flight grpc+tcp call to retrieve the object from the other plasma store. The PlasmaFlight Service is also capable of running the plasma store in the same container.
![image](https://user-images.githubusercontent.com/7478405/128829904-ea9088e4-3342-48c4-a9cc-57845c3e1e28.png)
![image](https://user-images.githubusercontent.com/7478405/128831692-9331aa25-a374-4905-8c45-4c442eee62c7.png)

Future work:
* PlasmaFlight has only been tested with a single engine compute node with manually entered IPs. Reliable support for more compute configurations will need some form of IP address macros.
* Reading a drop from a different compute node currently makes the assumption that the plasma socket is at the same local address.
* PlasmaFlight Service as a docker node currently blocks graph completion as the engine waits for the docker app to terminate. A new service type node that does not wait for termination would be ideal for situations such as this. 