### PR TITLE
Yan 945 - Improved display of LG schema errors 

### DIFF
--- a/daliuge-translator/dlg/dropmake/web/graph_init.js
+++ b/daliuge-translator/dlg/dropmake/web/graph_init.js
@@ -3,6 +3,11 @@ require([
     "/static/main.js",
 ]);
 
+function showMessageModal(title, content){
+    $("#messageModalTitle").text(title);
+    $("#messageModalContent").text(content);
+    $('#messageModal').modal('show');
+}
 
 function graphInit(graphType){
 
@@ -13,9 +18,9 @@ function graphInit(graphType){
         type: 'get',
         error: function(XMLHttpRequest, textStatus, errorThrown) {
             if (404 == XMLHttpRequest.status) {
-              alert('Server cannot locate physical graph file ' + pgtName.toString())
+              showMessageModal('Error', 'Server cannot locate physical graph file: ' + pgtName.toString());
             } else {
-              alert('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
+              showMessageModal('Error', 'status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
             }
         },
         success: function(data) {
@@ -34,7 +39,7 @@ function graphInit(graphType){
                     graphType = "sankey"
                 }
             }
-            
+
             //reset graph divs
             $("#main").empty()
 
@@ -44,7 +49,7 @@ function graphInit(graphType){
             }else if(graphType === "dag"){
                 dagGraphInit(data)
             }
-            
+
             //set correct graph button to active
             $(".graphChanger").removeClass("active")
             $("#" + graphType + "Button").addClass("active")
@@ -62,7 +67,7 @@ function graphInit(graphType){
 // dag graph setup
 
 function dagGraphInit(data) {
-        
+
   const heightValue = 300;
   const widthValue = 600;
 
@@ -154,7 +159,7 @@ function zoomFit() {
 }
 
 function drawGraphForDrops(g, drawGraph, data) {
-  
+
 	// Keep track of modifications to see if we need to re-draw
 	var modified = false;
 

--- a/daliuge-translator/dlg/dropmake/web/graph_init.js
+++ b/daliuge-translator/dlg/dropmake/web/graph_init.js
@@ -4,8 +4,8 @@ require([
 ]);
 
 function showMessageModal(title, content){
-    $("#messageModalTitle").text(title);
-    $("#messageModalContent").text(content);
+    $("#messageModalTitle").html(title);
+    $("#messageModalContent").html(content);
     $('#messageModal').modal('show');
 }
 
@@ -59,6 +59,11 @@ function graphInit(graphType){
                 $("#view-mode-buttons").hide();
             } else {
                 $("#view-mode-buttons").show();
+            }
+
+            // display any errors that were generated during translation
+            if (error !== "None"){
+                showMessageModal("Error", error);
             }
         }
     })

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -234,6 +234,7 @@ def load_pg_viewer():
             pgt_view_json_name=pgt_name,
             title="Physical Graph Template",
             partition_info="",
+            error=None
         )
     else:
         response.status = 404
@@ -482,6 +483,7 @@ def gen_pgt():
             partition_info=part_info,
             title="Physical Graph Template%s"
                   % ("" if num_partitions == 0 else "Partitioning"),
+            error=None
         )
     except GraphException as ge:
         response.status = 500
@@ -511,6 +513,7 @@ def gen_pgt_post():
     json_string = reqform.get("json_data")
     try:
         logical_graph = json.loads(json_string)
+        error = None
 
         # load LG schema
         lg_schema = None
@@ -520,7 +523,10 @@ def gen_pgt_post():
 
         # validate JSON (if schema was found)
         if lg_schema is not None:
-            validate(logical_graph, lg_schema)
+            try:
+                validate(logical_graph, lg_schema)
+            except ValidationError as ve:
+                error = "Validation Error {1}: {0}".format(str(ve), lg_name)
 
         # LG -> PGT
         pgt = unroll_and_partition_with_params(logical_graph, reqform)
@@ -538,9 +544,8 @@ def gen_pgt_post():
             title="Physical Graph Template {}".format(
                 "" if par_algo == "none" else "Partitioning"
             ),
+            error=error
         )
-    except ValidationError as ve:
-        return "Validation Error {1}: {0}".format(str(ve), lg_name)
     except GraphException as ge:
         trace_msg = traceback.format_exc()
         print(trace_msg)
@@ -621,6 +626,7 @@ def root():
         pgt_view_json_name=None,
         partition_info=None,
         title="Physical Graph Template",
+        error=None
     )
 
 

--- a/daliuge-translator/dlg/dropmake/web/main.js
+++ b/daliuge-translator/dlg/dropmake/web/main.js
@@ -221,7 +221,7 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nGetting PGT unsuccessful: Unable to contiune!");
+            showMessageModal("Error", error + "\nGetting PGT unsuccessful: Unable to continue!");
         });
     // fetch the nodelist from engine
     console.log("sending request to ", node_list_url);
@@ -237,7 +237,7 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nGetting node_list unsuccessful: Unable to contiune!");
+            showMessageModal('Error', error + "\nGetting node_list unsuccessful: Unable to continue!");
         });
     console.log("node_list", node_list);
     // build object containing manager data
@@ -260,7 +260,7 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nGetting pg_spec unsuccessful: Unable to contiune!");
+            showMessageModal('Error', error + "\nGetting pg_spec unsuccessful: Unable to continue!");
         });
 
     console.log("pg_spec response", pg_spec_response);
@@ -280,7 +280,7 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nCreating session unsuccessful: Unable to contiune!");
+            showMessageModal('Error', error + "\nCreating session unsuccessful: Unable to continue!");
         });
     console.log("create session response", create_session);
     // gzip the pg_spec
@@ -306,7 +306,7 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nUnable to contiune!");
+            showMessageModal('Error', error + "\nUnable to continue!");
         });
     console.log("append graph response", append_graph);
     // deploy graph
@@ -322,9 +322,9 @@ async function helmDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nUnable to contiune!");
+            showMessageModal('Error', error + "\nUnable to continue!");
         });
-    //alert("Chart deployed, check the dashboard of your k8s cluster for status updates.")
+    //showMessageModal("Chart deployed" , "Check the dashboard of your k8s cluster for status updates.");
     console.log("deploy graph response", deploy_graph);
     // Open DIM session page in new tab
     // Until we have somewhere else to re-direct helm deployments. This is probably for the best.
@@ -389,7 +389,7 @@ async function restDeploy() {
         .then(handleFetchErrors)
         .then(response => response.json())
         .catch(function (error) {
-            alert(error + "\nGetting PGT unsuccessful: Unable to contiune!");
+            showMessageModal('Error', error + "\nGetting PGT unsuccessful: Unable to continue!");
         });
 
     // This is for a deferred start of daliuge, e.g. on SLURM
@@ -416,7 +416,7 @@ async function restDeploy() {
             }
         })
         .catch(function (error) {
-            alert(error + "\nSending PGT to backend unsuccessfull!");
+            showMessageModal('Error', error + "\nSending PGT to backend unsuccessful!");
         });
 
 
@@ -428,7 +428,7 @@ async function restDeploy() {
 //   const node_list = await fetch(node_list_url, {
 //     method: 'GET',
 //     // mode: request_mode,
-//     // credentials: 'include', 
+//     // credentials: 'include',
 //     headers: {
 //       'Content-Type': 'application/x-www-form-urlencoded',
 //       'Origin': 'http://localhost:8084'
@@ -437,7 +437,7 @@ async function restDeploy() {
 //   .then(handleFetchErrors)
 //   .then(response => response.json())
 //   .catch(function(error){
-//     alert(error + "\nGetting node_list unsuccessful: Unable to contiune!");
+//     showMessageModal('Error', error + "\nGetting node_list unsuccessful: Unable to continue!");
 //   });
 
 //   console.log("node_list", node_list);
@@ -461,7 +461,7 @@ async function restDeploy() {
 //   .then(handleFetchErrors)
 //   .then(response => response.json())
 //   .catch(function(error){
-//     alert(error + "\nGetting pg_spec unsuccessful: Unable to contiune!");
+//     showMessageModal('Error', error + "\nGetting pg_spec unsuccessful: Unable to continue!");
 //   });
 
 //   console.log("pg_spec response", pg_spec_response);
@@ -482,7 +482,7 @@ async function restDeploy() {
 //   .then(handleFetchErrors)
 //   .then(response => response.json())
 //   .catch(function(error){
-//     alert(error + "\nCreating session unsuccessful: Unable to contiune!");
+//     showMessageModal('Error', error + "\nCreating session unsuccessful: Unable to continue!");
 //   });
 
 //   console.log("create session response", create_session);
@@ -494,7 +494,7 @@ async function restDeploy() {
 
 //   // append graph to session on engine
 //   const append_graph = await fetch(append_graph_url, {
-//     credentials: 'include', 
+//     credentials: 'include',
 //     method: 'POST',
 //     mode: request_mode,
 //     headers: {
@@ -507,14 +507,14 @@ async function restDeploy() {
 //   .then(handleFetchErrors)
 //   .then(response => response.json())
 //   .catch(function(error){
-//     alert(error + "\nUnable to contiune!");
+//     showMessageModal('Error', error + "\nUnable to continue!");
 //   });
 //   console.log("append graph response", append_graph);
 
 //   // deploy graph
 //   // NOTE: URLSearchParams here turns the object into a x-www-form-urlencoded form
 //   const deploy_graph = await fetch(deploy_graph_url, {
-//     credentials: 'include', 
+//     credentials: 'include',
 //     method: 'POST',
 //     mode: request_mode,
 //     body: new URLSearchParams({
@@ -524,7 +524,7 @@ async function restDeploy() {
 //   .then(handleFetchErrors)
 //   .then(response => response.json())
 //   .catch(function(error){
-//     alert(error + "\nUnable to contiune!");
+//     showMessageModal('Error', error + "\nUnable to continue!");
 //   });
 
 //   console.log("deploy graph response", deploy_graph);

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -24,7 +24,10 @@
 
 <!-- Global Variables -->
 <script>
-    var pgtName = "{{pgt_view_json_name}}"
+    var pgtName = "{{pgt_view_json_name}}";
+
+    // NOTE: error can be multi-line, so use back-ticks to contain the multi-line string
+    var error = `{{error}}`;
 </script>
 </head>
 
@@ -155,7 +158,7 @@
     </div>
 
     <div class="modal fade" id="messageModal" tabindex="-1" role="dialog" aria-labelledby="messageModalTitle" aria-hidden="true">
-       <div class="modal-dialog modal-dialog-centered" role="document">
+       <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="messageModalTitle">Title</h5>
@@ -164,7 +167,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <span id="messageModalContent">Message</span>
+                    <pre id="messageModalContent">Message</pre>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -154,6 +154,25 @@
         </div>
     </div>
 
+    <div class="modal fade" id="messageModal" tabindex="-1" role="dialog" aria-labelledby="messageModalTitle" aria-hidden="true">
+       <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="messageModalTitle">Title</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <span id="messageModalContent">Message</span>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- init script includes require, this links main js and echarts -->
     <script src="/static/graph_init.js"></script>
     <script>


### PR DESCRIPTION
Previously, if input JSON to the translator failed validation against the schema, no translation would take place, and the validation error is all that would be shown.

Now, the validation error, if one occurs, will be recorded and sent to the client along with the translated graph. The client will display the validation error to the user.

Updated translator to use a modal dialog for errors, instead of the native javascript alert().

One side effect: Previously, REST and HELM deploy failures would produce many (blocking) javascript alert()s in a row. Now, the first error in the deploy is not blocking, and the deploy continues, potentially overwriting the contents of the error dialog with subsequent errors. So when the REST and HELM deploy functions generate many errors, only the last error will be visible to the user. This seems like an issue with the deploy functions, they should probably stop once the first error is encountered.