### PR TITLE
YAN-973 test nifty cuda docker image

### DIFF
--- a/daliuge-engine/docker/Dockerfile.devall
+++ b/daliuge-engine/docker/Dockerfile.devall
@@ -27,9 +27,9 @@ ENV DLG_ROOT="/tmp/dlg"
 RUN apt install -y git python3-dev
 
 RUN pip install git+https://gitlab.com/ska-telescope/sdp/ska-gridder-nifty-cuda.git
-RUN pip install dlg-nifty-components
+RUN pip install dlg-nifty-components>=1.1.0
 
-RUN pip install --extra-index-url=https://artefact.skao.int/repository/pypi-internal/simple 'ska-sdp-cbf-emulator[plasma]==1.6.11'
-RUN pip install dlg-casacore-components
+RUN pip install 'ska-sdp-realtime-receive-modules[plasma]==2.0.1' 'ska-sdp-cbf-emulator==2.0.1' --extra-index-url=https://artefact.skao.int/repository/pypi-internal/simple
+RUN pip install dlg-casacore-components>=0.3.0
 
 CMD ["dlg", "daemon", "-vv"]

--- a/daliuge-engine/run_engine.sh
+++ b/daliuge-engine/run_engine.sh
@@ -2,6 +2,7 @@
 DOCKER_OPTS="\
 --shm-size=2g --ipc=shareable \
 --rm \
+$([[ $(nvidia-docker version) ]] && echo '--gpus=all' || echo '') \
 --name daliuge-engine \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -p 5555:5555 -p 6666:6666 \


### PR DESCRIPTION
Minor daliuge-engine docker dependency changes for better cuda compatibility, rebase of https://github.com/ICRAR/daliuge/pull/137