### PR TITLE
Fix broken template variable expansion

### DIFF
--- a/daliuge-engine/dlg/manager/web/dim.html
+++ b/daliuge-engine/dlg/manager/web/dim.html
@@ -90,18 +90,9 @@
         selectedNode = null;
     }
     var serverUrl = '{{serverUrl}}';
-    var dmPort = {
-    {
-        dmPort
-    }
-    }
-
-    var nodes = {
-    {
-        !nodes
-    }
-    }
-
+    var dmPort = {{dmPort}}
+    var nodes = {{!nodes}}
+    
     var refreshSessionListBtn = d3.select('#refreshSessionListBtn');
     var addSessionBtn = d3.select('#addSessionBtn');
     var sessionsTbodyEl = d3.select('#sessionsTable tbody');

--- a/daliuge-engine/dlg/manager/web/dm.html
+++ b/daliuge-engine/dlg/manager/web/dm.html
@@ -66,11 +66,7 @@
 <script type="text/javascript">
 
     var serverUrl = '{{serverUrl}}';
-    var reset = {
-    {
-        reset
-    }
-    }
+    var reset = {{reset}};
 
     var tbodyEl = d3.select("#sessionsTable tbody");
     var refreshBtn = d3.select('#refreshListBtn');


### PR DESCRIPTION
In 31c8e3a a lot of code was re-formatted, but the formatting tool
missed the fact that the dm.html file is not used as-is, but is rather a
template. In this template, variable expansion happens with double
curly braces, which must be together, but the automatic formatting
interpreted them as code block delimiters and placed them each on a new
line.

This bug was prevent the web UI from functioning correctly, with the
problem becoming clear once the browser developer console was fired up.

This was found while working on YAN-999.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>