### PR TITLE
LIU-165 Automatically remove dockerapp containers

### DIFF
--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -363,7 +363,8 @@ class DockerApp(BarrierAppDROP):
                 volumes=binds,
                 user=user,
                 environment=env,
-                working_dir=self.workdir
+                working_dir=self.workdir,
+                auto_remove=True
         )
         self._containerId = cId = container.id
         logger.info("Created container %s for %r", cId, self)

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -364,7 +364,7 @@ class DockerApp(BarrierAppDROP):
                 user=user,
                 environment=env,
                 working_dir=self.workdir,
-                auto_remove=True
+                auto_remove=self._removeContainer
         )
         self._containerId = cId = container.id
         logger.info("Created container %s for %r", cId, self)

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -28,6 +28,7 @@ import logging
 import os
 import threading
 import time
+from overrides import overrides
 
 from configobj import ConfigObj
 import docker
@@ -351,7 +352,7 @@ class DockerApp(BarrierAppDROP):
         c = DockerApp._get_client()
 
         # Create container
-        container = c.containers.create(
+        self.container = c.containers.create(
                 self._image,
                 cmd,
                 volumes=binds,
@@ -360,12 +361,12 @@ class DockerApp(BarrierAppDROP):
                 working_dir=self.workdir,
                 auto_remove=self._removeContainer
         )
-        self._containerId = cId = container.id
+        self._containerId = cId = self.container.id
         logger.info("Created container %s for %r", cId, self)
 
         # Start it
         start = time.time()
-        container.start()
+        self.container.start()
         logger.info("Started container %s", cId)
 
         # Figure out the container's IP and save it
@@ -378,7 +379,7 @@ class DockerApp(BarrierAppDROP):
         # Wait until it finishes
         # In docker-py < 3 the .wait() method returns the exit code directly
         # In docker-py >= 3 the .wait() method returns a dictionary with the API response
-        x = container.wait()
+        x = self.container.wait()
         if isinstance(x, dict) and 'StatusCode' in x:
             self._exitCode = x['StatusCode']
         else:
@@ -396,14 +397,29 @@ class DockerApp(BarrierAppDROP):
             stderr = container.logs(stream=False, stdout=False, stderr=True)
             msg = "Container %s didn't finish successfully (exit code %d)" % (cId, self._exitCode)
             logger.error(msg + ", output follows.\n==STDOUT==\n%s==STDERR==\n%s", stdout, stderr)
-            
-            if not self._removeContainer:
-                container.remove()
             raise Exception(msg)
 
-        if not self._removeContainer:
-            container.remove()
         c.api.close()
+
+    @overrides
+    def setCompleted(self):
+        super(BarrierAppDROP, self).setCompleted()
+        self.container.stop()
+
+    @overrides
+    def setError(self):
+        super(BarrierAppDROP, self).setError()
+        self.container.stop()
+
+    @overrides
+    def cancel(self):
+        super(BarrierAppDROP, self).cancel()
+        self.container.stop()
+
+    @overrides
+    def skip(self):
+        super(BarrierAppDROP, self).skip()
+        self.container.stop()
 
     @classmethod
     def _get_client(cls):

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -350,12 +350,6 @@ class DockerApp(BarrierAppDROP):
 
         c = DockerApp._get_client()
 
-        # Remove the container unless it's specified that we should keep it
-        # (used below)
-        def rm(container):
-            if self._removeContainer:
-                container.remove()
-
         # Create container
         container = c.containers.create(
                 self._image,
@@ -402,10 +396,13 @@ class DockerApp(BarrierAppDROP):
             stderr = container.logs(stream=False, stdout=False, stderr=True)
             msg = "Container %s didn't finish successfully (exit code %d)" % (cId, self._exitCode)
             logger.error(msg + ", output follows.\n==STDOUT==\n%s==STDERR==\n%s", stdout, stderr)
-            rm(container)
+            
+            if not self._removeContainer:
+                container.remove()
             raise Exception(msg)
 
-        rm(container)
+        if not self._removeContainer:
+            container.remove()
         c.api.close()
 
     @classmethod

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -124,6 +124,7 @@ install_requires = [
     "lockfile",
     # 0.10.6 builds correctly with old (<=3.10) Linux kernels
     "netifaces>=0.10.6",
+    "overrides",
     "paramiko",
     "psutil",
     "python-daemon",

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -816,7 +816,7 @@ class LGNode:
 
     @staticmethod
     def str_to_bool(value, default_value=False):
-        res = True if value in ["1", "true", "yes"] else default_value
+        res = True if value in ["1", "true", "True", "yes"] else default_value
         return res
 
     @staticmethod

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ MOCK_MODULES = (
  "netifaces",
  "networkx",
  "numpy",
+ "overrides",
  "paramiko",
  "paramiko.client",
  "paramiko.rsakey",


### PR DESCRIPTION
The `removeContainer` option currently does not remove stopped docker containers. Docker already provides a technique for automatically removing containers once stopped so I've updated the engine discarding logic to use the builtin docker autoremove. The other issue is that some containers never finish execution `container.stop` needs to be called seperately to `container.wait`. I've updated such that if this happens when the drop state changes away from running, however `stop()` can sometimes be a slow operation. On this side of this I've found an issue with a invalid unexpected boolean strings formats being sent to the translator.

Testing with the plasma dockerapp containers are now always cleaned up by default as long as the graph is cancelled at the end to stop the plasma stores.