### PR TITLE
DRAFT: YAN-913 Async Drop Streaming

### DIFF
--- a/daliuge-engine/dlg/apps/async_apps.py
+++ b/daliuge-engine/dlg/apps/async_apps.py
@@ -1,0 +1,127 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2017
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+"""Applications used as examples, for testing, or in simple situations"""
+import asyncio
+from numbers import Number
+import pickle
+import random
+from typing import AsyncIterable, List, Optional
+import urllib.error
+import urllib.request
+from overrides import overrides
+
+import time
+import ast
+import numpy as np
+
+from dlg import droputils, utils
+from dlg.drop import DataDROP, InputFiredAppDROP, BranchAppDrop, ContainerDROP, NullDROP
+from dlg.meta import (
+    dlg_float_param, 
+    dlg_string_param,
+    dlg_bool_param, 
+    dlg_int_param,
+    dlg_list_param,
+    dlg_component, 
+    dlg_batch_input,
+    dlg_batch_output, 
+    dlg_streaming_input
+)
+from dlg.exceptions import DaliugeException
+from dlg.apps.pyfunc import serialize_data, deserialize_data
+
+
+##
+# @brief CopyApp
+# @details A simple APP that copies its inputs into its outputs.
+# All inputs are copied into all outputs in the order they were declared in
+# the graph. If an input is a container (e.g. a directory) it copies the
+# content recursively.
+# @par EAGLE_START
+# @param category PythonApp
+# @param tag daliuge
+# @param[in] cparam/appclass Application Class/dlg.apps.simple.CopyApp/String/readonly/False//False/
+#     \~English Application class
+# @param[in] cparam/bufsize buffer size/65536/Integer/readwrite/False//False/
+#     \~English Application class
+# @param[in] cparam/execution_time Execution Time/5/Float/readonly/False//False/
+#     \~English Estimated execution time
+# @param[in] cparam/num_cpus No. of CPUs/1/Integer/readonly/False//False/
+#     \~English Number of cores used
+# @param[in] cparam/group_start Group start/False/Boolean/readwrite/False//False/
+#     \~English Is this node the start of a group?
+# @param[in] cparam/input_error_threshold "Input error rate (%)"/0/Integer/readwrite/False//False/
+#     \~English the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param[in] cparam/n_tries Number of tries/1/Integer/readwrite/False//False/
+#     \~English Specifies the number of times the 'run' method will be executed before finally giving up
+# @par EAGLE_END
+class AsyncCopyApp(InputFiredAppDROP):
+    """
+    A streaming app drop that copies its inputs into its outputs.
+    All inputs are copied into all outputs in the order they were declared in
+    the graph.
+    """
+
+    component_meta = dlg_component(
+        "AsyncCopyApp",
+        "Async Copy App.",
+        [dlg_batch_input("binary/*", [])],
+        [dlg_batch_output("binary/*", [])],
+        [dlg_streaming_input("binary/*")],
+    )
+
+    _bufsize = dlg_int_param("bufsize", 65536)
+
+    def run(self):
+        assert len(self.inputs) == len(self.outputs)
+        
+        # synchronous
+        #for inputDrop, outputDrop in zip(self.inputs, self.outputs):
+        #    droputils.copyDropContents(inputDrop, outputDrop, bufsize=self._bufsize)
+
+        # asynchronous
+        asyncio.run(self.copyAll())
+
+    async def copyAll(self):
+        tasks = []
+        for inputDrop, outputDrop in zip(self.inputs, self.outputs):
+            tasks.append(asyncio.create_task(AsyncCopyApp.asyncCopyDropContents(inputDrop, outputDrop)))
+        await asyncio.gather(*tasks)
+
+    @staticmethod
+    async def sync_to_async(a) -> AsyncIterable:
+        for i in a:
+            yield i
+
+    @staticmethod
+    async def asyncCopyDropContents(inputDrop: DataDROP, outputDrop: DataDROP):
+        desc = inputDrop.open()
+        s: AsyncIterable = await inputDrop.readStream(desc)
+        await outputDrop.writeStream(s)
+    
+    @overrides
+    async def readStream(self, descriptor, **kwargs) -> AsyncIterable:
+        raise NotImplementedError()
+
+    @overrides
+    async def writeStream(self, stream: AsyncIterable, **kwargs):
+        raise NotImplementedError()

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -236,7 +236,6 @@ class DockerApp(BarrierAppDROP):
     running in a container must quit themselves after successfully performing
     their task.
     """
-
     _container: Optional[Container] = None
 
     # signals for stopping this drop must first wait
@@ -245,7 +244,7 @@ class DockerApp(BarrierAppDROP):
     # be to use a stopcontainer member variable flag. As soon as the container is
     # created the running process checks to see if it should stop. Use lock for
     # atomicity with _container and _stopflag.
-    _containerLock = multiprocessing.synchronize.Lock
+    _containerLock: multiprocessing.synchronize.Lock
 
     @property
     def container(self) -> Optional[Container]:

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -30,7 +30,7 @@ import inspect
 import logging
 import pickle
 
-from typing import Callable, Optional
+from typing import Callable
 import dill
 from io import StringIO
 from contextlib import redirect_stdout

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -168,6 +168,8 @@ class CopyApp(BarrierAppDROP):
         self.copyAll()
 
     def copyAll(self):
+        # for inputDrop, outputDrop in zip(self.inputs, self.outputs):
+        #     droputils.copyDropContents(inputDrop, outputDrop, bufsize=self._bufsize)
         for inputDrop in self.inputs:
             self.copyRecursive(inputDrop)
 

--- a/daliuge-engine/dlg/ddap_protocol.py
+++ b/daliuge-engine/dlg/ddap_protocol.py
@@ -20,6 +20,7 @@
 #    MA 02111-1307  USA
 #
 import collections
+from enum import IntEnum
 
 
 class DROPLinkType:
@@ -47,24 +48,32 @@ class DROPLinkType:
     ) = range(8)
 
 
-class DROPStates:
+class DROPStates(IntEnum):
     """
     An enumeration of the different states a DROP can be found in. DROPs start
     in the INITIALIZED state, go optionally through WRITING and arrive to
     COMPLETED. Later, they transition through EXPIRED, eventually arriving to
     DELETED.
     """
+    INITIALIZED = 0
+    WRITING = 1
+    COMPLETED = 2
+    ERROR = 3
+    EXPIRED = 4
+    DELETED = 5
+    CANCELLED = 6
+    SKIPPED = 7
 
-    (
-        INITIALIZED,
-        WRITING,
-        COMPLETED,
-        ERROR,
-        EXPIRED,
-        DELETED,
-        CANCELLED,
-        SKIPPED,
-    ) = range(8)
+
+class DROPStreamingTypes(IntEnum):
+    """
+    An enumeration of the different types of streaming a data drop can be
+    configured to.
+    """
+    NONE = 0  # No data streaming. Single write, multiple reads.
+    SYNC_STREAM = 1  # Multiple reads using callback.
+    SINGLE_STREAM = 2  # Cold stream using AsyncIterable.
+    MULTI_STREAM = 3  # Hot stream using AsyncIterable.
 
 
 class AppDROPStates:

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -136,10 +136,11 @@ class ListAsDict(list):
     """A list that adds drop UIDs to a set as they get appended to the list"""
 
     def __init__(self, my_set):
+        super().__init__()
         self.set = my_set
 
     def append(self, drop):
-        super(ListAsDict, self).append(drop)
+        super().append(drop)
         self.set.add(drop.uid)
 
 
@@ -1337,7 +1338,7 @@ class DataDROP(AbstractDROP):
                 self._wio.open(OpenMode.OPEN_WRITE)
             except:
                 self.status = DROPStates.ERROR
-                raise Exception("Problem opening drop for write!")
+                raise  # Exception("Problem opening drop for write!")
         nbytes = self._wio.write(data)
 
         dataLen = len(data)
@@ -1823,6 +1824,7 @@ class InMemoryDROP(DataDROP):
     """
     A DROP that points data stored in memory.
     """
+    _buf: io.BytesIO
 
     def initialize(self, **kwargs):
         args = []

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -695,8 +695,8 @@ class AbstractDROP(EventFirer):
                     ].merkle_root
             else:
                 # Fill MerkleTree, add data and set the MerkleRoot Value
-                self._merkleTree = []  # MerkleTree(self._merkleData.items(), common_hash)
-                self._merkleRoot = []  # self._merkleTree.merkle_root
+                self._merkleTree = MerkleTree(self._merkleData.items(), common_hash)
+                self._merkleRoot = self._merkleTree.merkle_root
                 # Set as committed
             self._committed = True
         else:

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1305,10 +1305,14 @@ class DataDROP(AbstractDROP):
         io = self._rios[descriptor]
         return io.read(count, **kwargs)
 
-    async def readStream(self, descriptor, **kwargs) -> AsyncIterable:
+    def readStream(self, descriptor, **kwargs) -> AsyncIterable:
+        """
+        Retreives the async read stream from this drop with behaviour
+        depending on the streamingType.
+        """
         self._checkStateAndDescriptor(descriptor)
-        io = self._rios[descriptor]
-        return io.readStream()
+        rio = self._rios[descriptor]
+        return rio.readStream()
 
     def _checkStateAndDescriptor(self, descriptor):
         if self.status != DROPStates.COMPLETED:
@@ -1402,9 +1406,8 @@ class DataDROP(AbstractDROP):
         return nbytes
 
     async def writeStream(self, stream: AsyncIterable, **kwargs):
-        async for iterator in stream:
-            async for item in iterator:
-                self.write(item)
+        async for item in stream:
+            self.write(item)
 
     def _updateChecksum(self, chunk):
         # see __init__ for the initialization to None

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -695,8 +695,8 @@ class AbstractDROP(EventFirer):
                     ].merkle_root
             else:
                 # Fill MerkleTree, add data and set the MerkleRoot Value
-                self._merkleTree = MerkleTree(self._merkleData.items(), common_hash)
-                self._merkleRoot = self._merkleTree.merkle_root
+                self._merkleTree = []  # MerkleTree(self._merkleData.items(), common_hash)
+                self._merkleRoot = []  # self._merkleTree.merkle_root
                 # Set as committed
             self._committed = True
         else:

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -22,6 +22,8 @@
 """
 Module containing the core DROP classes.
 """
+from asyncio import subprocess
+import multiprocessing
 from sqlite3 import OperationalError
 import string
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -45,7 +47,7 @@ import re
 import sys
 import inspect
 import binascii
-from typing import AsyncIterable, Dict, List, Optional, Union
+from typing import AsyncIterable, Dict, List, Optional, TypeVar, Union
 from overrides import overrides
 
 import numpy as np
@@ -1306,7 +1308,7 @@ class DataDROP(AbstractDROP):
     async def readStream(self, descriptor, **kwargs) -> AsyncIterable:
         self._checkStateAndDescriptor(descriptor)
         io = self._rios[descriptor]
-        return await io.readStream()
+        return io.readStream()
 
     def _checkStateAndDescriptor(self, descriptor):
         if self.status != DROPStates.COMPLETED:
@@ -1400,7 +1402,9 @@ class DataDROP(AbstractDROP):
         return nbytes
 
     async def writeStream(self, stream: AsyncIterable, **kwargs):
-        raise NotImplementedError
+        async for iterator in stream:
+            async for item in iterator:
+                self.write(item)
 
     def _updateChecksum(self, chunk):
         # see __init__ for the initialization to None

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -28,6 +28,7 @@ import io
 import json
 import logging
 import pickle
+import asyncio
 import re
 import threading
 import traceback
@@ -347,8 +348,6 @@ async def load_npy_stream(drop: DataDROP, allow_pickle=False, backoff=0.01) -> A
     """
     Loads an async stream of numpy ndarrays from a data drop
     """
-    import asyncio
-
     desc = None
     while desc is None:
         try:

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -34,8 +34,9 @@ import traceback
 from typing import List, IO, Any, AsyncIterable, BinaryIO, Dict, Iterable, overload
 import numpy as np
 
-from dlg.ddap_protocol import DROPStates
+from dlg.ddap_protocol import DROPStates, DROPStreamingTypes
 from dlg.drop import AppDROP, AbstractDROP, DataDROP, PathBasedDrop
+from dlg.exceptions import DaliugeException
 from dlg.io import IOForURL, OpenMode
 from dlg import common
 from dlg.common import DropType
@@ -303,7 +304,7 @@ def save_npy(drop: DataDROP, ndarray: np.ndarray, allow_pickle=False):
     """
     Saves a numpy ndarray to a drop in npy format
     """
-    dropio = drop.getIO()
+    dropio = drop._getIO()
     dropio.open(OpenMode.OPEN_WRITE)
     # np.save accepts a "file-like" object which basically just requires
     # a .write() method. Try np.save(drop, array)
@@ -321,7 +322,7 @@ def load_npy(drop: DataDROP, allow_pickle=False) -> np.ndarray:
     """
     Loads a numpy ndarray from a drop in npy format
     """
-    dropio = drop.getIO()
+    dropio = drop._getIO()
     dropio.open(OpenMode.OPEN_READ)
     res = np.load(io.BytesIO(dropio.buffer()), allow_pickle=allow_pickle)
     dropio.close()
@@ -332,27 +333,46 @@ async def save_npy_stream(drop: DataDROP, arrays: AsyncIterable[np.ndarray], all
     """
     Saves an async stream of numpy ndarrays to a data drop
     """
-    dropio = drop.getIO()
-    dropio.open(OpenMode.OPEN_WRITE)
+    #assert drop.streamingType in (DROPStreamingTypes.SINGLE_STREAM, DROPStreamingTypes.MULTI_STREAM)
     async for ndarray in arrays:
+        logger.debug(f"saving... {drop._wio.tell() if drop._wio else 0}")
         bio = io.BytesIO()
         np.save(bio, ndarray, allow_pickle=allow_pickle)
-        dropio.write(bio.getbuffer())
-    dropio.close()
+        drop.write(bio.getbuffer())
+        logger.debug(f"saved {drop._wio.tell() if drop._wio else 0}")
+    drop.setCompleted()
 
 
-async def load_npy_stream(drop: DataDROP, allow_pickle=False) -> AsyncIterable[np.ndarray]:
+async def load_npy_stream(drop: DataDROP, allow_pickle=False, backoff=0.01) -> AsyncIterable[np.ndarray]:
     """
     Loads an async stream of numpy ndarrays from a data drop
     """
-    dropio = drop.getIO()
-    dropio.open(OpenMode.OPEN_READ)
-    # this requires dropio interface to contain read() and seek()
-    while dropio.peek(1):
-        # TODO: peek should also be awaitable, otherwise return regular iterable
-        yield np.load(dropio, allow_pickle=allow_pickle)
-    dropio.close()
+    import asyncio
 
+    desc = None
+    while desc is None:
+        try:
+            desc = drop.open()
+        except DaliugeException:
+            # cannot open for read before opening for write
+            logger.debug("load backing off")
+            await asyncio.sleep(backoff)
+    dropio = drop._rios[desc]
+
+    cursor = 0
+    while not (drop.isCompleted() and cursor == dropio.size()):
+        # TODO: peek ideally would be awaitable
+        if cursor != dropio.size(): #and dropio.peek(1):
+            dropio.seek(cursor)
+            logger.debug(f"loading.. {dropio.tell()}")
+            res = np.load(dropio, allow_pickle=allow_pickle)
+            # TODO(calgray): buffered reader stream position
+            # currently matches writer stream position.
+            cursor = dropio.tell()
+            yield res
+        else:
+            await asyncio.sleep(backoff)
+    drop.close(desc)
 
 # def save_jsonp(drop: PathBasedDrop, data: Dict[str, object]):
 #     with open(drop.path, 'r') as f:
@@ -366,7 +386,7 @@ async def load_npy_stream(drop: DataDROP, allow_pickle=False) -> AsyncIterable[n
 
 
 # def load_json(drop: DataDROP) -> dict:
-#     dropio = drop.getIO()
+#     dropio = drop._getIO()
 #     dropio.open(OpenMode.OPEN_READ)
 #     data = json.loads(dropio.buffer())
 #     dropio.close()

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -330,6 +330,10 @@ def load_npy(drop: DataDROP, allow_pickle=False) -> np.ndarray:
     return res
 
 
+def load_numpy(drop: DataDROP) -> np.ndarray:
+    return load_npy(drop)
+
+
 async def save_npy_stream(drop: DataDROP, arrays: AsyncIterable[np.ndarray], allow_pickle=False):
     """
     Saves an async stream of numpy ndarrays to a data drop

--- a/daliuge-engine/dlg/environmentvar_drop.py
+++ b/daliuge-engine/dlg/environmentvar_drop.py
@@ -81,8 +81,8 @@ class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):
         self._variables = dict()
         self._variables.update(_filter_parameters(self.parameters))
 
-    def getIO(self):
-        return MemoryIO(io.BytesIO(json.dumps(self._variables).encode("utf-8")))
+    def _getIO(self):
+        return MemoryIO(io.BytesIO(json.dumps(self._variables).encode('utf-8')))
 
     def get(self, key):
         """

--- a/daliuge-engine/dlg/io.py
+++ b/daliuge-engine/dlg/io.py
@@ -355,9 +355,9 @@ class MemoryIO(DataIO):
 
     class BytesIOReader(io.BufferedReader):
         """
-        An BinaryIO Reader that wraps a BytesIO object for concurrent
-        reading and writing. Closing this reader will not close other
-        readers observing the same BytesIO object.
+        A BinaryIO Reader that wraps a BytesIO object for concurrent
+        reading and writing. Closing this reader will not close the BytesIO
+        object and avoid preventing readers observing the same BytesIO object.
         """
         _closed = False
         def __init__(self, raw: io.BytesIO, buffer_size: int = 2048):
@@ -365,11 +365,13 @@ class MemoryIO(DataIO):
             # NOTE: BytesIO extends BufferedIOBase instead of RawIOBase. Read
             # and peek operations may return more bytes than requested.
             super().__init__(raw, buffer_size)  # type: ignore
-        def close(self) -> None:
-            self._closed = True
+
         @property
         def closed(self) -> bool:
             return self.closed
+
+        def close(self) -> None:
+            self._closed = True
 
     def _open(self, **kwargs):
         if self._mode == OpenMode.OPEN_WRITE:
@@ -438,6 +440,7 @@ class MemoryIO(DataIO):
     def buffer(self) -> memoryview:
         # TODO: This may also be an issue
         return self._buf.getbuffer()
+
 
 class SharedMemoryIO(DataIO):
     """

--- a/daliuge-engine/dlg/io.py
+++ b/daliuge-engine/dlg/io.py
@@ -20,6 +20,7 @@
 #    MA 02111-1307  USA
 #
 from abc import abstractmethod, ABCMeta
+from enum import IntEnum
 from http.client import HTTPConnection
 from multiprocessing.sharedctypes import Value
 from overrides import overrides
@@ -29,7 +30,7 @@ import os
 import sys
 import urllib.parse
 from abc import abstractmethod, ABCMeta
-from typing import Optional, Union
+from typing import BinaryIO, Optional, Union
 
 from . import ngaslite
 from .apps.plasmaflight import PlasmaFlightClient
@@ -43,16 +44,15 @@ if sys.version_info >= (3, 8):
 
 logger = logging.getLogger(__name__)
 
-
-class OpenMode:
+class OpenMode(IntEnum):
     """
     Open Mode for Data Drops
     """
+    OPEN_WRITE = 0
+    OPEN_READ = 1
 
-    OPEN_WRITE, OPEN_READ = range(2)
 
-
-class DataIO:
+class DataIO(io.BufferedIOBase, BinaryIO):
     """
     A class used to read/write data stored in a particular kind of storage in an
     abstract way. This base class simply declares a number of methods that
@@ -73,8 +73,10 @@ class DataIO:
 
     __metaclass__ = ABCMeta
     _mode: Optional[OpenMode]
+    _desc: Any
 
     def __init__(self):
+        super().__init__()
         self._mode = None
 
     def open(self, mode: OpenMode, **kwargs):
@@ -96,7 +98,7 @@ class DataIO:
             raise ValueError("Writing operation attempted on write-only DataIO object")
         return self._write(data, **kwargs)
 
-    def read(self, count: int, **kwargs):
+    def read(self, count: int, **kwargs) -> bytes:
         """
         Reads `count` bytes from the underlying storage.
         """
@@ -105,6 +107,24 @@ class DataIO:
         if self._mode == OpenMode.OPEN_WRITE:
             raise ValueError("Reading operation attempted on write-only DataIO object")
         return self._read(count, **kwargs)
+
+    def peek(self, size: int, **kwargs):
+        """
+        Previews `count` bytes from the underlying storage without moving the read cursor
+        """
+        return self._peek(size, **kwargs)
+
+    def tell(self):
+        """
+        Returns the current read cursor position.
+        """
+        return self._tell()
+
+    def seek(self, offset, whence):
+        """
+        Sets the position of the read cursor
+        """
+        return self._seek(offset, whence)
 
     def close(self, **kwargs):
         """
@@ -151,10 +171,25 @@ class DataIO:
 
     @abstractmethod
     def _open(self, **kwargs):
+        """
+        Returns a reader or writer object depending on self._mode
+        """
         pass
 
     @abstractmethod
-    def _read(self, count, **kwargs):
+    def _read(self, count, **kwargs) -> bytes:
+        pass
+
+    #@abstractmethod
+    def _peek(self, count, **kwargs):
+        pass
+
+    #@abstractmethod
+    def _tell(self):
+        pass
+
+    #@abstractmethod
+    def _seek(self, offset, whence):
         pass
 
     @abstractmethod
@@ -162,7 +197,7 @@ class DataIO:
         pass
 
     @abstractmethod
-    def _close(self, **kwargs):
+    def _close(self, **kwargs) -> None:
         pass
 
     @abstractmethod
@@ -175,15 +210,19 @@ class NullIO(DataIO):
     A DataIO that stores no data
     """
 
+    @overrides
     def _open(self, **kwargs):
         return None
 
-    def _read(self, count=4096, **kwargs):
+    @overrides
+    def _read(self, count=4096, **kwargs) -> bytes:
         return None
 
+    @overrides
     def _write(self, data, **kwargs) -> int:
         return len(data)
 
+    @overrides
     def _close(self, **kwargs):
         pass
 
@@ -213,7 +252,7 @@ class ErrorIO(DataIO):
         raise NotImplementedError()
 
     @overrides
-    def _read(self, count=4096, **kwargs):
+    def _read(self, count=4096, **kwargs) -> bytes:
         raise NotImplementedError()
 
     @overrides
@@ -242,8 +281,9 @@ class MemoryIO(DataIO):
     A DataIO class that reads/write from/into the BytesIO object given at
     construction time
     """
-
-    _desc: io.BytesIO  # TODO: This might actually be a problem
+    # TODO: This might actually be a problem
+    _desc: io.BufferedReader
+    _buf: io.BytesIO
 
     def __init__(self, buf: io.BytesIO, **kwargs):
         super().__init__()
@@ -253,8 +293,12 @@ class MemoryIO(DataIO):
         if self._mode == OpenMode.OPEN_WRITE:
             return self._buf
         elif self._mode == OpenMode.OPEN_READ:
-            # TODO: potentially wasteful copy
-            return io.BytesIO(self._buf.getbuffer())
+            # NOTE: BytesIO extends BufferedIOBase instead of RawIOBase
+            # TODO: a new bytesIO object must be created as it is currently
+            # convention to close the write dataIO afte writing
+            br = io.BufferedReader(io.BytesIO(self._buf.getbuffer()))
+            br.seek(0)
+            return br
         else:
             raise ValueError()
 
@@ -264,8 +308,17 @@ class MemoryIO(DataIO):
         return len(data)
 
     @overrides
-    def _read(self, count=4096, **kwargs):
+    def _read(self, count=4096, **kwargs) -> bytes:
         return self._desc.read(count)
+
+    def _peek(self, count, **kwargs):
+        return self._desc.peek(count)
+
+    def _tell(self):
+        return self._desc.tell()
+
+    def _seek(self, offset, whence):
+        return self._desc.seek(offset, whence)
 
     @overrides
     def _close(self, **kwargs):
@@ -332,7 +385,7 @@ class SharedMemoryIO(DataIO):
         return len(data)
 
     @overrides
-    def _read(self, count=4096, **kwargs):
+    def _read(self, count=4096, **kwargs) -> bytes:
         if self._pos == self._buf.size:
             return None
         start = self._pos
@@ -379,7 +432,7 @@ class FileIO(DataIO):
         return open(self._fnm, flag)
 
     @overrides
-    def _read(self, count=4096, **kwargs):
+    def _read(self, count=4096, **kwargs) -> bytes:
         return self._desc.read(count)
 
     @overrides
@@ -491,9 +544,9 @@ class NgasIO(DataIO):
         del self._desc
 
     @overrides
-    def _read(self, count, **kwargs):
+    def _read(self, count, **kwargs) -> bytes:
         # Read data from NGAS and give it back to our reader
-        self._desc.retrieve2File(self._fileId, cmd="QRETRIEVE")
+        return self._desc.retrieve2File(self._fileId, cmd="QRETRIEVE")
 
     @overrides
     def _write(self, data, **kwargs) -> int:
@@ -722,7 +775,8 @@ class PlasmaIO(DataIO):
         if self._reader:
             self._reader.close()
 
-    def _read(self, count, **kwargs):
+    @overrides
+    def _read(self, count, **kwargs) -> bytes:
         if not self._reader:
             [data] = self._desc.get_buffers([self._object_id])
             self._reader = pyarrow.BufferReader(data)
@@ -816,9 +870,11 @@ class PlasmaFlightIO(DataIO):
         self._buffer_size = 0
         self._use_staging = use_staging
 
+    @overrides
     def _open(self, **kwargs):
         return PlasmaFlightClient(socket=self._plasma_path)
 
+    @overrides
     def _close(self, **kwargs):
         if self._writer:
             if self._use_staging:
@@ -833,12 +889,14 @@ class PlasmaFlightIO(DataIO):
         if self._reader:
             self._reader.close()
 
-    def _read(self, count, **kwargs):
+    @overrides
+    def _read(self, count, **kwargs) -> bytes:
         if not self._reader:
             data = self._desc.get_buffer(self._object_id, self._flight_path)
             self._reader = pyarrow.BufferReader(data)
         return self._reader.read1(count)
 
+    @overrides
     def _write(self, data, **kwargs) -> int:
 
         # NOTE: data must be a collection of bytes for len to represent the buffer bytesize

--- a/daliuge-engine/dlg/io.py
+++ b/daliuge-engine/dlg/io.py
@@ -133,16 +133,13 @@ class DataIO(): # io.BufferedIOBase, BinaryIO
         raise Exception # TODO: NotImplementedError
 
     @abstractmethod
-    async def readStream(self) -> AsyncIterable:
+    def readStream(self) -> AsyncIterable:
         """
         Returns a asynchronous stream typically processed using
         `async for` that either yields when no data is available,
         iterates when data is buffered, or raises StopAsyncIterator
         when the stream is complete.
         """
-        # NOTE: yield is required for typing system to detect
-        # asynciterable instead of coroutine.
-        return EmptyAsyncIterable()
 
     def peek(self, size: int, **kwargs):
         """
@@ -300,6 +297,14 @@ class NullIO(DataIO):
     def delete(self):
         pass
 
+    @overrides
+    def readStream(self) -> AsyncIterable:
+        return EmptyAsyncIterable()
+    
+    @overrides
+    async def writeStream(self, stream: AsyncIterable):
+        pass
+
 
 class ErrorIO(DataIO):
     """
@@ -392,8 +397,8 @@ class MemoryIO(DataIO):
         return self._desc.read(count)
 
     @overrides
-    async def readStream(self) -> AsyncIterable:
-        yield self.__aiter__()
+    def readStream(self) -> AsyncIterable:
+        return DataIOAsyncIterator(self)
 
     def __aiter__(self) -> AsyncIterator:
         return DataIOAsyncIterator(self)

--- a/daliuge-engine/dlg/parset_drop.py
+++ b/daliuge-engine/dlg/parset_drop.py
@@ -86,7 +86,7 @@ class ParameterSetDROP(DataDROP):
             self.filter_parameters(self.parameters, self.mode), self.mode
         ).encode("utf-8")
 
-    def getIO(self):
+    def _getIO(self):
         return MemoryIO(io.BytesIO(self.config_data))
 
     @property

--- a/daliuge-engine/dlg/s3_drop.py
+++ b/daliuge-engine/dlg/s3_drop.py
@@ -106,7 +106,7 @@ class S3DROP(AbstractDROP):
 
         return -1
 
-    def getIO(self):
+    def _getIO(self):
         """
         This type of DROP cannot be accessed directly
         :return:

--- a/daliuge-engine/pip/requirements.txt
+++ b/daliuge-engine/pip/requirements.txt
@@ -1,4 +1,6 @@
 # The PIP requirements for daliuge - taken from setup.py
+aiostream
+asyncstdlib
 boto3
 bottle
 configobj

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -117,6 +117,7 @@ class lib64_path(install):
 # Keep alpha-sorted PLEASE!
 install_requires = [
     "wheel",  # need to get wheel first...
+    "aiostream",
     "asyncstdlib",
     "bottle",
     "configobj",

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -117,6 +117,7 @@ class lib64_path(install):
 # Keep alpha-sorted PLEASE!
 install_requires = [
     "wheel",  # need to get wheel first...
+    "asyncstdlib",
     "bottle",
     "configobj",
     "crc32c",

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -52,7 +52,7 @@ from dlg.drop import (
 )
 from dlg.droputils import DROPWaiterCtx
 from dlg.exceptions import InvalidDropException
-from dlg.apps.simple import NullBarrierApp, SimpleBranch, SleepAndCopyApp
+from dlg.apps.simple import CopyApp, NullBarrierApp, SimpleBranch, SleepAndCopyApp
 
 try:
     from crc32c import crc32c
@@ -364,20 +364,19 @@ class TestDROP(unittest.TestCase):
         cResExpected = b"we have an a here\nand another one\n"
         eResExpected = b"and another one\nwe have an a here\n"
         gResExpected = b"dna rehtona eno\new evah na a ereh\n"
+        resExpected = [cResExpected, eResExpected, gResExpected]
 
         a.write(contents)
-        with DROPWaiterCtx(self, g):
+        with DROPWaiterCtx(self, [c, e, g]):
             a.setCompleted()
 
         # Get intermediate and final results and compare
         actualRes = []
-        for i in [c]:
-            actualRes.append(droputils.allDropContents(i))
-        map(
-            lambda x, y: self.assertEqual(x, y),
-            [cResExpected, eResExpected, gResExpected],
-            actualRes,
-        )
+        for drop in [c, e, g]:
+            actualRes.append(droputils.allDropContents(drop))
+
+        # Assert
+        map(self.assertEqual, resExpected, actualRes)
 
     def test_errorState(self):
         a = InMemoryDROP("a", "a")

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -23,7 +23,7 @@
 import contextlib
 import io
 import os, unittest
-from typing import Any, AsyncIterable, AsyncIterator, Iterable
+from typing import Any, AsyncIterable, AsyncIterator, Iterable, List
 import random
 import shutil
 import sqlite3
@@ -31,6 +31,12 @@ import string
 import sys
 import tempfile
 import subprocess
+import asyncio
+import asyncstdlib
+import concurrent.futures
+
+import numpy as np
+from dlg.apps.async_apps import AsyncCopyApp
 
 import dlg.droputils as droputils
 from dlg.common.reproducibility.constants import ReproducibilityFlags
@@ -142,6 +148,14 @@ class TestDROP(unittest.TestCase):
     def test_stream_write_InMemoryDROP(self):
         self._test_async_stream_npy_withDropType(InMemoryDROP, 0.025, 0.01)
         self._test_async_stream_npy_withDropType(InMemoryDROP, 0.01, 0.025)
+
+    def test_threaded_stream_write_InMemoryDROP(self):
+        self._test_threaded_stream_npy_withDropType(InMemoryDROP, 0.025, 0.01)
+        self._test_threaded_stream_npy_withDropType(InMemoryDROP, 0.01, 0.025)
+    
+    def test_process_stream_write_InMemoryDROP(self):
+        self._test_process_stream_npy_withDropType(InMemoryDROP, 0.025, 0.01)
+        self._test_process_stream_npy_withDropType(InMemoryDROP, 0.01, 0.025)
 
     @unittest.skipIf(sys.version_info < (3, 8), "Shared memory does nt work < python 3.8")
     def test_write_SharedMemoryDROP(self):
@@ -257,20 +271,11 @@ class TestDROP(unittest.TestCase):
         self.assertEqual(a.checksum, test_crc)
         self.assertEqual(cChecksum, test_crc)
 
-    def _test_async_stream_npy_withDropType(self, dropType, write_delay: float, read_delay: float):
+    def _test_manual_async_stream_npy_withDropType(self, dropType, write_delay: float, read_delay: float):
         a: DataDROP = dropType("oid:A", "uid:A",
             expectedSize=-1, use_staging=True,
             streamingType=DROPStreamingTypes.SINGLE_STREAM)
         a.streamingType=DROPStreamingTypes.SINGLE_STREAM
-
-        import asyncio
-        import asyncstdlib
-        import numpy as np
-
-        async def delay_iterable(iterable, delay):
-            for i in iterable:
-                await asyncio.sleep(delay)
-                yield i
 
         in_arrays = [np.random.rand(10,10,10) for _ in range(0,10)]
 
@@ -287,6 +292,86 @@ class TestDROP(unittest.TestCase):
         with DROPWaiterCtx(self, a, 5):
             asyncio.run(write_read_assert_stream())
 
+    def _test_async_stream_npy_withDropType(self, dropType, write_delay: float, read_delay: float):
+        a: DataDROP = InMemoryDROP("oid:A", "oid:A")
+        b = AsyncCopyApp("oid:B", "uid:B", n_effective_inputs=1)
+        c: DataDROP = dropType("oid:C", "uid:C",
+            expectedSize=-1, use_staging=True,
+            streamingType=DROPStreamingTypes.SINGLE_STREAM)
+        c.streamingType=DROPStreamingTypes.SINGLE_STREAM
+
+        b.addInput(a)
+        b.addOutput(c)
+
+        in_arrays = [np.random.rand(10,10,10) for _ in range(0,10)]
+
+        async def write_read_assert_stream():
+            # NOTE: typically these are performed in parallel on seperate subprocesses
+            await droputils.save_npy_stream(a, TestDROP.delay_iterable(in_arrays, write_delay))
+            #asyncio.create_task(asyncstdlib.list(droputils.load_npy_stream(c, backoff=read_delay)))
+
+        with DROPWaiterCtx(self, (a,b,c), 5):
+            res = asyncio.run(write_read_assert_stream())
+
+        assert b.status != DROPStates.ERROR
+
+        #assert b.status == DROPStates.ERROR
+        #out_arrays = asyncio.run(asyncstdlib.list(droputils.load_npy_stream(c, backoff=read_delay)))
+        #assert len(in_arrays) == len(out_arrays)
+        #for in_array, out_array in zip(in_arrays, out_arrays):
+        #   np.testing.assert_array_equal(in_array, out_array)
+
+    def _test_threaded_stream_npy_withDropType(self, dropType, write_delay: float, read_delay: float):
+        a: DataDROP = dropType("oid:A", "uid:A",
+            expectedSize=-1, use_staging=True,
+            streamingType=DROPStreamingTypes.SINGLE_STREAM)
+        a.streamingType=DROPStreamingTypes.SINGLE_STREAM
+
+        in_arrays = [np.random.rand(10,10,10) for _ in range(0,10)]
+
+        # see https://idolstarastronomer.com/two-futures.html
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            cfutures = []
+            cfutures.append(executor.submit(asyncio.run,
+                droputils.save_npy_stream(a, TestDROP.delay_iterable(in_arrays, write_delay))))
+            cfutures.append(executor.submit(asyncio.run,
+                asyncstdlib.list(droputils.load_npy_stream(a, backoff=read_delay))))
+            out_arrays = cfutures[1].result()
+        assert len(in_arrays) == len(out_arrays)
+        for in_array, out_array in zip(in_arrays, out_arrays):
+            np.testing.assert_array_equal(in_array, out_array)
+
+    def _test_process_stream_npy_withDropType(self, dropType, write_delay: float, read_delay: float):
+        a: DataDROP = dropType("oid:A", "uid:A",
+            expectedSize=-1, use_staging=True,
+            streamingType=DROPStreamingTypes.SINGLE_STREAM)
+        a.streamingType=DROPStreamingTypes.SINGLE_STREAM
+
+        in_arrays = [np.random.rand(10,10,10) for _ in range(0,10)]
+
+        # see https://idolstarastronomer.com/two-futures.html
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            cfutures = []
+            cfutures.append(executor.submit(TestDROP.save, a, in_arrays, write_delay))
+            cfutures.append(executor.submit(TestDROP.load, a, read_delay))
+            out_arrays = cfutures[1].result()
+        assert len(in_arrays) == len(out_arrays)
+        for in_array, out_array in zip(in_arrays, out_arrays):
+            np.testing.assert_array_equal(in_array, out_array)
+
+    @staticmethod
+    async def delay_iterable(iterable, delay):
+        for i in iterable:
+            await asyncio.sleep(delay)
+            yield i
+
+    @staticmethod
+    def save(drop: DataDROP, input, delay):
+        asyncio.run(droputils.save_npy_stream(drop, input))
+
+    @staticmethod
+    def load(drop: DataDROP, delay):
+        asyncio.run(asyncstdlib.list(droputils.load_npy_stream(drop, delay)))
 
     def test_no_write_to_file_drop(self):
         """Check that FileDrops can be *not* written"""

--- a/docs/development/data_development/data_index.rst
+++ b/docs/development/data_development/data_index.rst
@@ -14,6 +14,20 @@ Different from most other frameworks |daliuge| makes data components first class
 * Abstraction of the I/O interface particularities of the underlying data storage mechanism.
 * Implementation of the DALiuGE data state engine, which is the |daliuge| mechansim to drive the execution of the workflow graphs.
 
+DataDROP Concepts
+=================
+
+DataDROP
+DropStates
+DROPPhases
+DropLink
+ChecksumTypes
+
+Streaming Data
+==============
+
+ExecutionMode
+
 Components
 ==========
 

--- a/docs/development/data_development/data_streaming.rst
+++ b/docs/development/data_development/data_streaming.rst
@@ -1,0 +1,53 @@
+.. _data_streaming:
+
+Synchronous Streaming
+---------------------
+
+This form of data streaming connects an app producer with an app consumer via the
+appdrop write method and dataWritten callback method. This effectively bypasses
+the datadrop component which removes the serialization performance overhead, but
+does not benefit from subprocessing parallelism without data buffering within the
+appdrop.
+
+Asynchronous Streaming (Proposed)
+---------------------------------
+
+Async streaming uses async interface such that drop subprocesses
+executing run() can use an async loop to await multiple io bound operations.
+This has the added benefit of utilizing subprocesses and handling multiple data
+streams at the cost of handling back-pressure in data drops.
+
+Some approaches are:
+
+asyncio and AsyncIterable - async-pull model
+uses asyncio loop
+
+ReactiveX for Python (RxPy) - async-push model
+uses reactivex loop
+
+asyncio and aioreactive - async-push and async-pull models
+uses asyncio loop
+
+Back-Pressure
+"""""""""""""
+
+Back pressure is when a stream is outputting items more rapidly than an operator
+can consume them.
+
+A cold stream can begin building back pressure until an observer sees fit to subscribe
+and consume them. A cold stream will always produce the same sequence regardless of
+when and how fast the observer consumes them. Synonymous to TCP.
+
+A hot stream begins to emit immediately when it is created. A hot stream creates items
+at its own pace and it's up to the observer to keep up. Synonymous to UDP.
+
+https://reactivex.io/documentation/operators/backpressure.html
+
+Single and Multi Stream
+"""""""""""""""""""""""
+
+AsyncMultiStream are hot
+
+AsyncSingleStream are cold
+
+See https://github.com/dbrattli/aioreactive


### PR DESCRIPTION
This change adds an alternative approach to stream buffering that utilizes dataDrops for controlling the stream backbuffer rather than passing directly to the next appdrop via callback. The motive for buffering is to allow subprocesses to asynchronously process streams rather than immediately invoke a chain of callbacks, all of which would be executed by the first streaming drop process.