### PR TITLE
Fix problems with python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       env: NO_DLG_RUNTIME=1
     - python: "3.8"
       env: NO_DLG_TRANSLATOR=1
+    - python: "3.9"
     # NOTE: The OpenAPI code still needs to be removed
     # - python: "3.8"
     #   env: TEST_OPENAPI=1

--- a/daliuge-engine/test/apps/dynlib_example2.c
+++ b/daliuge-engine/test/apps/dynlib_example2.c
@@ -162,6 +162,7 @@ PyObject* init2(dlg_app_info *app, PyObject* pyObject)
                     return error;
                 }
             }
+            Py_DECREF(s);
         }
         else {
             error = build_error(PyExc_TypeError, "One of the keys was not a string");


### PR DESCRIPTION
This fixes the main problems seen with python 3.9, and adds it back to the Travis build matrix.

There are still some stability problems with the unit tests around the multiprocessing support (one test runs out of file descriptors, and another leaves a dangling subprocess), but they are both currently circumvented (by chance!) in Travis, and they can also be easily avoided locally, so I'll leave those out for the time being as they require more work.