### PR TITLE
Liu 253 - Issue with appended reprodata

### DIFF
--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -349,16 +349,15 @@ class CompositeManager(DROPManager):
         # attribute set
         logger.info(f"Separating graph using partition attribute {self._partitionAttr}")
         perPartition = collections.defaultdict(list)
-        try:
-            if graphSpec[-1]["rmode"] is not None:
-                init_pg_repro_data(graphSpec)
-                self._graph["reprodata"] = graphSpec.pop()
-                logger.debug(
-                    "Composite manager found reprodata in dropspecList, rmode=%s",
-                    self._graph["reprodata"]["rmode"],
-                )
-        except KeyError:
-            pass
+        if "rmode" in graphSpec[-1]:
+            init_pg_repro_data(graphSpec)
+            self._graph["reprodata"] = graphSpec.pop()
+            logger.debug(
+                "Composite manager found reprodata in dropspecList, rmode=%s",
+                self._graph["reprodata"]["rmode"],
+            )
+        if graphSpec[-1] == {}:
+            graphSpec.pop()
         for dropSpec in graphSpec:
             if self._partitionAttr not in dropSpec:
                 msg = "Drop %s doesn't specify a %s attribute" % (

--- a/daliuge-engine/test/manager/test_dim.py
+++ b/daliuge-engine/test/manager/test_dim.py
@@ -305,6 +305,39 @@ class TestDIM(LocalDimStarter, unittest.TestCase):
         self.dim.addGraphSpec('a', graphSpec)
         self.assertEqual(len(graphSpec), self.dim.getGraphSize('a'))
 
+    def test_submit_noreprodata(self):
+        """
+        Need to ensure that the DIM can handle a graph with no reprodata
+        (the default if nothing is provided at translation time)
+        """
+        graphSpec = [
+            {
+                "oid": "A",
+                "type": "plain",
+                "storage": Categories.MEMORY,
+                "node": hostname,
+                "consumers": ["B"],
+            },
+            {
+                "oid": "B",
+                "type": "app",
+                "app": "dlg.apps.simple.SleepAndCopyApp",
+                "sleepTime": 1,
+                "outputs": ["C"],
+                "node": hostname,
+            },
+            {
+                "oid": "C",
+                "type": "plain",
+                "storage": Categories.MEMORY,
+                "node": hostname,
+            },
+        ]
+        self.dim.createSession('a')
+        self.assertEqual(0, self.dim.getGraphSize('a'))
+        self.dim.addGraphSpec('a', graphSpec)
+        self.assertEqual(len(graphSpec), self.dim.getGraphSize('a'))
+
 
 class TestREST(LocalDimStarter, unittest.TestCase):
     def test_fullRound(self):

--- a/daliuge-engine/test/manager/test_dim.py
+++ b/daliuge-engine/test/manager/test_dim.py
@@ -271,6 +271,40 @@ class TestDIM(LocalDimStarter, unittest.TestCase):
         #    a.setCompleted()
         assertGraphStatus(sessionId, DROPStates.CANCELLED)
 
+    def test_submit_unreprodata(self):
+        """
+        Need to ensure that the DIM can handle a graph with empty reprodata
+        (the default if nothing is provided at translation time)
+        """
+        graphSpec = [
+            {
+                "oid": "A",
+                "type": "plain",
+                "storage": Categories.MEMORY,
+                "node": hostname,
+                "consumers": ["B"],
+            },
+            {
+                "oid": "B",
+                "type": "app",
+                "app": "dlg.apps.simple.SleepAndCopyApp",
+                "sleepTime": 1,
+                "outputs": ["C"],
+                "node": hostname,
+            },
+            {
+                "oid": "C",
+                "type": "plain",
+                "storage": Categories.MEMORY,
+                "node": hostname,
+            },
+            {}  # A dummy empty reprodata (the default if absolutely nothing is specified)
+        ]
+        self.dim.createSession('a')
+        self.assertEqual(0, self.dim.getGraphSize('a'))
+        self.dim.addGraphSpec('a', graphSpec)
+        self.assertEqual(len(graphSpec), self.dim.getGraphSize('a'))
+
 
 class TestREST(LocalDimStarter, unittest.TestCase):
     def test_fullRound(self):

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -55,7 +55,7 @@ from dlg.common.reproducibility.reproducibility import (
     init_lgt_repro_data,
     init_lg_repro_data,
     init_pgt_unroll_repro_data,
-    init_pgt_partition_repro_data,
+    init_pgt_partition_repro_data, init_pg_repro_data,
 )
 from dlg.dropmake.lg import GraphException, load_lg
 from dlg.dropmake.pg_generator import unroll, partition
@@ -426,6 +426,7 @@ def gen_pg():
             # print "session created"
             completed_uids = common.get_roots(pg_spec)
             pg_spec.append(reprodata)
+            init_pg_repro_data(pg_spec)
             mgr_client.append_graph(ssid, pg_spec)
             # print "graph appended"
             mgr_client.deploy_session(ssid, completed_uids=completed_uids)

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -567,7 +567,6 @@ def gen_pgt_post():
 
     # Retrieve rmode value
     rmode = reqform.get("rmode", str(REPRO_DEFAULT.value))
-
     # Retrieve json data.
     json_string = reqform.get("json_data")
     try:
@@ -586,6 +585,7 @@ def gen_pgt_post():
                 validate(logical_graph, lg_schema)
             except ValidationError as ve:
                 error = "Validation Error {1}: {0}".format(str(ve), lg_name)
+        logical_graph = prepare_lgt(logical_graph, rmode)
         # LG -> PGT
         pgt = unroll_and_partition_with_params(logical_graph, reqform)
         par_algo = reqform.get("algo", "none")

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -55,7 +55,7 @@ from dlg.common.reproducibility.reproducibility import (
     init_lgt_repro_data,
     init_lg_repro_data,
     init_pgt_unroll_repro_data,
-    init_pgt_partition_repro_data, init_pg_repro_data,
+    init_pgt_partition_repro_data,
 )
 from dlg.dropmake.lg import GraphException, load_lg
 from dlg.dropmake.pg_generator import unroll, partition
@@ -426,7 +426,6 @@ def gen_pg():
             # print "session created"
             completed_uids = common.get_roots(pg_spec)
             pg_spec.append(reprodata)
-            init_pg_repro_data(pg_spec)
             mgr_client.append_graph(ssid, pg_spec)
             # print "graph appended"
             mgr_client.deploy_session(ssid, completed_uids=completed_uids)

--- a/daliuge-translator/dlg/dropmake/web/lg_web.py
+++ b/daliuge-translator/dlg/dropmake/web/lg_web.py
@@ -425,7 +425,7 @@ def gen_pg():
             mgr_client.create_session(ssid)
             # print "session created"
             completed_uids = common.get_roots(pg_spec)
-            # pg_spec.append(reprodata)
+            pg_spec.append(reprodata)
             mgr_client.append_graph(ssid, pg_spec)
             # print "graph appended"
             mgr_client.deploy_session(ssid, completed_uids=completed_uids)


### PR DESCRIPTION
PR #133 added a signature mechanism, which passes additional information alongside a graph from translation to execution.

The default value of this 'reprodata' in the PGT object is an empty dictionary but will non-empty if prior layers called their respective init_lgt/lg_reprodata functions. 
Since EAGLE is not yet configured to pass a reproducibility mode flag to the translator (yet), these functions are never called, leaving the PGT with the default value of an empty dictionary.

There is logic in the composite_manager when loading a graph to remove the appended reprodata, avoiding loading this information as a drop by checking if the last item in the dropspec (which is expected to be the reprodata) contains an rmode flag. This failed if the final drop in the list is an empty dictionary, the default value in the case of no rmode being specified in prior layers.

This PR changes that logic to additionally check for an empty dictionary at the end of the PGT and provides specific tests for this case in test_dim.py