### PR TITLE
Lessen resource usage when multiprocessing not in use

### DIFF
--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -275,13 +275,28 @@ class DropProxy(object):
     """
 
     def __init__(self, rpc_client, hostname, port, sessionId, uid):
-        self.rpc_client = ZeroRPCClient()
+        # The current version of multiprocessing support creates an RPCClient
+        # per DropProxy, disregarding the rpc_client parameter given here.
+        # This uses too many resources though, but is only needed if the NM is
+        # instructed to use multiprocessing support. To avoid this resource
+        # over-usage we then detect if the given rpc_client (an instance of
+        # NodeManagerBase) has been started with multiprocessing support (which
+        # is confusingly bound to there being a *thread* pool too) and only if
+        # we detect the situation we create our own RPCClient; otherwise we use
+        # the given rpc_client as is.
+        if hasattr(rpc_client, "_threadpool") and rpc_client._threadpool:
+            self.rpc_client = ZeroRPCClient()
+            self._own_rpc_client = True
+        else:
+            self.rpc_client = rpc_client
+            self._own_rpc_client = False
         self.hostname = hostname
         self.port = port
         self.session_id = sessionId
         self.uid = uid
         logger.debug("Created %r", self)
-        self.rpc_client.start()
+        if self._own_rpc_client:
+            self.rpc_client.start()
 
     def handleEvent(self, evt):
         pass
@@ -304,4 +319,5 @@ class DropProxy(object):
         )
 
     def __del__(self):
-        self.rpc_client.shutdown()
+        if self._own_rpc_client:
+            self.rpc_client.shutdown()


### PR DESCRIPTION
One of the problems with the current multiprocessing support in daliuge
is that it requires too many resources. This is because each DropProxy
object is creating its own RPCClient, which internally create their own
ZMQ context. This not only increases the runtime requirements of the
system (more objects need to be created, etc.) but also puts pressure on
system resources. This situation is described in detail in YAN-976, and the
test/manager/test_dm.py::TestDM::test_many_relationships unit test in
particular triggers this issue with ease.

This commit implements a partial fix for this issue. While it doesn't
take care of the problem itself, it identifies when a DropProxy is
created from a NodeManager that is *not* using multiprocessing support,
and avoid creating an RPCClient instance itself, instead using the
client provided as a parameter. This brings stability back to the
daliuge runtime when multiprocessing isn't used, containing the resource
over-usage to only when strictly necessary.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>