### PR TITLE
Liu 221 - Generate template.palette in DALiuGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ matrix:
         - git config --global user.name $GITHUB_USERNAME
         - git config --global user.email "$GITHUB_USERNAME@gmail.com"
       script:
-        - python3 tools/xml2palette/xml2palette.py -i ./ -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
+        - python3 tools/xml2palette/xml2palette.py -i ./ -t daliuge -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
+        - python3 tools/xml2palette/xml2palette.py -i ./ -t template -o $PROJECT_NAME-$TRAVIS_BRANCH-template.palette
       after_success:
         - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
         - mkdir -p EAGLE_test_repo/$PROJECT_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
         - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
         - mkdir -p EAGLE_test_repo/$PROJECT_NAME
         - mv $PROJECT_NAME-$TRAVIS_BRANCH.palette EAGLE_test_repo/$PROJECT_NAME/
+        - mv $PROJECT_NAME-$TRAVIS_BRANCH-template.palette EAGLE_test_repo/$PROJECT_NAME/
         - cd EAGLE_test_repo
         - git add *
         - git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $TRAVIS_BRANCH, commit $PROJECT_VERSION)"

--- a/daliuge-engine/dlg/apps/archiving.py
+++ b/daliuge-engine/dlg/apps/archiving.py
@@ -81,6 +81,7 @@ class ExternalStoreApp(BarrierAppDROP):
 # @details Takes an input and archives it in an NGAS server.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application class/dlg.apps.archiving.NgasArchivingApp/String/readonly/
 #     \~English Application class
 # @param[in] param/ngasSrv NGAS Server URL/localhost/String/readwrite/

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -305,6 +305,21 @@ class StreamingInputBashAppBase(BashShellBase, AppDROP):
 # * input-only stream
 # * full-stream
 #
+##
+# @brief BashShellApp
+# @details An application component able to run an arbitrary command within the Bash Shell
+# @par EAGLE_START
+# @param category BashShellApp
+# @param tag template
+# @param[in] param/command Command//String/readwrite/
+#     \~English The command to be executed
+# @param[in] param/input_redirection Input Redirection//String/readwrite/
+#     \~English The command line argument that specifies the input into this application
+# @param[in] param/output_redirection Output Redirection//String/readwrite/
+#     \~English The command line argument that specifies the output from this application
+# @param[in] param/command_line_arguments Command Line Arguments//String/readwrite/
+#     \~English Additional command line arguments to be added to the command line to be executed
+# @par EAGLE_END
 class BashShellApp(BashShellBase, BarrierAppDROP):
     """
     An app that runs a bash command in batch mode; that is, it waits until all

--- a/daliuge-engine/dlg/apps/crc.py
+++ b/daliuge-engine/dlg/apps/crc.py
@@ -78,6 +78,7 @@ class CRCApp(BarrierAppDROP):
 # i.e. A "streamingConsumer" of its predecessor in the graph
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.crc.CRCStreamApp/String/readonly/
 #     \~English Application class
 # @param[out] port/data Data/String/

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -67,6 +67,31 @@ class ContainerIpWaiter(object):
         return self._uid, self._containerIp
 
 
+##
+# @brief Docker
+# @details
+# @par EAGLE_START
+# @param category Docker
+# @param tag template
+# @param[in] param/image Image//String/readwrite/
+#     \~English The name of the docker image to be used for this application
+# @param[in] param/tag Tag/1.0/String/readwrite/
+#     \~English The tag of the docker image to be used for this application
+# @param[in] param/digest Digest//String/readwrite/
+#     \~English The hexadecimal hash (long version) of the docker image to be used for this application
+# @param[in] param/command Command//String/readwrite/
+#     \~English The command line to run within the docker instance. The specified command will be executed in a bash shell. That means that images will need a bash shell.
+# @param[in] param/user User//String/readwrite/
+#     \~English Username of the user who will run the application within the docker image
+# @param[in] param/ensureUserAndSwitch Ensure User And Switch/False/Boolean/readwrite/
+#     \~English Make sure the user specified in the User parameter exists and then run the docker container as that user
+# @param[in] param/removeContainer Remove Container/True/Boolean/readwrite/
+#     \~English Instruct Docker engine to delete the container after execution is complete
+# @param[in] param/additionalBindings Additional Bindings//String/readwrite/
+#     \~English Directories which will be visible inside the container during run-time. Format is srcdir_on_host:trgtdir_on_container. Multiple entries can be separated by commas.
+# @param[in] param/portMappings Port Mappings//String/readwrite/
+#     \~English Port mappings on the host machine
+# @par EAGLE_END
 class DockerApp(BarrierAppDROP):
     """
     A BarrierAppDROP that represents a process running in a container

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -348,6 +348,15 @@ class DynlibStreamApp(DynlibAppBase, AppDROP):
         self._c_app.n_streaming_inputs += 1
 
 
+##
+# @brief DynlibApp
+# @details An application component run from a dynamic library
+# @par EAGLE_START
+# @param category DynlibApp
+# @param tag template
+# @param[in] param/libpath Library Path//String/readwrite/
+#     \~English The location of the shared object/DLL that implements this application
+# @par EAGLE_END
 class DynlibApp(DynlibAppBase, BarrierAppDROP):
     """Loads a dynamic library into the current process and runs it"""
 

--- a/daliuge-engine/dlg/apps/mpi.py
+++ b/daliuge-engine/dlg/apps/mpi.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # @brief MPI
 # @details An application component using the Message Passing Interface (MPI)
 # @par EAGLE_START
-# @param category MPI
+# @param category Mpi
 # @param tag template
 # @param[in] param/num_of_procs Num procs//Integer/readwrite/
 #     \~English Number of processes used for this application

--- a/daliuge-engine/dlg/apps/mpi.py
+++ b/daliuge-engine/dlg/apps/mpi.py
@@ -32,7 +32,15 @@ from ..exceptions import InvalidDropException
 
 logger = logging.getLogger(__name__)
 
-
+##
+# @brief MPI
+# @details An application component using the Message Passing Interface (MPI)
+# @par EAGLE_START
+# @param category MPI
+# @param tag template
+# @param[in] param/num_of_procs Num procs//Integer/readwrite/
+#     \~English Number of processes used for this application
+# @par EAGLE_END
 class MPIApp(BarrierAppDROP):
     """
     An application drop representing an MPI job.

--- a/daliuge-engine/dlg/apps/plasma.py
+++ b/daliuge-engine/dlg/apps/plasma.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 # via Plasma.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/plasma_path Plasma Path//String/readwrite/
 #     \~English Path to plasma store.
 # @param[in] param/appclass Application class/dlg.apps.plasma.MSStreamingPlasmaConsumer/String/readonly/
@@ -135,6 +136,7 @@ class MSStreamingPlasmaConsumer(AppDROP):
 # via Plasma.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/plasma_path Plasma Path//String/readwrite/
 #     \~English Path to plasma store
 # @param[in] param/appclass Application class/dlg.apps.plasma.MSStreamingPlasmaProducer/String/readonly/
@@ -203,6 +205,7 @@ class MSStreamingPlasmaProducer(BarrierAppDROP):
 # @details Batch read entire Measurement Set from Plasma.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application class/dlg.apps.plasma.MSPlasmaReader/String/readonly/
 #     \~English Application class
 # @param[in] port/plasma_ms_input Plasma MS Input/Measurement Set/
@@ -265,6 +268,7 @@ class MSPlasmaReader(BarrierAppDROP):
 # @details Batch write entire Measurement Set to Plasma.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application class/dlg.apps.plasma.MSPlasmaWriter/String/readonly/
 #     \~English Application class
 # @param[in] port/input_ms Input MS/Measurement Set/

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -107,6 +107,7 @@ def import_using_code(code):
 # being written to its corresponding output.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.pyfunc.PyFuncApp/String/readonly/
 #     \~English Application class
 # @param[in] param/func_name Function Name//String/readwrite/

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -45,6 +45,7 @@ from dlg.meta import (
 # single output via SSH's scp protocol.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.scp.ScpApp/String/readonly/
 #     \~English Application class
 # @param[in] param/remoteUser Remote User//String/readwrite/

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -33,13 +33,13 @@ import numpy as np
 from dlg import droputils, utils
 from dlg.drop import BarrierAppDROP, BranchAppDrop, ContainerDROP
 from dlg.meta import (
-    dlg_float_param, 
+    dlg_float_param,
     dlg_string_param,
-    dlg_bool_param, 
+    dlg_bool_param,
     dlg_int_param,
-    dlg_component, 
+    dlg_component,
     dlg_batch_input,
-    dlg_batch_output, 
+    dlg_batch_output,
     dlg_streaming_input
 )
 from dlg.exceptions import DaliugeException
@@ -67,6 +67,7 @@ class NullBarrierApp(BarrierAppDROP):
 # without executing real algorithms. Very useful for debugging.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/sleepTime Sleep Time/5/Integer/readwrite/
 #     \~English The number of seconds to sleep
 # @param[in] param/appclass Application Class/dlg.apps.simple.SleepApp/String/readonly/

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -101,6 +101,7 @@ class SleepApp(BarrierAppDROP):
 # content recursively.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.simple.CopyApp/String/readonly/
 #     \~English Application class
 # @par EAGLE_END

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -152,6 +152,7 @@ class SleepAndCopyApp(SleepApp, CopyApp):
 # The resulting array will be send to all connected output apps.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/size Size/100/Integer/readwrite/
 #     \~English The size of the array
 # @param[in] param/integer Integer/True/Boolean/readwrite/
@@ -231,6 +232,7 @@ class RandomArrayApp(BarrierAppDROP):
 # will also be send to all connected output apps.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/method Method/mean/String/readwrite/
 #     \~English The method used for averaging
 # @param[in] param/appclass Application Class/dlg.apps.simple.AverageArraysApp/String/readonly/
@@ -320,6 +322,7 @@ class AverageArraysApp(BarrierAppDROP):
 # the same message. App does not require any input.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/greet Greet/World/String/readwrite/
 #     \~English What appears after 'Hello '
 # @param[in] param/appclass Application Class/dlg.apps.simple.HelloWorldApp/String/readonly/
@@ -372,6 +375,7 @@ class HelloWorldApp(BarrierAppDROP):
 # it to all outputs.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/url URL/"https://eagle.icrar.org"/String/readwrite/
 #     \~English The URL to retrieve
 # @param[in] param/appclass Application Class/dlg.apps.simple.UrlRetrieveApp/String/readonly/
@@ -423,6 +427,7 @@ class UrlRetrieveApp(BarrierAppDROP):
 # resulting array.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.simple.GenericScatterApp/String/readonly/
 #     \~English Application class
 # @param[out] port/array Array/Array/
@@ -481,6 +486,7 @@ class GenericScatterApp(BarrierAppDROP):
 # resulting array.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.simple.GenericNpyScatterApp/String/readonly/
 #     \~English Application class
 # @param[in] param/scatter_axes Scatter Axes/String/readwrite
@@ -556,9 +562,8 @@ class SimpleBranch(BranchAppDrop, NullBarrierApp):
 # since this operation will not yield.
 # The resulting array will be sent to all connected output apps.
 # @par EAGLE_START
-# @param gitrepo $(GIT_REPO)
-# @param version $(PROJECT_VERSION)
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/size/100/Integer/readwrite
 #     \~English the size of the array\n
 # @param[in] param/appclass/dlg.apps.simple.ListAppendThrashingApp/String/readonly

--- a/daliuge-engine/dlg/apps/socket_listener.py
+++ b/daliuge-engine/dlg/apps/socket_listener.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 # so data can be written into them through the framework.
 # @par EAGLE_START
 # @param category PythonApp
+# @param tag daliuge
 # @param[in] param/appclass Application Class/dlg.apps.socket_listener.SocketListener/String/readonly/
 #     \~English Application class
 # @param[in] param/host Host/127.0.0.1/String/readwrite/

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -2221,7 +2221,8 @@ class BranchAppDrop(BarrierAppDROP):
 # @brief Plasma
 # @details An object in a Apache Arrow Plasma in-memory object store
 # @par EAGLE_START
-# @par category Plasma
+# @param category Plasma
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -2265,7 +2266,8 @@ class PlasmaDROP(AbstractDROP):
 # @details An Apache Arrow Flight server providing distributed access
 # to a Plasma in-memory object store
 # @par EAGLE_START
-# @par category Plasma
+# @param category PlasmaFlight
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -2321,6 +2323,7 @@ class PlasmaFlightDROP(AbstractDROP):
 # @details A set of parameters, wholly specified in EAGLE
 # @par EAGLE_START
 # @param category ParameterSet
+# @param tag template
 # @param[in] param/mode Parset mode/"YANDA"/String/readonly/False/To what standard DALiuGE should filter and serialize the parameters.
 # @param[in] param/config_data ConfigData/""/String/readwrite/False/Additional configuration information to be mixed in with the initial data
 # @param[out] port/Config ConfigFile/File/The output configuration file

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -2196,7 +2196,17 @@ class BarrierAppDROP(InputFiredAppDROP):
         kwargs["n_effective_inputs"] = -1
         super(BarrierAppDROP, self).initialize(**kwargs)
 
-
+##
+# @brief Branch
+# @details A conditional branch to control flow
+# @par EAGLE_START
+# @param category Branch
+# @param tag template
+# @param[in] param/appclass Application Class/dlg.apps.simple.HelloWorldApp/String/readonly/
+#     \~English Application class
+# @param[in] param/group_start Group start/False/Boolean/readwrite/
+#     \~English Is this node the start of a group?
+# @par EAGLE_END
 class BranchAppDrop(BarrierAppDROP):
     """
     A special kind of application with exactly two outputs. After normal

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1396,7 +1396,7 @@ class FileDROP(AbstractDROP, PathBasedDrop):
 # @details An archive on the Next Generation Archive System (NGAS).
 # @par EAGLE_START
 # @par category NGAS
-# @par tag template
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -1517,7 +1517,7 @@ class NgasDROP(AbstractDROP):
 # @details In-memory storage of intermediate data products
 # @par EAGLE_START
 # @par category Memory
-# @par tag template
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -2202,7 +2202,7 @@ class BarrierAppDROP(InputFiredAppDROP):
 # @par EAGLE_START
 # @param category Branch
 # @param tag template
-# @param[in] param/appclass Application Class/dlg.apps.simple.HelloWorldApp/String/readonly/
+# @param[in] param/appclass Application Class/dlg.apps.simple.SimpleBranch/String/readonly/
 #     \~English Application class
 # @param[in] param/group_start Group start/False/Boolean/readwrite/
 #     \~English Is this node the start of a group?

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1219,6 +1219,7 @@ class PathBasedDrop(object):
 # @details A standard file on a filesystem mounted to the deployment machine
 # @par EAGLE_START
 # @par category File
+# @par tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -1394,7 +1395,8 @@ class FileDROP(AbstractDROP, PathBasedDrop):
 # @brief NGAS
 # @details An archive on the Next Generation Archive System (NGAS).
 # @par EAGLE_START
-# @par category File
+# @par category NGAS
+# @par tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -1515,6 +1517,7 @@ class NgasDROP(AbstractDROP):
 # @details In-memory storage of intermediate data products
 # @par EAGLE_START
 # @par category Memory
+# @par tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1218,8 +1218,8 @@ class PathBasedDrop(object):
 # @brief File
 # @details A standard file on a filesystem mounted to the deployment machine
 # @par EAGLE_START
-# @par category File
-# @par tag template
+# @param category File
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/
@@ -1395,7 +1395,7 @@ class FileDROP(AbstractDROP, PathBasedDrop):
 # @brief NGAS
 # @details An archive on the Next Generation Archive System (NGAS).
 # @par EAGLE_START
-# @par category NGAS
+# @param category NGAS
 # @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
@@ -1516,7 +1516,7 @@ class NgasDROP(AbstractDROP):
 # @brief Memory
 # @details In-memory storage of intermediate data products
 # @par EAGLE_START
-# @par category Memory
+# @param category Memory
 # @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node

--- a/daliuge-engine/dlg/s3_drop.py
+++ b/daliuge-engine/dlg/s3_drop.py
@@ -34,7 +34,8 @@ from .meta import dlg_string_param, dlg_list_param
 # @brief S3
 # @details A 'bucket' object available on Amazon's Simple Storage Service (S3)
 # @par EAGLE_START
-# @par category S3
+# @param category S3
+# @param tag template
 # @param[in] param/data_volume Data volume/5/Float/readwrite/
 #     \~English Estimated size of the data contained in this node
 # @param[in] param/group_end Group end/False/Boolean/readwrite/

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -148,7 +148,7 @@ def find_field_by_name(fields, name):
 
 
 def add_required_fields_for_category(fields, category):
-    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "MPI"]:
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "Mpi"]:
         if find_field_by_name(fields, "execution_time") is None:
             fields.append(
                 create_field(
@@ -220,7 +220,7 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
-    if category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3", "MPI"]:
+    if category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3", "Mpi"]:
         if find_field_by_name(fields, "group_end") is None:
             fields.append(
                 create_field(

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -191,7 +191,7 @@ def add_required_fields_for_category(fields, category):
                     "libpath", "Library path", "", "", "readwrite", "String", False
                 )
             )
-    elif category == "PythonApp":
+    elif category == "PythonApp" or category == "Branch":
         if find_field_by_name(fields, "execution_time") is None:
             fields.append(
                 create_field(

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -148,7 +148,7 @@ def find_field_by_name(fields, name):
 
 
 def add_required_fields_for_category(fields, category):
-    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp"]:
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "MPI"]:
         if find_field_by_name(fields, "execution_time") is None:
             fields.append(
                 create_field(
@@ -173,6 +173,8 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
+
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp"]:
         if find_field_by_name(fields, "group_start") is None:
             fields.append(
                 create_field(
@@ -185,14 +187,14 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
-    elif category == "DynlibApp":
+    if category == "DynlibApp":
         if find_field_by_name(fields, "libpath") is None:
             fields.append(
                 create_field(
                     "libpath", "Library path", "", "", "readwrite", "String", False
                 )
             )
-    elif category in ["PythonApp", "Branch"]:
+    if category in ["PythonApp", "Branch"]:
         if find_field_by_name(fields, "appclass") is None:
             fields.append(
                 create_field(
@@ -205,7 +207,7 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
-    elif category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3"]:
+    if category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3"]:
         if find_field_by_name(fields, "data_volume") is None:
             fields.append(
                 create_field(
@@ -218,6 +220,7 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
+    if category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3", "MPI"]:
         if find_field_by_name(fields, "group_end") is None:
             fields.append(
                 create_field(

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -474,9 +474,9 @@ def create_palette_node_from_params(params):
     add_required_fields_for_category(fields, category)
 
     # create and return the node
+    # TODO: we can remove a bunch of these attributes (isData etc)
     return {
         "category": category,
-        "categoryType": "Application",
         "tag": tag,
         "isData": False,
         "isGroup": False,

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -148,7 +148,7 @@ def find_field_by_name(fields, name):
 
 
 def add_required_fields_for_category(fields, category):
-    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "Mpi"]:
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "Mpi", "Docker"]:
         if find_field_by_name(fields, "execution_time") is None:
             fields.append(
                 create_field(
@@ -174,7 +174,7 @@ def add_required_fields_for_category(fields, category):
                 )
             )
 
-    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp"]:
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp", "Docker"]:
         if find_field_by_name(fields, "group_start") is None:
             fields.append(
                 create_field(

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -716,7 +716,6 @@ if __name__ == "__main__":
 
             # if the node tag matches the command line tag, or no tag was specified on the command line, add the node to the list to output
             if n["tag"] == tag or tag == "":
-                delattr(n, "tag")
                 nodes.append(n)
 
         # check if gitrepo and version params were found and cache the values

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -148,7 +148,7 @@ def find_field_by_name(fields, name):
 
 
 def add_required_fields_for_category(fields, category):
-    if category == "DynlibApp":
+    if category in ["DynlibApp", "PythonApp", "Branch", "BashShellApp"]:
         if find_field_by_name(fields, "execution_time") is None:
             fields.append(
                 create_field(
@@ -185,49 +185,14 @@ def add_required_fields_for_category(fields, category):
                     False,
                 )
             )
+    elif category == "DynlibApp":
         if find_field_by_name(fields, "libpath") is None:
             fields.append(
                 create_field(
                     "libpath", "Library path", "", "", "readwrite", "String", False
                 )
             )
-    elif category == "PythonApp" or category == "Branch":
-        if find_field_by_name(fields, "execution_time") is None:
-            fields.append(
-                create_field(
-                    "execution_time",
-                    "Execution time",
-                    5,
-                    "Estimated execution time",
-                    "readwrite",
-                    "Float",
-                    False,
-                )
-            )
-        if find_field_by_name(fields, "num_cpus") is None:
-            fields.append(
-                create_field(
-                    "num_cpus",
-                    "Num CPUs",
-                    1,
-                    "Number of cores used",
-                    "readwrite",
-                    "Integer",
-                    False,
-                )
-            )
-        if find_field_by_name(fields, "group_start") is None:
-            fields.append(
-                create_field(
-                    "group_start",
-                    "Group start",
-                    "false",
-                    "Component is start of a group",
-                    "readwrite",
-                    "Boolean",
-                    False,
-                )
-            )
+    elif category in ["PythonApp", "Branch"]:
         if find_field_by_name(fields, "appclass") is None:
             fields.append(
                 create_field(
@@ -237,6 +202,31 @@ def add_required_fields_for_category(fields, category):
                     "Application class",
                     "readwrite",
                     "String",
+                    False,
+                )
+            )
+    elif category in ["File", "Memory", "NGAS", "ParameterSet", "Plasma", "PlasmaFlight", "S3"]:
+        if find_field_by_name(fields, "data_volume") is None:
+            fields.append(
+                create_field(
+                    "data_volume",
+                    "Data volume",
+                    5,
+                    "Estimated size of the data contained in this node",
+                    "readwrite",
+                    "Integer",
+                    False,
+                )
+            )
+        if find_field_by_name(fields, "group_end") is None:
+            fields.append(
+                create_field(
+                    "group_end",
+                    "Group end",
+                    "false",
+                    "Component is end of a group",
+                    "readwrite",
+                    "Boolean",
                     False,
                 )
             )

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -716,6 +716,7 @@ if __name__ == "__main__":
 
             # if the node tag matches the command line tag, or no tag was specified on the command line, add the node to the list to output
             if n["tag"] == tag or tag == "":
+                delattr(n, "tag")
                 nodes.append(n)
 
         # check if gitrepo and version params were found and cache the values


### PR DESCRIPTION
Changes to the xml2palette script to allow users to build a palette from a subset of component descriptions within the input code that match a given tag.

For DALiuGE we generate two palettes:
- one containing the components with the "template" tag, resulting in the "Raw Components" palette for EAGLE
- one containing the components with the "daliuge" tag, resulting in the "DALiuGE Components" palette for EAGLE

I've added Doxygen comments to a number of classes, in order the generate additional components. I changes some @par doxygen commands to @param, since the former is not picked up by xml2palette.py.

I've updated the section of xml2palette that automatically adds some of the "component" parameters, such as "Execution time", to components with specific categories. I think this should be temporary. Once we add support for cparam and aparam keywords in xml2palette, we could explicitly list all params for a component. Then we wouldn't need this section of opaque code that adds parameters to certain categories of components.