### PR TITLE
Skip multiprocessing tests by default

### DIFF
--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -648,6 +648,7 @@ class TestDM(NodeManagerTestsBase, unittest.TestCase):
 
 
 
-@unittest.skipIf(multiprocessing.cpu_count() < 4, "Not enough threads to test multiprocessing")
+@unittest.skipUnless(os.environ.get('DALIUGE_RUN_MP_TESTS', '0') == '1',
+                     "Unstable multiprocessing tests not run by default")
 class TestDMParallel(NodeManagerTestsBase, unittest.TestCase):
     nm_threads = multiprocessing.cpu_count()


### PR DESCRIPTION
These tests are not stable (see YAN-976 for some examples), but their
instability has been hidden by the fact that they are never run on
Travis anyway. On my laptop though they often cause issues, making the
whole test suite unreliable.

This commit changes the skip condition for the multiprocessing tests to
only run if a specific environment variable is set (it isn't by
default). This will allow us to continue hiding the problem, but in a
more controller manner, while also giving us an easy switch to turn the
tests on when we start addressing their problems.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>