### PR TITLE
Liu 247

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
     # travis early build stage fails non-reproducible
     # - python: "3.7"
     - name: doxygen
+      include:
+        - dist: focal
       before_install:
       install:
         - sudo apt-get update && sudo apt-get install -y doxygen xsltproc

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,30 +41,6 @@ matrix:
     # NOTE: commenting 3.7 for now.
     # travis early build stage fails non-reproducible
     # - python: "3.7"
-    - name: doxygen
-      include:
-        - dist: focal
-      before_install:
-      install:
-        - sudo apt-get update && sudo apt-get install -y doxygen xsltproc
-      before_script:
-        - export PROJECT_NAME=daliuge
-        - export PROJECT_VERSION=$(git rev-parse --short HEAD)
-        - export GIT_REPO=$(git config --get remote.origin.url)
-        - git config --global user.name $GITHUB_USERNAME
-        - git config --global user.email "$GITHUB_USERNAME@gmail.com"
-      script:
-        - python3 tools/xml2palette/xml2palette.py -i ./ -t daliuge -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
-        - python3 tools/xml2palette/xml2palette.py -i ./ -t template -o $PROJECT_NAME-$TRAVIS_BRANCH-template.palette
-      after_success:
-        - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
-        - mkdir -p EAGLE_test_repo/$PROJECT_NAME
-        - mv $PROJECT_NAME-$TRAVIS_BRANCH.palette EAGLE_test_repo/$PROJECT_NAME/
-        - mv $PROJECT_NAME-$TRAVIS_BRANCH-template.palette EAGLE_test_repo/$PROJECT_NAME/
-        - cd EAGLE_test_repo
-        - git add *
-        - git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $TRAVIS_BRANCH, commit $PROJECT_VERSION)"
-        - git push
 
     # Build documentation similarly to how RTD does
     - name: documentation
@@ -74,6 +50,33 @@ matrix:
         - pip install sphinx sphinx-rtd-theme
       script:
         - READTHEDOCS=True make -C docs html SPHINXOPTS="-W --keep-going"
+jobs:
+    include:
+      - name: doxygen-focal
+        dist: focal
+        before_install:
+        install:
+          - sudo apt-get update && sudo apt-get install -y doxygen xsltproc
+        before_script:
+          - export PROJECT_NAME=daliuge
+          - export PROJECT_VERSION=$(git rev-parse --short HEAD)
+          - export GIT_REPO=$(git config --get remote.origin.url)
+          - git config --global user.name $GITHUB_USERNAME
+          - git config --global user.email "$GITHUB_USERNAME@gmail.com"
+        script:
+          - python3 tools/xml2palette/xml2palette.py -i ./ -t daliuge -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
+          - python3 tools/xml2palette/xml2palette.py -i ./ -t template -o $PROJECT_NAME-$TRAVIS_BRANCH-template.palette
+        after_success:
+          - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
+          - mkdir -p EAGLE_test_repo/$PROJECT_NAME
+          - mv $PROJECT_NAME-$TRAVIS_BRANCH.palette EAGLE_test_repo/$PROJECT_NAME/
+          - mv $PROJECT_NAME-$TRAVIS_BRANCH-template.palette EAGLE_test_repo/$PROJECT_NAME/
+          - cd EAGLE_test_repo
+          - git add *
+          - git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $TRAVIS_BRANCH, commit $PROJECT_VERSION)"
+          - git push
+
+
 
 
 # We want to use docker during the tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@
 
 # To use docker later...
 sudo: required
+dist: focal
 
 # let's go!
 language: python
@@ -41,6 +42,28 @@ matrix:
     # NOTE: commenting 3.7 for now.
     # travis early build stage fails non-reproducible
     # - python: "3.7"
+    - name: doxygen
+      before_install:
+      install:
+        - sudo apt-get update && sudo apt-get install -y doxygen xsltproc
+      before_script:
+        - export PROJECT_NAME=daliuge
+        - export PROJECT_VERSION=$(git rev-parse --short HEAD)
+        - export GIT_REPO=$(git config --get remote.origin.url)
+        - git config --global user.name $GITHUB_USERNAME
+        - git config --global user.email "$GITHUB_USERNAME@gmail.com"
+      script:
+        - python3 tools/xml2palette/xml2palette.py -i ./ -t daliuge -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
+        - python3 tools/xml2palette/xml2palette.py -i ./ -t template -o $PROJECT_NAME-$TRAVIS_BRANCH-template.palette
+      after_success:
+        - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
+        - mkdir -p EAGLE_test_repo/$PROJECT_NAME
+        - mv $PROJECT_NAME-$TRAVIS_BRANCH.palette EAGLE_test_repo/$PROJECT_NAME/
+        - mv $PROJECT_NAME-$TRAVIS_BRANCH-template.palette EAGLE_test_repo/$PROJECT_NAME/
+        - cd EAGLE_test_repo
+        - git add *
+        - git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $TRAVIS_BRANCH, commit $PROJECT_VERSION)"
+        - git push
 
     # Build documentation similarly to how RTD does
     - name: documentation
@@ -50,33 +73,6 @@ matrix:
         - pip install sphinx sphinx-rtd-theme
       script:
         - READTHEDOCS=True make -C docs html SPHINXOPTS="-W --keep-going"
-jobs:
-    include:
-      - name: doxygen-focal
-        dist: focal
-        before_install:
-        install:
-          - sudo apt-get update && sudo apt-get install -y doxygen xsltproc
-        before_script:
-          - export PROJECT_NAME=daliuge
-          - export PROJECT_VERSION=$(git rev-parse --short HEAD)
-          - export GIT_REPO=$(git config --get remote.origin.url)
-          - git config --global user.name $GITHUB_USERNAME
-          - git config --global user.email "$GITHUB_USERNAME@gmail.com"
-        script:
-          - python3 tools/xml2palette/xml2palette.py -i ./ -t daliuge -o $PROJECT_NAME-$TRAVIS_BRANCH.palette
-          - python3 tools/xml2palette/xml2palette.py -i ./ -t template -o $PROJECT_NAME-$TRAVIS_BRANCH-template.palette
-        after_success:
-          - git clone https://$GITHUB_TOKEN@github.com/ICRAR/EAGLE_test_repo
-          - mkdir -p EAGLE_test_repo/$PROJECT_NAME
-          - mv $PROJECT_NAME-$TRAVIS_BRANCH.palette EAGLE_test_repo/$PROJECT_NAME/
-          - mv $PROJECT_NAME-$TRAVIS_BRANCH-template.palette EAGLE_test_repo/$PROJECT_NAME/
-          - cd EAGLE_test_repo
-          - git add *
-          - git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $TRAVIS_BRANCH, commit $PROJECT_VERSION)"
-          - git push
-
-
 
 
 # We want to use docker during the tests

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -40,7 +40,7 @@ class Categories:
     PLASMA = "Plasma"
     PLASMAFLIGHT = "PlasmaFlight"
     PARSET = "ParameterSet"
-    ENVIRONMENTVARS = "EnvironmentVars"
+    ENVIRONMENTVARS = "EnvironmentVariables"
 
     MKN = "MKN"
     SCATTER = "Scatter"

--- a/daliuge-common/docker/Dockerfile
+++ b/daliuge-common/docker/Dockerfile
@@ -7,7 +7,9 @@ FROM ubuntu:20.04
 ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
-RUN apt-get update && apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils libmetis-dev curl && apt-get clean
+RUN apt-get update && \
+    apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl && \
+    apt-get clean
 
 COPY / /daliuge
 

--- a/daliuge-common/docker/Dockerfile.dev
+++ b/daliuge-common/docker/Dockerfile.dev
@@ -8,13 +8,14 @@ ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
 RUN apt-get update && \
-    apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils libmetis-dev curl git sudo && \
+    apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl git sudo && \
     apt-get clean
 
 COPY / /daliuge
 
 RUN cd / && python3 -m venv dlg && cd /daliuge && \
     . /dlg/bin/activate && \
+    pip install --upgrade pip && \
     pip install wheel numpy && \
     pip install .
 

--- a/daliuge-engine/build_engine.sh
+++ b/daliuge-engine/build_engine.sh
@@ -41,12 +41,12 @@ case "$1" in
         C_TAG="master"
         [[ ! -z $2 ]] && C_TAG=$2
         echo "Building daliuge-engine slim version ${VCS_TAG} using daliuge-common:${C_TAG}"
-        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine:${DEV_TAG} -f docker/Dockerfile .
+        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine:${DEV_TAG} -f docker/Dockerfile.dev .
         echo "Build finished! Slimming the image now"
         echo ">>>>> docker-slim output <<<<<<<<<"
         docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
-            --include-path /usr/local/lib --include-path /usr/local/bin --include-path /usr/lib/python3.8/multiprocessing \
-            --include-path /usr/lib/python3.8/distutils --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
+            --include-path /etc --include-path /usr/local/lib --include-path /usr/local/bin --include-path /usr/lib/python3.8 \
+            --include-path /usr/lib/python3 --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
             --http-probe-exec start_local_managers.sh --http-probe=true --tag=icrar/daliuge-engine.slim:${DEV_TAG}\
             icrar/daliuge-engine:${DEV_TAG} \
 	    ;;

--- a/daliuge-engine/build_engine.sh
+++ b/daliuge-engine/build_engine.sh
@@ -3,9 +3,11 @@
 # branch name or with a release tag depending whether this is a development or deployment
 # version.
 
+export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+export DEV_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
+
 case "$1" in
     "dep")
-        export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
         echo "Building daliuge-engine version using tag ${VCS_TAG}"
         echo $VCS_TAG > dlg/manager/web/VERSION
         cp ../LICENSE dlg/manager/web/.
@@ -16,36 +18,37 @@ case "$1" in
         C_TAG="master"
         [[ ! -z $2 ]] && C_TAG=$2
         export VERSION=`git describe --tags --abbrev=0|sed s/v//`
-        export VCS_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
+        export VCS_TAG=DEV_TAG
         echo "Building daliuge-engine development version using daliuge-common:${C_TAG}"
         echo "$VERSION:$VCS_TAG" > dlg/manager/web/VERSION
         git rev-parse --verify HEAD >> dlg/manager/web/VERSION
         cp ../LICENSE dlg/manager/web/.
-        docker build --build-arg VCS_TAG=${C_TAG} --no-cache -t icrar/daliuge-engine:${VCS_TAG} -f docker/Dockerfile.dev .
+        docker build --build-arg VCS_TAG=${C_TAG} --no-cache -t icrar/daliuge-engine:${DEV_TAG} -f docker/Dockerfile.dev .
         echo "Build finished!"
         exit 0;;
     "devall")
         [[ ! -z $2 ]] && C_TAG=$2
         export VERSION=`git describe --tags --abbrev=0|sed s/v//`
         export VCS_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
-        echo "Building daliuge-engine development version using daliuge-common:${VCS_TAG}"
+        echo "Building daliuge-engine development version using daliuge-common:${DEV_TAG}"
         echo "$VERSION:$VCS_TAG" > dlg/manager/web/VERSION
         git rev-parse --verify HEAD >> dlg/manager/web/VERSION
         cp ../LICENSE dlg/manager/web/.
-        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine:${VCS_TAG} -f docker/Dockerfile.devall .
+        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine:${DEV_TAG} -f docker/Dockerfile.devall .
         echo "Build finished!"
         exit 0;;
     "slim")
-        export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
-        echo "Building daliuge-engine slim version ${VCS_TAG}"
-        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine.big:${VCS_TAG} -f docker/Dockerfile .
+        C_TAG="master"
+        [[ ! -z $2 ]] && C_TAG=$2
+        echo "Building daliuge-engine slim version ${VCS_TAG} using daliuge-common:${C_TAG}"
+        docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine:${DEV_TAG} -f docker/Dockerfile .
         echo "Build finished! Slimming the image now"
         echo ">>>>> docker-slim output <<<<<<<<<"
         docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
             --include-path /usr/local/lib --include-path /usr/local/bin --include-path /usr/lib/python3.8/multiprocessing \
-            --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
-            --http-probe-exec start_local_managers.sh --http-probe=true --tag=icrar/daliuge-engine:${VCS_TAG}\
-            icrar/daliuge-engine.big:${VCS_TAG} \
+            --include-path /usr/lib/python3.8/distutils --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
+            --http-probe-exec start_local_managers.sh --http-probe=true --tag=icrar/daliuge-engine.slim:${DEV_TAG}\
+            icrar/daliuge-engine:${DEV_TAG} \
 	    ;;
     *)
         echo "Usage: build_engine.sh <dep|dev|devall|slim>"

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -335,11 +335,14 @@ class PyFuncApp(BarrierAppDROP):
 
         The priority follows the list above with input ports overruling the others.
 
-        All function arguments are internally dealt with as keyword arguments, i.e. 
-        positional aruments will be referred to by name, not by position. This also
-        implies that positional ONLY arguments are not supported, but they are rarely
-        used. Positional arguments defined by the function ar mandatory and thus the
-        implementation is checking whether they are provided (by name).
+        Function arguments in Python can be passed as positional, kw-value, positional
+        only, kw-value only, and catch-all *args and **kwargs, which don't provide any
+        hint about the names of accepted parameters. All of them are now supported. If
+        positional arguments or kw-value arguments are provided by the user, but are 
+        not explicitely defined in the function signiture AND *args and/or **kwargs are
+        allowed then these arguments are passed to the function. For *args this is
+        somewhat risky, since the order is relevant and in this code derived from the
+        order defined in the graph (same order as defined in the component description).
 
         Input ports will NOT be used by order (anymore), but by the IdText (name field
         in EAGLE) of the port. Since each input port requires an associated data drop,
@@ -370,11 +373,6 @@ class PyFuncApp(BarrierAppDROP):
         # if defaults dict has not been specified at all we'll go ahead anyway
         n_args = len(self.func_defaults)
         argnames = self.arguments.args
-        # if self.fn_nargs > n_args:
-        #     logger.warning(f"Function {self.f.__name__} expects {self.fn_nargs} argument defaults")
-        #     logger.warning(f"only {sum(n_args)} found!")
-        #     logger.warning("Please correct the function default specification")
-        #     #raise ValueError
 
         # use explicit mapping of inputs to arguments first
         # TODO: Required by dlg_delayed?? Else, we should really not do this. 

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -338,11 +338,11 @@ class PyFuncApp(BarrierAppDROP):
         The priority follows the list above with input ports overruling the others.
 
         Function arguments in Python can be passed as positional, kw-value, positional
-        only, kw-value only, and catch-all *args and **kwargs, which don't provide any
+        only, kw-value only, and catch-all args and kwargs, which don't provide any
         hint about the names of accepted parameters. All of them are now supported. If
         positional arguments or kw-value arguments are provided by the user, but are 
-        not explicitely defined in the function signiture AND *args and/or **kwargs are
-        allowed then these arguments are passed to the function. For *args this is
+        not explicitely defined in the function signiture AND args and/or kwargs are
+        allowed then these arguments are passed to the function. For args this is
         somewhat risky, since the order is relevant and in this code derived from the
         order defined in the graph (same order as defined in the component description).
 

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -460,6 +460,24 @@ class PyFuncApp(BarrierAppDROP):
                         logger.warning(f"Keyword argument '{ka}' not found!")
             logger.debug(f"updating funcargs with {kwargs}")
             self.funcargs.update(kwargs)
+            vparg = []
+            vkarg = {}
+            logger.debug(f"Remaining AppArguments {appArgs}")
+            for arg in appArgs:
+                if appArgs[arg]['type'] in ['Json', 'Complex']:
+                    value = ast.literal_eval(appArgs[arg]['value'])
+                else:
+                    value = appArgs[arg]['value']
+                if appArgs[arg]['positional']:
+                    vparg.append(value)
+                else:
+                    vkarg.update({arg:value})
+
+            # any remaining application arguments will be used for vargs and vkwargs
+            if self.arguments.varargs:
+                self.pargs.extend(vparg)
+            if self.arguments.varkw:
+                self.funcargs.update(vkarg)
 
         # Fill rest with default arguments if there are any more
         kwargs = {}
@@ -469,26 +487,6 @@ class PyFuncApp(BarrierAppDROP):
                 kwargs.update({kw: value})
         logger.debug(f"updating funcargs with {kwargs}")
         self.funcargs.update(kwargs)
-
-        vparg = []
-        vkarg = {}
-        logger.debug(f"Remaining AppArguments {appArgs}")
-        for arg in appArgs:
-            if appArgs[arg]['type'] in ['Json', 'Complex']:
-                value = ast.literal_eval(appArgs[arg]['value'])
-            else:
-                value = appArgs[arg]['value']
-            if appArgs[arg]['positional']:
-                vparg.append(value)
-            else:
-                vkarg.update({arg:value})
-
-        # any remaining application arguments will be used for vargs and vkwargs
-        if self.arguments.varargs:
-            self.pargs.extend(vparg)
-        if self.arguments.varkw:
-            self.funcargs.update(vkarg)
-
 
         logger.debug(f"Running {self.func_name} with *{self.pargs} **{self.funcargs}")
         result = self.f(*self.pargs, **self.funcargs)

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -119,7 +119,7 @@ def import_using_code(code):
 # being written to its corresponding output.
 # @par EAGLE_START
 # @param category PythonApp
-# @param tag daliuge
+# @param tag template
 # @param[in] cparam/appclass Application Class/dlg.apps.pyfunc.PyFuncApp/String/readonly/False//False/
 #     \~English Application class
 # @param[in] cparam/execution_time Execution Time/5/Float/readonly/False//False/

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -308,6 +308,8 @@ class PyFuncApp(BarrierAppDROP):
         logger.info(f"Args positional: {self.arguments.args[:self.fn_npos]}")
         logger.info(f"Args keyword: {self.arguments.args[self.fn_npos:]}")
         logger.info(f"Args supplied:  {self.func_defaults}")
+        logger.info(f"VarArgs allowed:  {self.arguments.varargs}")
+        logger.info(f"VarKwds allowed:  {self.arguments.varkw}")
 
         # Mapping between argument name and input drop uids
         logger.debug(f"Input mapping: {self.func_arg_mapping}")
@@ -424,7 +426,7 @@ class PyFuncApp(BarrierAppDROP):
             logger.debug(f"updating funcargs with {kwargs}")
             self.funcargs.update(kwargs)
 
-            # Try to get values for still missing kwargs arguments from parameters
+            # Try to get values for still missing kwargs arguments from Application kws
             kwargs = {}
             kws = self.arguments.args[self.fn_npos:]
             for ka in kws:

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -31,6 +31,8 @@ import pickle
 
 from typing import Callable
 import dill
+from io import StringIO
+from contextlib import redirect_stdout
 
 from dlg import droputils, utils
 from dlg.drop import BarrierAppDROP
@@ -179,7 +181,7 @@ class PyFuncApp(BarrierAppDROP):
 
     ``{"kwargs":{"kw1_name":kw1_value, "kw2_name":kw2_value}, "args":[arg1, arg2]}``
 
-    The positional args will be used in order of appearance.
+    The positional onlyargs will be used in order of appearance.
     """
 
     component_meta = dlg_component(
@@ -487,7 +489,12 @@ class PyFuncApp(BarrierAppDROP):
         self.funcargs.update(kwargs)
 
         logger.debug(f"Running {self.func_name} with *{self.pargs} **{self.funcargs}")
-        result = self.f(*self.pargs, **self.funcargs)
+
+        # we capture and log whatever is produced on STDOUT
+        capture = StringIO()
+        with redirect_stdout(capture):
+            result = self.f(*self.pargs, **self.funcargs)
+        logger.info(f"Captured output from function app '{self.func_name}': {capture.getvalue()}")
         logger.debug(f"Finished execution of {self.func_name}.")
 
         # Depending on how many outputs we have we treat our result

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -63,6 +63,36 @@ class NullBarrierApp(BarrierAppDROP):
     def run(self):
         pass
 
+##
+# @brief PythonApp
+# @details A placeholder APP to aid construction of new applications.
+# This is mainly useful (and used) when starting a new workflow from scratch.
+# @par EAGLE_START
+# @param category PythonApp
+# @param tag template
+# @param[in] cparam/appclass Application Class//String/readonly/False//False/
+#     \~English Application class
+# @param[in] cparam/execution_time Execution Time/0.1/Float/readonly/False//False/
+#     \~English Estimated execution time
+# @param[in] cparam/group_start Group start/False/Boolean/readwrite/False//False/
+#     \~English Is this node the start of a group?
+# @par EAGLE_END
+class PythonApp(BarrierAppDROP):
+    """A placeholder BarrierAppDrop that sleeps for 0.1s"""
+    component_meta = dlg_component(
+        "PythonApp",
+        "Python App.",
+        [dlg_batch_input("binary/*", [])],
+        [dlg_batch_output("binary/*", [])],
+        [dlg_streaming_input("binary/*")],
+    )
+
+    def initialize(self, **kwargs):
+        super(PythonApp, self).initialize(**kwargs)
+
+    def run(self):
+        time.sleep(0.1) 
+
 
 ##
 # @brief SleepApp
@@ -71,21 +101,15 @@ class NullBarrierApp(BarrierAppDROP):
 # without executing real algorithms. Very useful for debugging.
 # @par EAGLE_START
 # @param category PythonApp
-# @param tag daliuge
+# @param tag template
 # @param[in] aparam/sleepTime Sleep Time/5/Integer/readwrite/False//False/
 #     \~English The number of seconds to sleep
 # @param[in] cparam/appclass Application Class/dlg.apps.simple.SleepApp/String/readonly/False//False/
 #     \~English Application class
 # @param[in] cparam/execution_time Execution Time/5/Float/readonly/False//False/
 #     \~English Estimated execution time
-# @param[in] cparam/num_cpus No. of CPUs/1/Integer/readonly/False//False/
-#     \~English Number of cores used
 # @param[in] cparam/group_start Group start/False/Boolean/readwrite/False//False/
 #     \~English Is this node the start of a group?
-# @param[in] cparam/input_error_threshold "Input error rate (%)"/0/Integer/readwrite/False//False/
-#     \~English the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param[in] cparam/n_tries Number of tries/1/Integer/readwrite/False//False/
-#     \~English Specifies the number of times the 'run' method will be executed before finally giving up
 # @par EAGLE_END
 class SleepApp(BarrierAppDROP):
     """A BarrierAppDrop that sleeps the specified amount of time (0 by default)"""

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -72,27 +72,16 @@ class NullBarrierApp(BarrierAppDROP):
 # @param tag template
 # @param[in] cparam/appclass Application Class//String/readonly/False//False/
 #     \~English Application class
-# @param[in] cparam/execution_time Execution Time/0.1/Float/readonly/False//False/
+# @param[in] cparam/num_cpus No. of CPUs/1/Integer/readonly/False//False/
+#     \~English Number of cores used
+# @param[in] cparam/execution_time Execution Time/5/Float/readonly/False//False/
 #     \~English Estimated execution time
 # @param[in] cparam/group_start Group start/False/Boolean/readwrite/False//False/
 #     \~English Is this node the start of a group?
 # @par EAGLE_END
 class PythonApp(BarrierAppDROP):
-    """A placeholder BarrierAppDrop that sleeps for 0.1s"""
-    component_meta = dlg_component(
-        "PythonApp",
-        "Python App.",
-        [dlg_batch_input("binary/*", [])],
-        [dlg_batch_output("binary/*", [])],
-        [dlg_streaming_input("binary/*")],
-    )
-
-    def initialize(self, **kwargs):
-        super(PythonApp, self).initialize(**kwargs)
-
-    def run(self):
-        time.sleep(0.1) 
-
+    """A placeholder BarrierAppDrop that just aids the generation of the palette component"""
+    pass
 
 ##
 # @brief SleepApp

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1241,7 +1241,7 @@ class DataDROP(AbstractDROP):
 # @details A standard file on a filesystem mounted to the deployment machine
 # @par EAGLE_START
 # @param category File
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/
@@ -1421,7 +1421,7 @@ class FileDROP(DataDROP, PathBasedDrop):
 # @details An archive on the Next Generation Archive System (NGAS).
 # @par EAGLE_START
 # @param category NGAS
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/
@@ -1542,7 +1542,7 @@ class NgasDROP(DataDROP):
 # @details In-memory storage of intermediate data products
 # @par EAGLE_START
 # @param category Memory
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/
@@ -1624,7 +1624,7 @@ class SharedMemoryDROP(DataDROP):
 # @details A Drop not storing any data (useful for just passing on events)
 # @par EAGLE_START
 # @param category Memory
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/0/Float/readonly/False//False/
 #     \~English This never stores any data
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/
@@ -1880,7 +1880,7 @@ class DirectoryContainer(PathBasedDrop, ContainerDROP):
 # @details An object in a Apache Arrow Plasma in-memory object store
 # @par EAGLE_START
 # @param category Plasma
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/
@@ -1926,7 +1926,7 @@ class PlasmaDROP(DataDROP):
 # to a Plasma in-memory object store
 # @par EAGLE_START
 # @param category PlasmaFlight
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/

--- a/daliuge-engine/dlg/environmentvar_drop.py
+++ b/daliuge-engine/dlg/environmentvar_drop.py
@@ -61,7 +61,7 @@ def _filter_parameters(parameters: dict):
 # @brief Environment variables
 # @details A set of environment variables, wholly specified in EAGLE and accessible to all drops.
 # @par EAGLE_START
-# @param category EnvironmentVars
+# @param category EnvironmentVariables
 # @param tag daliuge
 # @par EAGLE_END
 class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):

--- a/daliuge-engine/dlg/environmentvar_drop.py
+++ b/daliuge-engine/dlg/environmentvar_drop.py
@@ -62,6 +62,7 @@ def _filter_parameters(parameters: dict):
 # @details A set of environment variables, wholly specified in EAGLE and accessible to all drops.
 # @par EAGLE_START
 # @param category EnvironmentVars
+# @param tag daliuge
 # @par EAGLE_END
 class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):
     """

--- a/daliuge-engine/dlg/s3_drop.py
+++ b/daliuge-engine/dlg/s3_drop.py
@@ -35,7 +35,7 @@ from .meta import dlg_string_param, dlg_list_param
 # @details A 'bucket' object available on Amazon's Simple Storage Service (S3)
 # @par EAGLE_START
 # @param category S3
-# @param tag template
+# @param tag daliuge
 # @param[in] cparam/data_volume Data volume/5/Float/readwrite/False//False/
 #     \~English Estimated size of the data contained in this node
 # @param[in] cparam/group_end Group end/False/Boolean/readwrite/False//False/

--- a/daliuge-engine/docker/Dockerfile.dev
+++ b/daliuge-engine/docker/Dockerfile.dev
@@ -6,7 +6,7 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 
 COPY / /daliuge
-RUN . /dlg/bin/activate && pip install wheel && cd /daliuge && \
+RUN . /dlg/bin/activate && pip install --upgrade pip && pip install wheel && cd /daliuge && \
     pip install . 
 
 EXPOSE 9000

--- a/daliuge-engine/run_engine.sh
+++ b/daliuge-engine/run_engine.sh
@@ -22,6 +22,8 @@ common_prep ()
     DOCKER_OPTS=${DOCKER_OPTS}" -v ${DLG_ROOT}:${DLG_ROOT} --env DLG_ROOT=${DLG_ROOT}"
 }
 
+export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+export C_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
 case "$1" in
     "dep")
         DLG_ROOT="/var/dlg_home"
@@ -30,7 +32,6 @@ case "$1" in
             echo "Deployment version requires access to a directory /var/dlg_home, but that does not exist!"
             echo "Please either create and grant access to $USER or build and run the development version."
         else
-            VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
             common_prep
             echo "Running Engine deployment version in background..."
             echo "docker run -td "${DOCKER_OPTS}"  icrar/daliuge-engine:${VCS_TAG}"
@@ -39,11 +40,10 @@ case "$1" in
         fi;;
     "dev")
         export DLG_ROOT="$HOME/dlg"
-        export VCS_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
         common_prep
         echo "Running Engine development version in background..."
-        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${VCS_TAG}"
-        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${VCS_TAG}
+        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${C_TAG}"
+        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${C_TAG}
         sleep 3
         ./start_local_managers.sh
         exit 0;;
@@ -59,12 +59,12 @@ case "$1" in
         ./start_local_managers.sh
         exit 0;;
     "slim")
-        export DLG_ROOT="/tmp/dlg"
+        export DLG_ROOT="$HOME/dlg"
         export VCS_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
         common_prep
         echo "Running Engine development version in background..."
-        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim"
-        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim
+        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim:${C_TAG}"
+        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim:${C_TAG}
         sleep 3
         ./start_local_managers.sh
         exit 0;;

--- a/daliuge-engine/test/graphs/compilePG.graph
+++ b/daliuge-engine/test/graphs/compilePG.graph
@@ -1,0 +1,154 @@
+[
+    {
+        "oid": "2022-05-06T08:43:26_-1_0",
+        "type": "app",
+        "app": "dlg.apps.pyfunc.PyFuncApp",
+        "rank": [
+            0
+        ],
+        "loop_cxt": null,
+        "tw": 5,
+        "num_cpus": 1,
+        "appclass": "dlg.apps.pyfunc.PyFuncApp",
+        "execution_time": 5,
+        "group_start": false,
+        "input_error_threshold": 0,
+        "n_tries": 1,
+        "applicationArgs": {
+            "func_name": {
+                "text": "Function Name",
+                "value": "compile",
+                "defaultValue": "",
+                "description": "Python function name",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "func_code": {
+                "text": "Function Code",
+                "value": "",
+                "defaultValue": "",
+                "description": "Python function code, e.g. 'def function_name(args): return args'",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "pickle": {
+                "text": "Pickle",
+                "value": false,
+                "defaultValue": "false",
+                "description": "Whether the python arguments are pickled.",
+                "readonly": false,
+                "type": "Boolean",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "func_defaults": {
+                "text": "Function Defaults",
+                "value": "",
+                "defaultValue": "",
+                "description": "Mapping from argname to default value. Should match only the last part of the argnames list. Values are interpreted as Python code literals and that means string values need to be quoted.",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "func_arg_mapping": {
+                "text": "Function Arguments Mapping",
+                "value": "",
+                "defaultValue": "",
+                "description": "Mapping between argument name and input drop uids",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "source": {
+                "text": "source",
+                "value": "print('Hello')",
+                "defaultValue": "",
+                "description": "",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "filename": {
+                "text": "filename",
+                "value": "",
+                "defaultValue": "",
+                "description": "",
+                "readonly": false,
+                "type": "String",
+                "precious": true,
+                "options": [],
+                "positional": false
+            },
+            "mode": {
+                "text": "mode",
+                "value": "exec",
+                "defaultValue": "",
+                "description": "",
+                "readonly": false,
+                "type": "String",
+                "precious": false,
+                "options": [],
+                "positional": false
+            },
+            "optimize": {
+                "text": "optimize",
+                "value": true,
+                "defaultValue": "",
+                "description": "",
+                "readonly": false,
+                "type": "Boolean",
+                "precious": false,
+                "options": [],
+                "positional": false
+            }
+        },
+        "iid": "0",
+        "lg_key": -1,
+        "dt": "PythonApp",
+        "nm": "compile",
+        "inputs": [
+            {
+                "2022-05-06T08:43:26_-2_0": "filename"
+            }
+        ],
+        "node": "localhost",
+        "island": "localhost"
+    },
+    {
+        "oid": "2022-05-06T08:43:26_-2_0",
+        "type": "plain",
+        "storage": "Memory",
+        "rank": [
+            0
+        ],
+        "loop_cxt": null,
+        "dw": 0,
+        "data_volume": 0,
+        "group_end": false,
+        "applicationArgs": {},
+        "iid": "0",
+        "lg_key": -2,
+        "dt": "Memory",
+        "nm": "NULL",
+        "consumers": [
+            {
+                "2022-05-06T08:43:26_-1_0": "filename"
+            }
+        ],
+        "node": "localhost",
+        "island": "localhost"
+    }
+]

--- a/daliuge-engine/test/graphs/test_graphExecution.py
+++ b/daliuge-engine/test/graphs/test_graphExecution.py
@@ -148,3 +148,25 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         with droputils.DROPWaiterCtx(self, init_drop, 3):
             [a.setCompleted() for a in start_drops]
 
+    def test_pos_only_args(self):
+        """
+        Use a graph with compile function to test positional only arguments
+        """
+        sessionId = "lalo"
+        with pkg_resources.resource_stream(
+                "test", "graphs/compilePG.graph"
+            ) as f:  # @UndefinedVariable
+            graphSpec = json.load(f)
+        # dropSpecs = graph_loader.loadDropSpecs(graphSpec)
+        self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
+
+        # Deploy now and get OIDs
+        self.dim.deploySession(sessionId)
+        sd = self.dm._sessions[sessionId].drops["2022-05-06T08:43:26_-2_0"]
+        fd = self.dm._sessions[sessionId].drops["2022-05-06T08:43:26_-1_0"]
+        with droputils.DROPWaiterCtx(self, fd, 3):
+            sd.write("''".encode())
+            sd.setCompleted()
+
+        #logger.debug(f'PyfuncAPPDrop signature: {dir(fd)}')
+        logger.debug(f'PyfuncAPPDrop status: {fd.status}')


### PR DESCRIPTION
Main objective was to support *args and **kwargs for PyfuncApps. In addition to that we are now also supporting positional only args and kwargs only. Thus we are covering all Python cases. Additional changes:

- Fixed the issue with the Travis version of doxygen wrongly extracting information from the docstring, if that contained highlighting markup. That messed up the hover help text of a number of components, including the updated PyfuncApp. The fix involved moving the Travis tests to Ubuntu Focal. Also cleaned up the default palettes extracted by xml2palette and enabled the extraction of a few more of the existing apps.  
- added a dummy PythonApp to simple.py to trigger the extraction of the associated palette documentation. The PythonApp palette component only existed as a hard-coded component in EAGLE. 
- Aligned the EnvironmentApp category with EAGLE, where this was called EnvironmentVariables.