### PR TITLE
Correctly calculate roots of PG before submission

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -179,7 +179,8 @@ def get_roots(pg_spec):
     all_oids = set()
     nonroots = set()
     for dropspec in pg_spec:
-
+        if "oid" not in dropspec:  # Assumed to be reprodata / other non-drop elements
+            continue
         oid = dropspec["oid"]
         all_oids.add(oid)
 

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -179,8 +179,18 @@ def get_roots(pg_spec):
     all_oids = set()
     nonroots = set()
     for dropspec in pg_spec:
-        if "oid" not in dropspec:  # Assumed to be reprodata / other non-drop elements
+
+        # Assumed to be reprodata / other non-drop elements
+        #
+        # TODO (rtobar): Note that this should be a temporary measure.
+        # In principle the pg_spec given here should be a graph, which (until
+        # recently) consisted on drop specifications only. The fact that repro
+        # data is now appended at the end of some graphs highlights the need for
+        # a more formal specification of graphs and other pieces of data that we
+        # move through the system.
+        if "oid" not in dropspec:
             continue
+
         oid = dropspec["oid"]
         all_oids.add(oid)
 

--- a/daliuge-engine/dlg/deploy/common.py
+++ b/daliuge-engine/dlg/deploy/common.py
@@ -185,7 +185,7 @@ def submit(
     """
     client = _get_client(host, port, timeout)
     session_id = session_id or "%f" % (time.time())
-    completed_uids = droputils.get_roots(pg[:-1])
+    completed_uids = droputils.get_roots(pg)
     with client:
         client.create_session(session_id)
         logger.info("Session %s created", session_id)


### PR DESCRIPTION
The removal of the last node in the PG seems to correspond to the logic
of that last node having the reproducibility data of the graph instead
of an actual drop specification (this is the implication I gathered by
looking at the rest of the changes in 58138a30b, the commit where this
change was introduced). This reproducibility data is optional though,
and therefore the "dlg submit" tool, via this submit() function, was
broken and removed the last drop specification from the calculation of
the graph roots, which in turn had the effect that the session didn't
trigger one of the roots of the graph at graph submission time, leaving
the graph in Running state forever.

This change fixes the submission of "normal" graphs (i.e., without the
extra reproducibility data object at the end), making the tool usable
for existing graphs. This will clearly break graphs *with* the
reproducibility data, but those are still fewer in number.

I found this problem while working on YAN-999.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>