### PR TITLE
Liu 220 - Environment Variable Drop 

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -39,6 +39,7 @@ class Categories:
     PLASMA = "Plasma"
     PLASMAFLIGHT = "PlasmaFlight"
     PARSET = "ParameterSet"
+    ENVIRONMENTVARS = "EnvironmentVars"
 
     MKN = "MKN"
     SCATTER = "Scatter"
@@ -72,7 +73,8 @@ STORAGE_TYPES = {
     Categories.JSON,
     Categories.PLASMA,
     Categories.PLASMAFLIGHT,
-    Categories.PARSET
+    Categories.PARSET,
+    Categories.ENVIRONMENTVARS
 }
 APP_DROP_TYPES = [
     Categories.COMPONENT,

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -77,8 +77,6 @@ DEFAULT_INTERNAL_PARAMETERS = {'storage', 'rank', 'loop_cxt', 'dw', 'iid', 'dt',
 if sys.version_info >= (3, 8):
     from .io import SharedMemoryIO
 from .utils import prepare_sql, createDirIfMissing, isabs, object_tracking
-from .meta import dlg_float_param, dlg_int_param, dlg_list_param, \
-    dlg_string_param, dlg_bool_param, dlg_dict_param
 from dlg.process import DlgProcess
 from .meta import (
     dlg_float_param,
@@ -2268,66 +2266,6 @@ class PlasmaFlightDROP(AbstractDROP):
     @property
     def dataURL(self):
         return "plasmaflight://%s" % (binascii.hexlify(self.object_id).decode("ascii"))
-
-
-##
-# @brief ParameterSet
-# @details A set of parameters, wholly specified in EAGLE
-# @par EAGLE_START
-# @param category ParameterSet
-# @param[in] param/mode Parset mode/"YANDA"/String/readonly/False/To what standard DALiuGE should filter and serialize the parameters.
-# @param[in] param/config_data ConfigData/""/String/readwrite/False/Additional configuration information to be mixed in with the initial data
-# @param[out] port/Config ConfigFile/File/The output configuration file
-# @par EAGLE_END
-class ParameterSetDROP(AbstractDROP):
-    """
-    A generic configuration file template wrapper
-    This drop opens an (optional) file containing some initial configuration information, then
-    appends any additional specified parameters to it, finally serving it as a data object.
-    """
-
-    config_data = b''
-
-    mode = dlg_string_param('mode', None)
-
-    @abstractmethod
-    def serialize_parameters(self, parameters: dict, mode):
-        """
-        Returns a string representing a serialization of the parameters.
-        """
-        if mode == "YANDA":
-            # TODO: Add more complex value checking
-            return "\n".join(f"{x}={y}" for x, y in parameters.items())
-        # Add more formats (.ini for example)
-        return "\n".join(f"{x}={y}" for x, y in parameters.items())
-
-    @abstractmethod
-    def filter_parameters(self, parameters: dict, mode):
-        """
-        Returns a dictionary of parameters, with daliuge-internal or other parameters filtered out
-        """
-        if mode == 'YANDA':
-            forbidden_params = list(DEFAULT_INTERNAL_PARAMETERS)
-            if parameters['config_data'] == "":
-                forbidden_params.append('configData')
-            return {key: val for key, val in parameters.items() if
-                    key not in DEFAULT_INTERNAL_PARAMETERS}
-        return parameters
-
-    def initialize(self, **kwargs):
-        """
-        TODO: Open input file
-        """
-        self.config_data = self.serialize_parameters(
-            self.filter_parameters(self.parameters, self.mode), self.mode).encode('utf-8')
-
-    def getIO(self):
-        return MemoryIO(io.BytesIO(self.config_data))
-
-    @property
-    def dataURL(self):
-        hostname = os.uname()[1]
-        return f"config://{hostname}/{os.getpid()}/{id(self.config_data)}"
 
 
 # Dictionary mapping 1-to-many DROPLinkType constants to the corresponding methods

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -221,9 +221,6 @@ class AbstractDROP(EventFirer):
         self._producers_uids = set()
         self._producers = ListAsDict(self._producers_uids)
 
-        # Global environment variable stores. Kept separate since they are perpetually available
-        self._environment_variable_stores = self._getArg(kwargs, "environment_stores", {})
-
         # Set holding the state of the producers that have finished their
         # execution. Once all producers have finished, this DROP moves
         # itself to the COMPLETED state
@@ -613,8 +610,11 @@ class AbstractDROP(EventFirer):
             return None
         key_edit = key[1:]
         env_var_ref, env_var_key = key_edit.split('.')[0], '.'.join(key_edit.split('.')[1:])
-        env_var_drop = self._environment_variable_stores.get(env_var_ref)
-        if env_var_drop is not None:
+        env_var_drop = None
+        for producer in self.producers:
+            if producer.name == env_var_ref:
+                env_var_drop = producer
+        if env_var_drop is not None:  # TODO: Check for KeyValueDROP interface support
             return env_var_drop.get(env_var_key)
         else:
             return None

--- a/daliuge-engine/dlg/environmentvar_drop.py
+++ b/daliuge-engine/dlg/environmentvar_drop.py
@@ -74,6 +74,7 @@ class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):
         """
         Runs through all parameters, putting each into this drop's variable dict
         """
+        super(EnvironmentVarDROP, self).initialize(**kwargs)
         self._variables = dict()
         self._variables.update(_filter_parameters(self.parameters))
 

--- a/daliuge-engine/dlg/environmentvar_drop.py
+++ b/daliuge-engine/dlg/environmentvar_drop.py
@@ -1,0 +1,68 @@
+import abc
+import io
+import os
+import json
+
+from dlg.drop import AbstractDROP, DEFAULT_INTERNAL_PARAMETERS
+from dlg.io import MemoryIO
+
+
+class KeyValueDROP:
+
+    @abc.abstractmethod
+    def get(self, key):
+        """
+        Returns the value stored by this drop for the given key. Returns None if not present
+        """
+
+    @abc.abstractmethod
+    def get_multiple(self, keys: list):
+        """
+        Returns a list of values stored by this drop. Maintains order returning None for any keys
+        not present.
+        """
+
+    # TODO: Implement Set(key, value) operations
+
+
+def _filter_parameters(parameters: dict):
+    return {key: val for key, val in parameters.items() if
+            key not in DEFAULT_INTERNAL_PARAMETERS}
+
+
+##
+# @brief Environment variables
+# @details A set of environment variables, wholly specified in EAGLE and accessible to all drops.
+# @par EAGLE_START
+# @param category EnvironmentVars
+# @par EAGLE_END
+class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):
+    """
+    Drop storing static variables for access by all drops.
+    Functions effectively like a globally-available Python dictionary
+    """
+
+    variables = {}
+
+    def initialize(self, **kwargs):
+        """
+        Runs through all parameters, putting each into this drop's variable dict
+        """
+        self.variables.update(_filter_parameters(self.parameters))
+
+    def getIO(self):
+        return MemoryIO(io.BytesIO(json.dumps(self.variables).encode('utf-8')))
+
+    def get(self, key):
+        return self.variables.get(key)
+
+    def get_multiple(self, keys: list):
+        return_vars = []
+        for key in keys:
+            return_vars.append(self.variables.get(key))
+        return return_vars
+
+    @property
+    def dataURL(self):
+        hostname = os.uname()[1]
+        return f"config://{hostname}/{os.getpid()}/{id(self.variables)}"

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -42,9 +42,9 @@ from .drop import (
     NullDROP,
     EndDROP,
     PlasmaDROP,
-    PlasmaFlightDROP,
-    ParameterSetDROP
+    PlasmaFlightDROP
 )
+from dlg.parset_drop import ParameterSetDROP
 from .exceptions import InvalidGraphException
 from .json_drop import JsonDROP
 from .common import Categories, DropType

--- a/daliuge-engine/dlg/parset_drop.py
+++ b/daliuge-engine/dlg/parset_drop.py
@@ -1,3 +1,24 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2014
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
 import io
 import os
 from abc import abstractmethod

--- a/daliuge-engine/dlg/parset_drop.py
+++ b/daliuge-engine/dlg/parset_drop.py
@@ -1,0 +1,67 @@
+import io
+import os
+from abc import abstractmethod
+
+from dlg.drop import AbstractDROP, DEFAULT_INTERNAL_PARAMETERS
+from dlg.io import MemoryIO
+from dlg.meta import dlg_string_param
+
+
+##
+# @brief ParameterSet
+# @details A set of parameters, wholly specified in EAGLE
+# @par EAGLE_START
+# @param category ParameterSet
+# @param[in] param/mode Parset mode/"YANDA"/String/readonly/False/To what standard DALiuGE should filter and serialize the parameters.
+# @param[in] param/config_data ConfigData/""/String/readwrite/False/Additional configuration information to be mixed in with the initial data
+# @param[out] port/Config ConfigFile/File/The output configuration file
+# @par EAGLE_END
+class ParameterSetDROP(AbstractDROP):
+    """
+    A generic configuration file template wrapper
+    This drop opens an (optional) file containing some initial configuration information, then
+    appends any additional specified parameters to it, finally serving it as a data object.
+    """
+
+    config_data = b''
+
+    mode = dlg_string_param('mode', None)
+
+    @abstractmethod
+    def serialize_parameters(self, parameters: dict, mode):
+        """
+        Returns a string representing a serialization of the parameters.
+        """
+        if mode == "YANDA":
+            # TODO: Add more complex value checking
+            return "\n".join(f"{x}={y}" for x, y in parameters.items())
+        # Add more formats (.ini for example)
+        return "\n".join(f"{x}={y}" for x, y in parameters.items())
+
+    @abstractmethod
+    def filter_parameters(self, parameters: dict, mode):
+        """
+        Returns a dictionary of parameters, with daliuge-internal or other parameters filtered out
+        """
+        if mode == 'YANDA':
+            forbidden_params = list(DEFAULT_INTERNAL_PARAMETERS)
+            if parameters['config_data'] == "":
+                forbidden_params.append('configData')
+            return {key: val for key, val in parameters.items() if
+                    key not in DEFAULT_INTERNAL_PARAMETERS}
+        return parameters
+
+    def initialize(self, **kwargs):
+        """
+        TODO: Open input file
+        """
+        self.config_data = self.serialize_parameters(
+            self.filter_parameters(self.parameters, self.mode), self.mode).encode('utf-8')
+
+    def getIO(self):
+        return MemoryIO(io.BytesIO(self.config_data))
+
+    @property
+    def dataURL(self):
+        hostname = os.uname()[1]
+        return f"config://{hostname}/{os.getpid()}/{id(self.config_data)}"

--- a/daliuge-engine/dlg/utils.py
+++ b/daliuge-engine/dlg/utils.py
@@ -40,7 +40,6 @@ import netifaces
 
 from . import common
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -216,6 +215,16 @@ def getDlgPath():
     currently doesn't exist
     """
     return os.path.join(getDlgDir(), "code")
+
+
+def getDlgVariable(key: str):
+    """
+    Queries environment for variables assumed to start with 'DLG_'.
+    Special case for DLG_ROOT, since this is easily identifiable.
+    """
+    if key == "$DLG_ROOT":
+        return getDlgDir()
+    return os.environ.get(key[1:])
 
 
 def createDirIfMissing(path):

--- a/daliuge-engine/test/test_ParameterSetDROP.py
+++ b/daliuge-engine/test/test_ParameterSetDROP.py
@@ -20,7 +20,7 @@
 #    MA 02111-1307  USA
 #
 import unittest
-from dlg.drop import ParameterSetDROP
+from dlg.parset_drop import ParameterSetDROP
 from dlg.droputils import allDropContents
 
 

--- a/daliuge-engine/test/test_environmentvars.py
+++ b/daliuge-engine/test/test_environmentvars.py
@@ -82,8 +82,8 @@ class TestEnvironmentVarDROP(unittest.TestCase):
         Tests the AbstractDROP fetch routine functions correctly with a single environment drop
         """
         env_drop = create_std_env_vars()
-        app_drop = AppDROP(uid='b', oid='b', environment_stores={env_drop.name: env_drop})
-        print(app_drop._environment_variable_stores)
+        app_drop = AppDROP(uid='b', oid='b')
+        app_drop.addProducer(env_drop)
         self.assertEqual('/DLG_HOME/', app_drop.get_environment_variable('$env_vars.dlg_root'))
         self.assertEqual(3, app_drop.get_environment_variable('$env_vars.int_var'))
         self.assertEqual(False, app_drop.get_environment_variable('$env_vars.bool_var'))
@@ -101,7 +101,8 @@ class TestEnvironmentVarDROP(unittest.TestCase):
         """
         env_name = 'env_vars'
         env_drop = create_std_env_vars(name=env_name)
-        app_drop = AppDROP(uid='b', oid='b', environment_stores={env_drop.name: env_drop})
+        app_drop = AppDROP(uid='b', oid='b')
+        app_drop.addProducer(env_drop)
         expected_vars = [None, '/DLG_HOME/', 3, False, 0.5, {'first': 1, 'second': 'sec'},
                          [1, 2.0, '3'], None]
         query_keys = ['uid', 'dlg_root', 'int_var', 'bool_var', 'float_var', 'dict_var', 'list_var',
@@ -118,7 +119,8 @@ class TestEnvironmentVarDROP(unittest.TestCase):
         """
         env_name = ''
         env_drop = create_empty_env_vars(name=env_name)
-        app_drop = AppDROP(uid='c', oid='c', environment_stores={env_drop.name: env_drop})
+        app_drop = AppDROP(uid='c', oid='c')
+        app_drop.addProducer(env_drop)
         self.assertEqual(None, app_drop.get_environment_variable(''))
         self.assertEqual(None, app_drop.get_environment_variable('$'))
 
@@ -131,8 +133,9 @@ class TestEnvironmentVarDROP(unittest.TestCase):
         env1_drop = create_std_env_vars(name=env1_name)
         env2_drop = EnvironmentVarDROP(oid='d', uid='d', nm=env2_name, dlg_root='/DIFFERENT/',
                                        int_var=4)
-        app_drop = AppDROP(uid='c', oid='c',
-                           environment_stores={env1_name: env1_drop, env2_name: env2_drop})
+        app_drop = AppDROP(uid='c', oid='c')
+        app_drop.addProducer(env1_drop)
+        app_drop.addProducer(env2_drop)
         self.assertEqual('/DLG_HOME/', app_drop.get_environment_variable(f"${env1_name}.dlg_root"))
         self.assertEqual('/DIFFERENT/', app_drop.get_environment_variable(f"${env2_name}.dlg_root"))
         self.assertEqual(3, app_drop.get_environment_variable(f"${env1_name}.int_var"))

--- a/daliuge-engine/test/test_environmentvars.py
+++ b/daliuge-engine/test/test_environmentvars.py
@@ -1,0 +1,148 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2014
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+import unittest
+from dlg.environmentvar_drop import EnvironmentVarDROP
+from dlg.drop import AppDROP
+
+
+def create_std_env_vars(name='env_vars'):
+    return EnvironmentVarDROP(oid='a', uid='a', nm=name, dlg_root='/DLG_HOME/', int_var=3,
+                              bool_var=False,
+                              float_var=0.5, dict_var={'first': 1, 'second': 'sec'},
+                              list_var=[1, 2.0, '3'])
+
+
+def create_empty_env_vars(name='env_vars'):
+    return EnvironmentVarDROP(oid='b', uid='b', nm=name)
+
+
+class TestEnvironmentVarDROP(unittest.TestCase):
+
+    def test_get(self):
+        """
+        Tests that environment variables are read in and fetched correctly.
+        """
+        env_drop = create_std_env_vars()
+        self.assertEqual('/DLG_HOME/', env_drop.get('dlg_root'))
+        self.assertEqual(3, env_drop.get('int_var'))
+        self.assertEqual(False, env_drop.get('bool_var'))
+        self.assertEqual(0.5, env_drop.get('float_var'))
+        self.assertEqual({'first': 1, 'second': 'sec'}, env_drop.get('dict_var'))
+        self.assertEqual([1, 2.0, '3'], env_drop.get('list_var'))
+        self.assertIsNone(env_drop.get('non_var'))
+        self.assertIsNone(env_drop.get('uid'))
+
+    def test_get_empty(self):
+        """
+        Tests that an empty environment drop contains no environment variables.
+        """
+        env_drop = create_empty_env_vars()
+        self.assertEqual(dict(), env_drop._variables)
+
+    def test_get_multiple(self):
+        """
+        Tests the get_multiple routine for environment variables is correct
+        """
+        env_drop = create_std_env_vars()
+        expected_vars = [None, '/DLG_HOME/', 3, False, 0.5, {'first': 1, 'second': 'sec'},
+                         [1, 2.0, '3'], None]
+        query_keys = ['uid', 'dlg_root', 'int_var', 'bool_var', 'float_var', 'dict_var', 'list_var',
+                      'non_var']
+        self.assertEqual(expected_vars, env_drop.get_multiple(query_keys))
+
+    def test_set(self):
+        """
+        Should currently raise un-implemented, but here for completeness
+        """
+        env_drop = create_std_env_vars()
+        self.assertRaises(NotImplementedError, env_drop.set, 'var', 'val')
+
+    def test_drop_get_single(self):
+        """
+        Tests the AbstractDROP fetch routine functions correctly with a single environment drop
+        """
+        env_drop = create_std_env_vars()
+        app_drop = AppDROP(uid='b', oid='b', environment_stores={env_drop.name: env_drop})
+        print(app_drop._environment_variable_stores)
+        self.assertEqual('/DLG_HOME/', app_drop.get_environment_variable('$env_vars.dlg_root'))
+        self.assertEqual(3, app_drop.get_environment_variable('$env_vars.int_var'))
+        self.assertEqual(False, app_drop.get_environment_variable('$env_vars.bool_var'))
+        self.assertEqual(0.5, app_drop.get_environment_variable('$env_vars.float_var'))
+        self.assertEqual({'first': 1, 'second': 'sec'},
+                         app_drop.get_environment_variable('$env_vars.dict_var'))
+        self.assertEqual([1, 2.0, '3'], app_drop.get_environment_variable('$env_vars.list_var'))
+        self.assertIsNone(app_drop.get_environment_variable('$env_vars.non_var'))
+        self.assertIsNone(app_drop.get_environment_variable('$env_vars.uid'))
+
+    def test_drop_get_multiple(self):
+        """
+        Tests the AbstractDROP multiple fetch routine functions correctly with a single environment
+        drop
+        """
+        env_name = 'env_vars'
+        env_drop = create_std_env_vars(name=env_name)
+        app_drop = AppDROP(uid='b', oid='b', environment_stores={env_drop.name: env_drop})
+        expected_vars = [None, '/DLG_HOME/', 3, False, 0.5, {'first': 1, 'second': 'sec'},
+                         [1, 2.0, '3'], None]
+        query_keys = ['uid', 'dlg_root', 'int_var', 'bool_var', 'float_var', 'dict_var', 'list_var',
+                      'non_var']
+        query_keys = [f'${env_name}.{x}' for x in query_keys]  # Build queries of the correct form
+        # Add some purposefully malformed vars
+        query_keys.extend(['dlg_root', '$non_store.non_var'])
+        expected_vars.extend([None, None])
+        self.assertEqual(expected_vars, app_drop.get_environment_variables(query_keys))
+
+    def test_drop_get_empty(self):
+        """
+        Tests the case where the environment drop has no name
+        """
+        env_name = ''
+        env_drop = create_empty_env_vars(name=env_name)
+        app_drop = AppDROP(uid='c', oid='c', environment_stores={env_drop.name: env_drop})
+        self.assertEqual(None, app_drop.get_environment_variable(''))
+        self.assertEqual(None, app_drop.get_environment_variable('$'))
+
+    def test_drop_get_multiEnv(self):
+        """
+        Tests the AbstractDROP fetch routine with multiple environment drops
+        """
+        env1_name = 'env_vars'
+        env2_name = 'more_vars'
+        env1_drop = create_std_env_vars(name=env1_name)
+        env2_drop = EnvironmentVarDROP(oid='d', uid='d', nm=env2_name, dlg_root='/DIFFERENT/',
+                                       int_var=4)
+        app_drop = AppDROP(uid='c', oid='c',
+                           environment_stores={env1_name: env1_drop, env2_name: env2_drop})
+        self.assertEqual('/DLG_HOME/', app_drop.get_environment_variable(f"${env1_name}.dlg_root"))
+        self.assertEqual('/DIFFERENT/', app_drop.get_environment_variable(f"${env2_name}.dlg_root"))
+        self.assertEqual(3, app_drop.get_environment_variable(f"${env1_name}.int_var"))
+        self.assertEqual(4, app_drop.get_environment_variable(f"${env2_name}.int_var"))
+        self.assertIsNone(app_drop.get_environment_variable(f'{env1_name}.int_var'))
+        self.assertIsNone(app_drop.get_environment_variable(f'.int_var'))
+        self.assertIsNone(app_drop.get_environment_variable(f'$third_env.int_var'))
+        self.assertEqual(['/DLG_HOME/', '/DIFFERENT/', 3, 4, None, None],
+                         app_drop.get_environment_variables(
+                             [f'${env1_name}.dlg_root', f'${env2_name}.dlg_root',
+                              f'${env1_name}.int_var', f'${env2_name}.int_var',
+                              f'${env1_name}.non_var', '$fake.var']
+                         ))

--- a/docs/architecture/graphs.rst
+++ b/docs/architecture/graphs.rst
@@ -255,6 +255,19 @@ Shrunk memory will be truncated, grown blocks will contain a copy of the old dat
 As mentioned previously, if DALiuGE is configured to utilise multiple cores, there is no need to specifically use SharedMemoryDROPs, InMemoryDROPs will be switched automatically.
 However, if the need arises, one can specifically use SharedMemoryDROPs.
 
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+Often, several workflow components rely on shared global configuration values, usually stored in
+imaginatively named configuration files.
+DALiuGE supports this approach, of course, but offers additional, more transparent options.
+The EnvironmentVarDROP is a simple key-value store accessible at runtime by all drops in a workflow.
+One can include multiple ``EnivronmentVarDROP``s in a single workflow, **but each variable store must have a unique name**.
+In a logical graph, reference environment variables as component or application parameters with the following syntax:
+``${EnvironmentVarDROP_Name}.{Variable_name}``
+The translator and engine handle parsing and filling of these parameters automatically.
+One may also access these variables at runtime using the ``get_environment_variable(key)`` function, which accepts a key in the syntax mentioned above, returning ``None`` if the variable store or key does not exist.
+
+
 .. |lgt| replace:: *logical graph template*
 .. |lg| replace:: *logical graph*
 .. |pgt| replace:: *physical graph template*

--- a/docs/architecture/graphs.rst
+++ b/docs/architecture/graphs.rst
@@ -265,7 +265,10 @@ One can include multiple ``EnivronmentVarDROP``s in a single workflow, **but eac
 In a logical graph, reference environment variables as component or application parameters with the following syntax:
 ``${EnvironmentVarDROP_Name}.{Variable_name}``
 The translator and engine handle parsing and filling of these parameters automatically.
-One may also access these variables at runtime using the ``get_environment_variable(key)`` function, which accepts a key in the syntax mentioned above, returning ``None`` if the variable store or key does not exist.
+Variables beginning with ``$DLG_``, such as ``$DLG_ROOT`` are an exception which are handled seperately.
+These variables come from the deployment themselves and are fetched from the deployment environment at runtime.
+
+One may also access these variables individually at runtime using the ``get_environment_variable(key)`` function, which accepts a key in the syntax mentioned above, returning ``None`` if the variable store or key does not exist.
 
 
 .. |lgt| replace:: *logical graph template*


### PR DESCRIPTION
Adds a new EnvironmentVariableDROP which acts as a KeyValue store. Incidentally adds a KeyValueDROP abstract type which can be mixed in with other drops if needed. These variables can be referenced as parameters in EAGLE, DALiuGE handles translating and fetching these references at runtime.

Limitations:
- Values are static. The interface has room for a GET(key) operation, but owing to potential difficulties with shared memory I suggest this is better dealt with by another service, such as Redis, for example.
- Environment variables are not automatically pulled in at runtime. Drops need to call 'auto_fill_environment_vars()' to trigger the parsing of these variable references. This decision reflects the possibility to add producers/inputs after the initialization of the drop object itself.
- Values are fetched at runtime, even if they could be inferred at translation time. This is both a hindrance and a feature. On one hand, this introduces potentially more communication versus writing the values requested in the logical graph directly. On the other hand, these values can now be determined at runtime; there is room for extended logic to build these variables before serving them to drops, which may be useful.

Important details:
- Format for variable references is $store_name.var_name
- EnvironmentDrops ought to be uniquely named in EAGLE, else aliasing will occur 