### PR TITLE
Yan 854 -- Shared Memory DROPs

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -30,6 +30,7 @@ class Categories:
     END = "End"
 
     MEMORY = "Memory"
+    SHMEM = "SharedMemory"
     FILE = "File"
     NGAS = "NGAS"
     NULL = "null"
@@ -63,6 +64,7 @@ class Categories:
 
 STORAGE_TYPES = {
     Categories.MEMORY,
+    Categories.SHMEM,
     Categories.FILE,
     Categories.NGAS,
     Categories.NULL,

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -24,6 +24,7 @@ from dlg.drop import (
     BarrierAppDROP,
     NgasDROP,
     InMemoryDROP,
+    SharedMemoryDROP,
     NullDROP,
     RDBMSDrop,
     ContainerDROP,
@@ -78,12 +79,14 @@ class ScpApp(BarrierAppDROP):
         "input onto its single output via SSHs scp protocol.",
         [
             dlg_batch_input(
-                "binary/*", [NgasDROP, InMemoryDROP, NullDROP, RDBMSDrop, ContainerDROP]
+                "binary/*",
+                [NgasDROP, InMemoryDROP, SharedMemoryDROP, NullDROP, RDBMSDrop, ContainerDROP]
             )
         ],
         [
             dlg_batch_output(
-                "binary/*", [NgasDROP, InMemoryDROP, NullDROP, RDBMSDrop, ContainerDROP]
+                "binary/*",
+                [NgasDROP, InMemoryDROP, SharedMemoryDROP, NullDROP, RDBMSDrop, ContainerDROP]
             )
         ],
         [dlg_streaming_input("binary/*")],

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1452,6 +1452,36 @@ class InMemoryDROP(AbstractDROP):
         return "mem://%s/%d/%d" % (hostname, os.getpid(), id(self._buf))
 
 
+class SharedMemoryDROP(AbstractDROP):
+    """
+    A DROP that points to data stored in shared memory.
+    This drop is functionality equivalent to an InMemory drop running in a concurrent environment.
+    In this case however, the requirement for shared memory is explicit.
+
+    @WARNING Currently implemented as writing to shmem and there is no backup behaviour.
+    """
+
+    def initialize(self, **kwargs):
+        args = []
+        if "pydata" in kwargs:
+            pydata = kwargs.pop("pydata")
+            if isinstance(pydata, str):
+                pydata = pydata.encode("utf8")
+            args.append(base64.b64decode(pydata))
+        self._buf = io.BytesIO(*args)
+
+    def getIO(self):
+        if hasattr(self, '_sessID') and sys.version_info >= (3, 8):
+            return SharedMemoryIO(self.oid, self._sessID)
+        else:
+            raise NotImplementedError("Shared memory is only available with Python >= 3.8")
+
+    @property
+    def dataURL(self):
+        hostname = os.uname()[1]
+        return f"shmem://{hostname}/{os.getpid()}/{id(self._buf)}"
+
+
 class NullDROP(AbstractDROP):
     """
     A DROP that doesn't store any data.

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -22,7 +22,7 @@
 """
 Module containing the core DROP classes.
 """
-
+import string
 from abc import ABCMeta, abstractmethod
 import ast
 import base64
@@ -1471,8 +1471,14 @@ class SharedMemoryDROP(AbstractDROP):
         self._buf = io.BytesIO(*args)
 
     def getIO(self):
-        if hasattr(self, '_sessID') and sys.version_info >= (3, 8):
-            return SharedMemoryIO(self.oid, self._sessID)
+        print(sys.version_info)
+        if sys.version_info >= (3, 8):
+            if hasattr(self, '_sessID'):
+                return SharedMemoryIO(self.oid, self._sessID)
+            else:
+                # Using Drop without manager, just generate a random name.
+                sess_id = ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
+                return SharedMemoryIO(self.oid, sess_id)
         else:
             raise NotImplementedError("Shared memory is only available with Python >= 3.8")
 
@@ -2175,6 +2181,7 @@ class PlasmaFlightDROP(AbstractDROP):
     @property
     def dataURL(self):
         return "plasmaflight://%s" % (binascii.hexlify(self.object_id).decode("ascii"))
+
 
 ##
 # @brief ParameterSet

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -34,6 +34,7 @@ from .ddap_protocol import DROPRel, DROPLinkType
 from .drop import (
     ContainerDROP,
     InMemoryDROP,
+    SharedMemoryDROP,
     FileDROP,
     NgasDROP,
     LINKTYPE_NTO1_PROPERTY,
@@ -51,6 +52,7 @@ from .common import Categories, DropType
 
 STORAGE_TYPES = {
     Categories.MEMORY: InMemoryDROP,
+    Categories.SHMEM: SharedMemoryDROP,
     Categories.FILE: FileDROP,
     Categories.NGAS: NgasDROP,
     Categories.NULL: NullDROP,

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -623,7 +623,7 @@ class TestDM(NMTestsMixIn, unittest.TestCase):
         dm = self._start_dm()
         sessionID = "s1"
         if sys.version_info < (3, 8):
-            self.assertRaises(NotImplementedError, quickDeploy(dm, sessionID, graph))
+            self.assertRaises(NotImplementedError, quickDeploy, dm, sessionID, graph)
         else:
             quickDeploy(dm, sessionID, graph)
             self.assertEqual(1, len(dm._sessions[sessionID].drops))

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -27,6 +27,7 @@ import random
 import shutil
 import sqlite3
 import string
+import sys
 import tempfile
 import subprocess
 
@@ -132,12 +133,14 @@ class TestDROP(unittest.TestCase):
         """
         self._test_dynamic_write_withDropType(InMemoryDROP)
 
+    @unittest.skipIf(sys.version_info < (3, 8), "Shared memory does nt work < python 3.8")
     def test_write_SharedMemoryDROP(self):
         """
         Test a SharedMemoryDROP with simple AppDROP (for checksum calculation)
         """
         self._test_write_withDropType(SharedMemoryDROP)
 
+    @unittest.skipIf(sys.version_info < (3, 8), "Shared memory does nt work < python 3.8")
     def test_dynamic_write_SharedMemoryDROP(self):
         """
         Test a SharedMemoryDROP with simple AppDROP (for checksum calculation)

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -36,6 +36,7 @@ from dlg.drop import (
     FileDROP,
     AppDROP,
     InMemoryDROP,
+    SharedMemoryDROP,
     PlasmaDROP,
     PlasmaFlightDROP,
     NullDROP,
@@ -130,6 +131,18 @@ class TestDROP(unittest.TestCase):
         Test an InMemoryDROP and a simple AppDROP (for checksum calculation)
         """
         self._test_dynamic_write_withDropType(InMemoryDROP)
+
+    def test_write_SharedMemoryDROP(self):
+        """
+        Test a SharedMemoryDROP with simple AppDROP (for checksum calculation)
+        """
+        self._test_write_withDropType(SharedMemoryDROP)
+
+    def test_dynamic_write_SharedMemoryDROP(self):
+        """
+        Test a SharedMemoryDROP with simple AppDROP (for checksum calculation)
+        """
+        self._test_dynamic_write_withDropType(SharedMemoryDROP)
 
     def test_write_plasmaDROP(self):
         """

--- a/daliuge-engine/test/test_graph_loader.py
+++ b/daliuge-engine/test/test_graph_loader.py
@@ -23,7 +23,7 @@ import unittest
 
 from dlg import graph_loader
 from dlg.ddap_protocol import DROPLinkType, DROPRel
-from dlg.drop import InMemoryDROP, ContainerDROP, AppDROP, DirectoryContainer
+from dlg.drop import InMemoryDROP, SharedMemoryDROP, ContainerDROP, AppDROP, DirectoryContainer
 from dlg.common import Categories
 
 
@@ -37,6 +37,13 @@ class TestGraphLoader(unittest.TestCase):
         dropSpecList = [{"oid": "A", "type": "plain", "storage": Categories.MEMORY}]
         a = graph_loader.createGraphFromDropSpecList(dropSpecList)[0]
         self.assertIsInstance(a, InMemoryDROP)
+        self.assertEqual("A", a.oid)
+        self.assertEqual("A", a.uid)
+
+    def test_sharedMemoryDrop(self):
+        dropSpecList = [{"oid": "A", "type": "plain", "storage": Categories.SHMEM}]
+        a = graph_loader.createGraphFromDropSpecList(dropSpecList)[0]
+        self.assertIsInstance(a, SharedMemoryDROP)
         self.assertEqual("A", a.oid)
         self.assertEqual("A", a.uid)
 

--- a/daliuge-translator/test/dropmake/logical_graphs/SharedMemoryTest.graph
+++ b/daliuge-translator/test/dropmake/logical_graphs/SharedMemoryTest.graph
@@ -1,0 +1,715 @@
+{
+    "linkDataArray": [
+        {
+            "from": -1,
+            "fromPort": "b845e9f8-d19c-4fc7-a073-8bcc64e086e2",
+            "loop_aware": "0",
+            "to": -2,
+            "toPort": "a8ecb5d5-55d3-4d2e-80d4-7f019afdf179"
+        },
+        {
+            "from": -2,
+            "fromPort": "7c3bdeac-cb1d-4502-9ada-d7fc65344200",
+            "loop_aware": "0",
+            "to": -3,
+            "toPort": "03b96b10-8f1a-4fec-b1d9-f6799146dd77"
+        },
+        {
+            "from": -2,
+            "fromPort": "7c3bdeac-cb1d-4502-9ada-d7fc65344200",
+            "loop_aware": "0",
+            "to": -5,
+            "toPort": "72238898-292f-4a5f-85c0-6474b810caad"
+        },
+        {
+            "from": -2,
+            "fromPort": "7c3bdeac-cb1d-4502-9ada-d7fc65344200",
+            "loop_aware": "0",
+            "to": -4,
+            "toPort": "2b5dc75a-2588-4ef2-bf5a-b2a22b32ba23"
+        },
+        {
+            "from": -3,
+            "fromPort": "886fe73c-4f86-4551-a1b9-94fe9ed247a0",
+            "loop_aware": "0",
+            "to": -6,
+            "toPort": "9857a4e2-2f05-4850-bafd-24581f530e32"
+        },
+        {
+            "from": -5,
+            "fromPort": "8b4258f6-1504-4988-9638-233782dee15b",
+            "loop_aware": "0",
+            "to": -7,
+            "toPort": "b221cb23-e256-49c5-b3d2-0bc6f2b3c53a"
+        },
+        {
+            "from": -4,
+            "fromPort": "d6f695db-2e2e-42d3-98a4-4713872a2b98",
+            "loop_aware": "0",
+            "to": -8,
+            "toPort": "9b6ec8c5-6cd9-4b0b-a52b-394b018d5bbd"
+        }
+    ],
+    "modelData": {
+        "eagleCommitHash": "Unknown",
+        "eagleVersion": "Unknown",
+        "filePath": "Diagram-2022-01-06-11-21-40.graph",
+        "fileType": "Graph",
+        "gitUrl": "",
+        "lastModifiedDatetime": 0,
+        "lastModifiedEmail": "",
+        "lastModifiedName": "",
+        "readonly": true,
+        "repo": "",
+        "repoBranch": "",
+        "repoService": "Unknown",
+        "schemaVersion": "OJS",
+        "sha": ""
+    },
+    "nodeDataArray": [
+        {
+            "applicationParams": [],
+            "category": "PythonApp",
+            "collapsed": false,
+            "color": "#0059a5",
+            "description": "An application component in the form of a Python app",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimate of execution time (in seconds) for this application.",
+                    "name": "execution_time",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Execution time",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "1",
+                    "description": "Number of CPUs used for this application.",
+                    "name": "num_cpus",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Num CPUs",
+                    "type": "Integer",
+                    "value": 1
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the start of a group?",
+                    "name": "group_start",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group start",
+                    "type": "Boolean",
+                    "value": false
+                },
+                {
+                    "defaultValue": "test.graphsRepository",
+                    "description": "The python class that implements this application",
+                    "name": "appclass",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Appclass",
+                    "type": "String",
+                    "value": "dlg.apps.simple.HelloWorldApp"
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [],
+            "isGroup": false,
+            "key": -1,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [
+                {
+                    "Id": "b845e9f8-d19c-4fc7-a073-8bcc64e086e2",
+                    "IdText": "hello",
+                    "description": " The port carrying the message produced by the app.",
+                    "event": false,
+                    "text": "Hello",
+                    "type": "String"
+                }
+            ],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Python App",
+            "width": 200,
+            "x": 346,
+            "y": 563
+        },
+        {
+            "applicationParams": [],
+            "category": "SharedMemory",
+            "collapsed": false,
+            "color": "#2c2c2c",
+            "description": "Shared memory storage of intermediate data products. Implemented using shmem.",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimated size of the data contained in this node",
+                    "name": "data_volume",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Data volume",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the end of a group?",
+                    "name": "group_end",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group end",
+                    "type": "Boolean",
+                    "value": false
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "a8ecb5d5-55d3-4d2e-80d4-7f019afdf179",
+                    "IdText": "hello",
+                    "description": " The port carrying the message produced by the app.",
+                    "event": false,
+                    "text": "Hello",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -2,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [
+                {
+                    "Id": "7c3bdeac-cb1d-4502-9ada-d7fc65344200",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Shared Memory",
+            "width": 200,
+            "x": 596,
+            "y": 565
+        },
+        {
+            "applicationParams": [],
+            "category": "PythonApp",
+            "collapsed": false,
+            "color": "#0059a5",
+            "description": "An application component in the form of a Python app",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimate of execution time (in seconds) for this application.",
+                    "name": "execution_time",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Execution time",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "1",
+                    "description": "Number of CPUs used for this application.",
+                    "name": "num_cpus",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Num CPUs",
+                    "type": "Integer",
+                    "value": 1
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the start of a group?",
+                    "name": "group_start",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group start",
+                    "type": "Boolean",
+                    "value": false
+                },
+                {
+                    "defaultValue": "test.graphsRepository",
+                    "description": "The python class that implements this application",
+                    "name": "appclass",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Appclass",
+                    "type": "String",
+                    "value": "dlg.apps.simple.CopyApp"
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "03b96b10-8f1a-4fec-b1d9-f6799146dd77",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -3,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [
+                {
+                    "Id": "886fe73c-4f86-4551-a1b9-94fe9ed247a0",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Python App",
+            "width": 200,
+            "x": 860,
+            "y": 395
+        },
+        {
+            "applicationParams": [],
+            "category": "PythonApp",
+            "collapsed": false,
+            "color": "#0059a5",
+            "description": "An application component in the form of a Python app",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimate of execution time (in seconds) for this application.",
+                    "name": "execution_time",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Execution time",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "1",
+                    "description": "Number of CPUs used for this application.",
+                    "name": "num_cpus",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Num CPUs",
+                    "type": "Integer",
+                    "value": 1
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the start of a group?",
+                    "name": "group_start",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group start",
+                    "type": "Boolean",
+                    "value": false
+                },
+                {
+                    "defaultValue": "test.graphsRepository",
+                    "description": "The python class that implements this application",
+                    "name": "appclass",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Appclass",
+                    "type": "String",
+                    "value": "dlg.apps.simple.CopyApp"
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "2b5dc75a-2588-4ef2-bf5a-b2a22b32ba23",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -4,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [
+                {
+                    "Id": "d6f695db-2e2e-42d3-98a4-4713872a2b98",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Python App",
+            "width": 200,
+            "x": 857,
+            "y": 653
+        },
+        {
+            "applicationParams": [],
+            "category": "PythonApp",
+            "collapsed": false,
+            "color": "#0059a5",
+            "description": "An application component in the form of a Python app",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimate of execution time (in seconds) for this application.",
+                    "name": "execution_time",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Execution time",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "1",
+                    "description": "Number of CPUs used for this application.",
+                    "name": "num_cpus",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Num CPUs",
+                    "type": "Integer",
+                    "value": 1
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the start of a group?",
+                    "name": "group_start",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group start",
+                    "type": "Boolean",
+                    "value": false
+                },
+                {
+                    "defaultValue": "test.graphsRepository",
+                    "description": "The python class that implements this application",
+                    "name": "appclass",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Appclass",
+                    "type": "String",
+                    "value": "dlg.apps.simple.CopyApp"
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "72238898-292f-4a5f-85c0-6474b810caad",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -5,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [
+                {
+                    "Id": "8b4258f6-1504-4988-9638-233782dee15b",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Python App",
+            "width": 200,
+            "x": 856,
+            "y": 525
+        },
+        {
+            "applicationParams": [],
+            "category": "SharedMemory",
+            "collapsed": false,
+            "color": "#2c2c2c",
+            "description": "Shared memory storage of intermediate data products. Implemented using shmem.",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimated size of the data contained in this node",
+                    "name": "data_volume",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Data volume",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the end of a group?",
+                    "name": "group_end",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group end",
+                    "type": "Boolean",
+                    "value": false
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "9857a4e2-2f05-4850-bafd-24581f530e32",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -6,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Shared Memory",
+            "width": 200,
+            "x": 1183,
+            "y": 384
+        },
+        {
+            "applicationParams": [],
+            "category": "SharedMemory",
+            "collapsed": false,
+            "color": "#2c2c2c",
+            "description": "Shared memory storage of intermediate data products. Implemented using shmem.",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimated size of the data contained in this node",
+                    "name": "data_volume",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Data volume",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the end of a group?",
+                    "name": "group_end",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group end",
+                    "type": "Boolean",
+                    "value": false
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "b221cb23-e256-49c5-b3d2-0bc6f2b3c53a",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -7,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Shared Memory",
+            "width": 200,
+            "x": 1199,
+            "y": 532
+        },
+        {
+            "applicationParams": [],
+            "category": "SharedMemory",
+            "collapsed": false,
+            "color": "#2c2c2c",
+            "description": "Shared memory storage of intermediate data products. Implemented using shmem.",
+            "drawOrderHint": 0,
+            "expanded": false,
+            "fields": [
+                {
+                    "defaultValue": "5",
+                    "description": "Estimated size of the data contained in this node",
+                    "name": "data_volume",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Data volume",
+                    "type": "Float",
+                    "value": 5
+                },
+                {
+                    "defaultValue": "false",
+                    "description": "Is this node the end of a group?",
+                    "name": "group_end",
+                    "precious": false,
+                    "readonly": false,
+                    "text": "Group end",
+                    "type": "Boolean",
+                    "value": false
+                }
+            ],
+            "flipPorts": false,
+            "git_url": "",
+            "height": 72,
+            "inputAppFields": [],
+            "inputApplicationKey": null,
+            "inputApplicationName": "",
+            "inputApplicationType": "None",
+            "inputLocalPorts": [],
+            "inputPorts": [
+                {
+                    "Id": "9b6ec8c5-6cd9-4b0b-a52b-394b018d5bbd",
+                    "IdText": "data",
+                    "description": "",
+                    "event": false,
+                    "text": "Data",
+                    "type": "String"
+                }
+            ],
+            "isGroup": false,
+            "key": -8,
+            "outputAppFields": [],
+            "outputApplicationKey": null,
+            "outputApplicationName": "",
+            "outputApplicationType": "None",
+            "outputLocalPorts": [],
+            "outputPorts": [],
+            "precious": false,
+            "readonly": false,
+            "sha": "",
+            "streaming": false,
+            "subject": null,
+            "text": "Shared Memory",
+            "width": 200,
+            "x": 1165,
+            "y": 676
+        }
+    ]
+}

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -230,3 +230,14 @@ class TestPGGen(unittest.TestCase):
             fp = get_lg_fname(lg)
             lg = LG(fp)
             lg.unroll_to_tpl()
+
+    def test_shmem_graph(self):
+        # Test loading of shared memory graph
+        lgs = ["SharedMemoryTest.graph"]
+        for lg in lgs:
+            fp = get_lg_fname(lg)
+            lg = LG(fp)
+            out = lg.unroll_to_tpl()
+            for drop in out:
+                if drop['type'] == 'plain':
+                    self.assertEqual("SharedMemory", drop['storage'])


### PR DESCRIPTION
This merge transforms the underlying SharedMemory implementation used to facilitate multiprocessing (YAN-847) into stand-alone drops for explicit use.
Some documentation has been added to the ``graphs`` page in the docs.

Unlike the multiprocessing implementation, there is no fall-back to standard InMemory drops in the case of an incompatible system (Windows or python < 3.8) - it is assumed that specifically requesting shared memory is intentional.