### PR TITLE
Speedup instantiation of bigger graphs

### DIFF
--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -30,8 +30,6 @@ import logging
 
 from dlg.common.reproducibility.constants import ReproducibilityFlags
 
-from numpy import isin
-
 from . import droputils
 from .apps.socket_listener import SocketListenerApp
 from .common import Categories
@@ -53,7 +51,7 @@ from .environmentvar_drop import EnvironmentVarDROP
 from dlg.parset_drop import ParameterSetDROP
 from .exceptions import InvalidGraphException
 from .json_drop import JsonDROP
-from .common import Categories, DropType
+from .common import DropType
 
 
 STORAGE_TYPES = {

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -137,10 +137,10 @@ def removeUnmetRelationships(dropSpecList):
     normalise_oid = lambda oid: next(iter(oid)) if isinstance(oid, dict) else oid
 
     # Step #1: Get all OIDs
-    oids = []
+    oids = set()
     for dropSpec in dropSpecList:
         oid = normalise_oid(dropSpec["oid"])
-        oids.append(oid)
+        oids.add(oid)
 
     # Step #2: find unmet relationships and remove them from the original
     # DROP spec, keeping track of them

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -188,9 +188,7 @@ def removeUnmetRelationships(dropSpecList):
                 to_delete.append(rel)
 
         for rel in to_delete:
-            ds = dropSpec[rel]
-            ds = list(ds.keys())[0] if isinstance(ds, dict) else ds
-            del ds
+            del dropSpec[rel]
 
     return unmetRelationships
 

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -134,19 +134,19 @@ def addLink(linkType, lhDropSpec, rhOID, force=False):
 def removeUnmetRelationships(dropSpecList):
     unmetRelationships = []
 
+    normalise_oid = lambda oid: next(iter(oid)) if isinstance(oid, dict) else oid
+
     # Step #1: Get all OIDs
     oids = []
     for dropSpec in dropSpecList:
-        oid = dropSpec["oid"]
-        oid = list(oid.keys())[0] if isinstance(oid, dict) else oid
+        oid = normalise_oid(dropSpec["oid"])
         oids.append(oid)
 
     # Step #2: find unmet relationships and remove them from the original
     # DROP spec, keeping track of them
     for dropSpec in dropSpecList:
 
-        this_oid = dropSpec["oid"]
-        this_oid = list(this_oid.keys())[0] if isinstance(this_oid, dict) else this_oid
+        this_oid = normalise_oid(dropSpec["oid"])
         to_delete = []
 
         for rel in dropSpec:
@@ -160,7 +160,7 @@ def removeUnmetRelationships(dropSpecList):
                 # removing them from the current DROP spec
                 ds = dropSpec[rel]
                 if isinstance(ds[0], dict):
-                    ds = [list(d.keys())[0] for d in ds]
+                    ds = [next(iter(d)) for d in ds]
                 missingOids = [oid for oid in ds if oid not in oids]
                 for oid in missingOids:
                     unmetRelationships.append(DROPRel(oid, link, this_oid))
@@ -176,8 +176,7 @@ def removeUnmetRelationships(dropSpecList):
                 link = __TOONE[rel]
 
                 # Check if OID is missing
-                oid = dropSpec[rel]
-                oid = list(oid.keys())[0] if isinstance(oid, dict) else oid
+                oid = normalise_oid(dropSpec[rel])
                 if oid in oids:
                     continue
 


### PR DESCRIPTION
These changes speed up the daliuge-engine runtime when submitting big graphs, which is done by our `test_scalability` test. I noticed the test was taking longer than it used to: about 50, 60 seconds now when it previously finished in less than 10. After some profiling I found two bottlenecks:
 * The `removeUnmetDependencies` function during graph addition (before actual deployment) due to unnecessary object creation in tight loops.
 * The `drop._extract_members` function, which wasn't using caching between different drop instantiations.

With these changes the `test_scalability` walltime comes down by ~40 seconds; after these are applied most of the time is spent building reproducibility data on the graph, but that can be tackled separately.