### PR TITLE
REF: https://github.com/ICRAR/daliuge/issues/83

### DIFF
--- a/daliuge-translator/dlg/dropmake/dm_utils.py
+++ b/daliuge-translator/dlg/dropmake/dm_utils.py
@@ -456,9 +456,9 @@ def convert_construct(lgo):
         app_node["key"] = node["key"]
         app_node["category"] = node[has_app]  # node['application']
         if has_app[0] == "i":
-            app_node["text"] = node["inputApplicationName"]
+            app_node["text"] = node["text"]
         else:
-            app_node["text"] = node["outputApplicationName"]
+            app_node["text"] = node["text"]
 
         if "mkn" in node:
             app_node["mkn"] = node["mkn"]

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -984,7 +984,7 @@ class PGT(object):
                 return None
         if app_drop_only:
             lp = DAGUtil.get_longest_path(G, show_path=True)[0]
-            return sum(G.node[u].get(wk, 0) for u in lp)
+            return sum(G.nodes[u].get(wk, 0) for u in lp)
         else:
             return DAGUtil.get_longest_path(G, show_path=False)[1]
 
@@ -1129,9 +1129,9 @@ class PGT(object):
                     link = dict()
                     link["from"] = myk
                     from_dt = 0 if drop["type"] == DropType.PLAIN else 1
-                    to_dt = G.node[oup]["dt"]
+                    to_dt = G.nodes[oup]["dt"]
                     if from_dt == to_dt:
-                        to_drop = G.node[oup]["drop_spec"]
+                        to_drop = G.nodes[oup]["drop_spec"]
                         if from_dt == 0:
                             # add an extra app DROP
                             extra_oid = "{0}_TransApp_{1}".format(oid, i)
@@ -1177,7 +1177,7 @@ class PGT(object):
                         # global graph updates
                         # the new drop must have the same gid as the to_drop
                         add_nodes.append(
-                            (lid, 1, mydt, dropSpec, G.node[oup].get("gid", None))
+                            (lid, 1, mydt, dropSpec, G.nodes[oup].get("gid", None))
                         )
                         remove_edges.append((myk, oup))
                         add_edges.append((myk, lid))
@@ -1491,8 +1491,8 @@ class MetisPGTP(PGT):
         GG = self._G
         part_edges = defaultdict(int)  # k: from_gid + to_gid, v: sum_of_weight
         for e in GG.edges(data=True):
-            from_gid = GG.node[e[0]]["gid"]
-            to_gid = GG.node[e[1]]["gid"]
+            from_gid = GG.nodes[e[0]]["gid"]
+            to_gid = GG.nodes[e[1]]["gid"]
             k = "{0}**{1}".format(from_gid, to_gid)
             part_edges[k] += e[2]["weight"]
 
@@ -1767,7 +1767,7 @@ class MySarkarPGTP(PGT):
 
             node_list = jsobj["nodeDataArray"]
             for node in node_list:
-                gid = G.node[node["key"]]["gid"]  # gojs group_id
+                gid = G.nodes[node["key"]]["gid"]  # gojs group_id
                 if gid is None:
                     raise GPGTException(
                         "Node {0} does not have a Partition".format(node["key"])

--- a/daliuge-translator/dlg/dropmake/utils/antichains.py
+++ b/daliuge-translator/dlg/dropmake/utils/antichains.py
@@ -34,33 +34,33 @@ import sys
 
 import networkx as nx
 
-
-def _create_split_graph(dag, w_attr="weight"):
+def _create_split_graph(dag, w_attr='weight'):
     """
     Given a normal DiGraph, create its equivalent split graph
     """
     bpg = nx.DiGraph()
     for el in dag.nodes(data=True):
-        xi = "{0}_x".format(el[0])
-        yi = "{0}_y".format(el[0])
-        # print(el)
-        bpg.add_edge("s", xi, capacity=el[1].get(w_attr, 1), weight=0)
+        xi = '{0}_x'.format(el[0])
+        yi = '{0}_y'.format(el[0])
+        #print(el)
+        bpg.add_edge('s', xi, capacity=el[1].get(w_attr, 1), weight=0)
         bpg.add_edge(xi, yi, capacity=sys.maxsize, weight=1)
-        bpg.add_edge(yi, "t", capacity=el[1].get(w_attr, 1), weight=0)
+        bpg.add_edge(yi, 't', capacity=el[1].get(w_attr, 1), weight=0)
 
         el_des = nx.descendants(dag, el[0])
         el_pred = nx.ancestors(dag, el[0])
 
         for udown in el_des:
-            bpg.add_edge(xi, "{0}_y".format(udown), capacity=sys.maxsize, weight=0)
+            bpg.add_edge(xi, '{0}_y'.format(udown),
+            capacity=sys.maxsize, weight=0)
         for uup in el_pred:
-            bpg.add_edge("{0}_x".format(uup), yi, capacity=sys.maxsize, weight=0)
+            bpg.add_edge('{0}_x'.format(uup), yi,
+            capacity=sys.maxsize, weight=0)
 
     return bpg
 
-
 def _get_pi_solution(split_graph):
-    """
+        """
         1. create H (admissable graph) based on Section 3
         http://fmdb.cs.ucla.edu/Treports/930014.pdf
 
@@ -72,41 +72,40 @@ def _get_pi_solution(split_graph):
 
         4. calculate Pi based on Section 3 again
         """
-    # Step 1
-    H = nx.DiGraph()
-    H.add_nodes_from(split_graph)
-    for ed in split_graph.edges(data=True):
-        Cxy = ed[2].get("capacity", sys.maxsize)
-        Axy = ed[2]["weight"]
-        if Axy == 0 and Cxy > 0:
-            H.add_edge(ed[0], ed[1], capacity=Cxy, weight=Axy)
+        # Step 1
+        H = nx.DiGraph()
+        H.add_nodes_from(split_graph)
+        for ed in split_graph.edges(data=True):
+            Cxy = ed[2].get('capacity', sys.maxsize)
+            Axy = ed[2]['weight']
+            if (Axy == 0 and Cxy > 0):
+                H.add_edge(ed[0], ed[1], capacity=Cxy, weight=Axy)
 
-    # Step 2
-    flow_value, flow_dict = nx.maximum_flow(H, "s", "t")
+        # Step 2
+        flow_value, flow_dict = nx.maximum_flow(H, 's', 't')
 
-    # Step 3
-    R = nx.DiGraph()
-    R.add_nodes_from(H)
-    for ed in H.edges(data=True):
-        Xij = flow_dict[ed[0]][ed[1]]
-        Uij = ed[2].get("capacity", sys.maxsize)
-        Cij = ed[2]["weight"]
-        if (Uij - Xij) > 0:
-            R.add_edge(ed[0], ed[1], weight=Cij)
-        if Xij > 0:
-            R.add_edge(ed[1], ed[0], weight=-1 * Cij)
+        # Step 3
+        R = nx.DiGraph()
+        R.add_nodes_from(H)
+        for ed in H.edges(data=True):
+            Xij = flow_dict[ed[0]][ed[1]]
+            Uij = ed[2].get('capacity', sys.maxsize)
+            Cij = ed[2]['weight']
+            if (Uij - Xij) > 0:
+                R.add_edge(ed[0], ed[1], weight=Cij)
+            if (Xij > 0):
+                R.add_edge(ed[1], ed[0], weight=-1 * Cij)
 
-    # Step 4
-    pai = dict()
-    for n in R.nodes():
-        if nx.has_path(R, "s", n):
-            pai[n] = 0
-        else:
-            pai[n] = 1
-    return pai
+        # Step 4
+        pai = dict()
+        for n in R.nodes():
+            if (nx.has_path(R, 's', n)):
+                pai[n] = 0
+            else:
+                pai[n] = 1
+        return pai
 
-
-def get_max_weighted_antichain(dag, w_attr="weight"):
+def get_max_weighted_antichain(dag, w_attr='weight'):
     """
     Given a a nextworkx DiGraph `dag`, return a tuple.
     The first element is the length of the max_weighted_antichain
@@ -119,30 +118,29 @@ def get_max_weighted_antichain(dag, w_attr="weight"):
     bpg = _create_split_graph(dag, w_attr=w_attr)
     pai = _get_pi_solution(bpg)
 
-    w_antichain_len = 0  # weighted antichain length
+    w_antichain_len = 0 #weighted antichain length
     antichain_names = []
     for h in range(2):
         for nd in bpg.nodes():
-            if nd.endswith("_x"):
-                y_nd = nd.split("_x")[0] + "_y"
-                if (1 - pai[nd] + pai["s"] == h) and (pai[y_nd] - pai[nd] == 1):
-                    w_antichain_len += bpg.adj["s"][nd]["capacity"]
-                    # print(' *** %d' % bpg.edge['s'][nd]['capacity'])
+            if (nd.endswith('_x')):
+                y_nd = nd.split('_x')[0] + '_y'
+                if ((1 - pai[nd] + pai['s'] == h) and
+                (pai[y_nd] - pai[nd] == 1)):
+                    w_antichain_len += bpg.adj['s'][nd]['capacity']
+                    #print(' *** %d' % bpg.edge['s'][nd]['capacity'])
                     antichain_names.append(nd)
 
     return w_antichain_len, antichain_names
-
 
 def create_small_seq_graph():
     G = nx.DiGraph()
     G.add_edge(1, 2)
     G.add_edge(2, 3)
-    G.node[1]["weight"] = 5
-    G.node[2]["weight"] = 4
-    G.node[3]["weight"] = 7
-    # print("")
+    G.nodes[1]['weight'] = 5
+    G.nodes[2]['weight'] = 4
+    G.nodes[3]['weight'] = 7
+    #print("")
     return G, 7
-
 
 def create_medium_seq_graph():
     G = create_small_seq_graph()[0]
@@ -151,44 +149,39 @@ def create_medium_seq_graph():
     G.add_edge(4, 6)
     G.add_edge(5, 6)
     G.add_edge(6, 7)
-    G.node[4]["weight"] = 3
-    G.node[5]["weight"] = 2
-    G.node[6]["weight"] = 6
-    G.node[7]["weight"] = 1
+    G.nodes[4]['weight'] = 3
+    G.nodes[5]['weight'] = 2
+    G.nodes[6]['weight'] = 6
+    G.nodes[7]['weight'] = 1
     return G, 7
-
 
 def create_small_parral_graph():
     G = nx.DiGraph()
     G.add_edge(1, 2)
     G.add_edge(1, 3)
 
-    G.node[1]["weight"] = 5
-    G.node[2]["weight"] = 6
-    G.node[3]["weight"] = 7
+    G.nodes[1]['weight'] = 5
+    G.nodes[2]['weight'] = 6
+    G.nodes[3]['weight'] = 7
     return G, 13
-
 
 def create_medium_parral_graph():
     G = create_small_parral_graph()[0]
     G.add_edge(2, 4)
     G.add_edge(2, 5)
-    G.node[4]["weight"] = 3
-    G.node[5]["weight"] = 4
+    G.nodes[4]['weight'] = 3
+    G.nodes[5]['weight'] = 4
     return G, 14
 
-
 if __name__ == "__main__":
-    gs = [
-        create_small_seq_graph(),
-        create_medium_seq_graph(),
-        create_small_parral_graph(),
-        create_medium_parral_graph(),
-    ]
+    gs = [create_small_seq_graph(),
+          create_medium_seq_graph(),
+          create_small_parral_graph(),
+          create_medium_parral_graph()]
     for g, lt in gs:
         w, l = get_max_weighted_antichain(g)
         print(w)
         print(l)
-        if w != lt:
+        if (w != lt):
             print("Calculated %d != %d, which is the ground-truth" % (w, lt))
-        print("")
+        print('')

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     "daliuge-common==%s" % (VERSION,),
     "metis>=0.2a3",
     # We are not compatible with networkx 2.4 yet, so we need to constrain that
-    "networkx<2.4",
+    "networkx",
     "numpy",
     "psutil",
     "pyswarm",


### PR DESCRIPTION
As per https://networkx.org/documentation/latest/release/release_2.4.html,
NetworkX uses `Graph.nodes[u]` to access a node `u` in the Graph.

This update changes any `DiGraph.node[u]` access to `DiGraph.nodes[u]`.