### PR TITLE
DLM revisit: fine-grained control on which tasks can run

### DIFF
--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1819,6 +1819,14 @@ class InMemoryDROP(DataDROP):
     A DROP that points data stored in memory.
     """
 
+    # Allow in-memory drops to be automatically removed by default
+    def __init__(self, *args, **kwargs):
+        if 'precious' not in kwargs:
+            kwargs['precious'] = False
+        if 'expireAfterUse' not in kwargs:
+            kwargs['expireAfterUse'] = True
+        super().__init__(*args, **kwargs)
+
     def initialize(self, **kwargs):
         args = []
         if "pydata" in kwargs:

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -43,13 +43,10 @@ import threading
 import time
 import re
 import sys
-import inspect
 import binascii
 from typing import List, Union
 
 import numpy as np
-import pyarrow.plasma as plasma
-import six
 from dlg.common.reproducibility.constants import (
     ReproducibilityFlags,
     REPRO_DEFAULT,
@@ -58,7 +55,6 @@ from dlg.common.reproducibility.constants import (
 )
 from dlg.common.reproducibility.reproducibility import common_hash
 from merklelib import MerkleTree
-from six import BytesIO
 
 from .ddap_protocol import (
     ExecutionMode,

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -208,7 +208,7 @@ class DataLifecycleManager:
     An object that deals with automatic data drop replication and deletion.
     """
 
-    def __init__(self, check_period=10, cleanup_period=100, enable_drop_replication=True):
+    def __init__(self, check_period=0, cleanup_period=0, enable_drop_replication=False):
         self._reg = registry.InMemoryRegistry()
         self._listener = DropEventListener(self)
         self._enable_drop_replication = enable_drop_replication

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -139,14 +139,13 @@ class DataLifecycleManagerBackgroundTask(threading.Thread):
     signaled to stop
     """
 
-    def __init__(self, dlm, period, finishedEvent):
+    def __init__(self, dlm, period):
         threading.Thread.__init__(self, name="DLMBackgroundTask")
         self._dlm = dlm
         self._period = period
-        self._finishedEvent = finishedEvent
 
     def run(self):
-        ev = self._finishedEvent
+        ev = self._dlm._finishedEvent
         dlm = self._dlm
         p = self._period
         while True:
@@ -226,17 +225,16 @@ class DataLifecycleManager(object):
 
     def startup(self):
         # Spawn the background threads
-        finishedEvent = threading.Event()
-        dropChecker = DROPChecker(self, self._checkPeriod, finishedEvent)
+        self._finishedEvent = threading.Event()
+        dropChecker = DROPChecker(self, self._checkPeriod)
         dropChecker.start()
         dropGarbageCollector = DROPGarbageCollector(
-            self, self._cleanupPeriod, finishedEvent
+            self, self._cleanupPeriod
         )
         dropGarbageCollector.start()
 
         self._dropChecker = dropChecker
         self._dropGarbageCollector = dropGarbageCollector
-        self._finishedEvent = finishedEvent
 
     def cleanup(self):
         logger.info("Cleaning up the DLM")

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -139,10 +139,11 @@ class DataLifecycleManagerBackgroundTask(threading.Thread):
     signaled to stop
     """
 
-    def __init__(self, dlm, period):
+    def __init__(self, name, dlm, period):
         threading.Thread.__init__(self, name="DLMBackgroundTask")
         self._dlm = dlm
         self._period = period
+        logger.info("Starting %s running every %.3f [s]", name, self._period)
 
     def run(self):
         ev = self._dlm._finishedEvent
@@ -232,11 +233,17 @@ class DataLifecycleManager:
     def startup(self):
         # Spawn the background threads
         if self._check_period:
-            self._drop_checker = DROPChecker(self, self._check_period)
+            self._drop_checker = DROPChecker(
+                "DropChecker",
+                self,
+                self._check_period
+            )
             self._drop_checker.start()
         if self._cleanup_period:
             self._drop_garbage_collector = DROPGarbageCollector(
-                self, self._cleanup_period
+                "DropGarbageCollector",
+                self,
+                self._cleanup_period
             )
             self._drop_garbage_collector.start()
 

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -292,10 +292,8 @@ class DataLifecycleManager:
             # are finished using this DROP
             if drop.expireAfterUse:
                 allDone = all(
-                    [
-                        c.execStatus in [AppDROPStates.FINISHED, AppDROPStates.ERROR]
-                        for c in drop.consumers
-                    ]
+                    c.execStatus in [AppDROPStates.FINISHED, AppDROPStates.ERROR]
+                    for c in drop.consumers
                 )
                 if not allDone:
                     continue

--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -350,8 +350,24 @@ def dlgNM(parser, args):
         "--no-dlm",
         action="store_true",
         dest="noDLM",
-        help="Don't start the Data Lifecycle Manager on this NodeManager",
-        default=True,
+        help="(DEPRECATED) Don't start the Data Lifecycle Manager on this NodeManager",
+    )
+    parser.add_option(
+        "--dlm-check-period",
+        type="float",
+        help="Time in seconds between background DLM drop status checks (defaults to 10)",
+        default=10
+    )
+    parser.add_option(
+        "--dlm-cleanup-period",
+        type="float",
+        help="Time in seconds between background DLM drop automatic cleanups (defaults to 100)",
+        default=100
+    )
+    parser.add_option(
+        "--dlm-enable-replication",
+        action="store_true",
+        help="Turn on data drop automatic replication (off by default)",
     )
     parser.add_option(
         "--dlg-path",
@@ -388,13 +404,22 @@ def dlgNM(parser, args):
     )
     (options, args) = parser.parse_args(args)
 
+    # No logging setup at this point yet
+    if options.noDLM:
+        print("WARNING: --no-dlm is deprecated, use the --dlm-* options instead")
+        options.dlm_check_period = 0
+        options.dlm_cleanup_period = 0
+        options.dlm_enable_replication = False
+
     # Add DM-specific options
     # Note that the host we use to expose the NodeManager itself through Pyro is
     # also used to expose the Sessions it creates
     options.dmType = NodeManager
     options.dmArgs = ()
     options.dmKwargs = {
-        "useDLM": not options.noDLM,
+        "dlm_check_period": options.dlm_check_period,
+        "dlm_cleanup_period": options.dlm_cleanup_period,
+        "dlm_enable_replication": options.dlm_enable_replication,
         "dlgPath": options.dlgPath,
         "host": options.host,
         "error_listener": options.errorListener,

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -135,7 +135,14 @@ class NodeManagerBase(DROPManager):
         logdir=utils.getDlgLogsDir(),
     ):
 
-        self._dlm = DataLifecycleManager() if useDLM else None
+        dlm_params = {}
+        if useDLM:
+            dlm_params = {
+                'check_period': 10,
+                'cleanup_period': 100,
+                'enable_drop_replication': True
+            }
+        self._dlm = DataLifecycleManager(**dlm_params)
         self._sessions = {}
         self.logdir = logdir
 

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -127,7 +127,9 @@ class NodeManagerBase(DROPManager):
 
     def __init__(
         self,
-        useDLM=False,
+        dlm_check_period=0,
+        dlm_cleanup_period=0,
+        dlm_enable_replication=False,
         dlgPath=None,
         error_listener=None,
         event_listeners=[],
@@ -135,14 +137,11 @@ class NodeManagerBase(DROPManager):
         logdir=utils.getDlgLogsDir(),
     ):
 
-        dlm_params = {}
-        if useDLM:
-            dlm_params = {
-                'check_period': 10,
-                'cleanup_period': 100,
-                'enable_drop_replication': True
-            }
-        self._dlm = DataLifecycleManager(**dlm_params)
+        self._dlm = DataLifecycleManager(
+            check_period=dlm_check_period,
+            cleanup_period=dlm_cleanup_period,
+            enable_drop_replication=dlm_enable_replication
+        )
         self._sessions = {}
         self.logdir = logdir
 
@@ -271,8 +270,7 @@ class NodeManagerBase(DROPManager):
                     )
                 drop._sessID = sessionId
                 self._memoryManager.register_drop(drop.uid, sessionId)
-            if self._dlm:
-                self._dlm.addDrop(drop)
+            self._dlm.addDrop(drop)
 
             # Remote event forwarding
             evt_listener = NMDropEventListener(self, sessionId)

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -571,15 +571,11 @@ class RpcMixIn(rpc.RPCClient, rpc.RPCServer):
 class NodeManager(EventMixIn, RpcMixIn, NodeManagerBase):
     def __init__(
         self,
-        useDLM=True,
-        dlgPath=utils.getDlgPath(),
-        error_listener=None,
-        event_listeners=[],
-        max_threads=0,
-        logdir=utils.getDlgLogsDir(),
         host=None,
         rpc_port=constants.NODE_DEFAULT_RPC_PORT,
         events_port=constants.NODE_DEFAULT_EVENTS_PORT,
+        *args,
+        **kwargs
     ):
         # We "just know" that our RpcMixIn will have a create_context static
         # method, which in reality means we are using the ZeroRPCServer class
@@ -587,9 +583,7 @@ class NodeManager(EventMixIn, RpcMixIn, NodeManagerBase):
         host = host or "127.0.0.1"
         EventMixIn.__init__(self, host, events_port)
         RpcMixIn.__init__(self, host, rpc_port)
-        NodeManagerBase.__init__(
-            self, useDLM, dlgPath, error_listener, event_listeners, max_threads, logdir
-        )
+        NodeManagerBase.__init__(self, *args, **kwargs)
 
     def shutdown(self):
         super(NodeManager, self).shutdown()

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -187,7 +187,12 @@ class NodeManagerBase(DROPManager):
         debugging = logger.isEnabledFor(logging.DEBUG)
         self._logging_event_listener = LogEvtListener() if debugging else None
 
+    def start(self):
+        super().start()
+        self._dlm.startup()
+
     def shutdown(self):
+        self._dlm.cleanup()
         if self._threadpool:
             self._threadpool.close()
             self._threadpool.join()

--- a/daliuge-engine/dlg/testutils.py
+++ b/daliuge-engine/dlg/testutils.py
@@ -75,10 +75,3 @@ class ManagerStarter(object):
         return self._start_manager_in_thread(
             port, MasterManager, CompositeManagerRestServer, nm_hosts
         )
-
-    def start_mm_in_thread(
-        self, nm_hosts=["127.0.0.1"], port=constants.MASTER_DEFAULT_REST_PORT
-    ):
-        return self._start_manager_in_thread(
-            port, MasterManager, CompositeManagerRestServer, nm_hosts
-        )

--- a/daliuge-engine/test/lifecycle/test_dlm.py
+++ b/daliuge-engine/test/lifecycle/test_dlm.py
@@ -76,7 +76,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertEqual(1, len(manager.getDropUids(drop)))
 
     def test_expiringNormalDrop(self):
-        with dlm.DataLifecycleManager(checkPeriod=0.5) as manager:
+        with dlm.DataLifecycleManager(check_period=0.5) as manager:
             drop = FileDROP("oid:A", "uid:A1", expectedSize=1, lifespan=0.5)
             manager.addDrop(drop)
 
@@ -89,7 +89,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertEqual(DROPStates.EXPIRED, drop.status)
 
     def test_lostDrop(self):
-        with dlm.DataLifecycleManager(checkPeriod=0.5) as manager:
+        with dlm.DataLifecycleManager(check_period=0.5) as manager:
             drop = FileDROP(
                 "oid:A", "uid:A1", expectedSize=1, lifespan=10, precious=False
             )
@@ -106,7 +106,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertEqual(DROPPhases.LOST, drop.phase)
 
     def test_cleanupExpiredDrops(self):
-        with dlm.DataLifecycleManager(checkPeriod=0.5, cleanupPeriod=2) as manager:
+        with dlm.DataLifecycleManager(check_period=0.5, cleanup_period=2) as manager:
             drop = FileDROP(
                 "oid:A", "uid:A1", expectedSize=1, lifespan=1, precious=False
             )
@@ -134,7 +134,7 @@ class TestDataLifecycleManager(unittest.TestCase):
         different values, and after they are used we check whether their data
         is still there or not
         """
-        with dlm.DataLifecycleManager(checkPeriod=0.5, cleanupPeriod=2) as manager:
+        with dlm.DataLifecycleManager(check_period=0.5, cleanup_period=2) as manager:
             a = DirectoryContainer(
                 "a",
                 "a",
@@ -171,7 +171,3 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertFalse(a.exists())
             self.assertTrue(b.exists())
             b.delete()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/daliuge-engine/test/lifecycle/test_dlm.py
+++ b/daliuge-engine/test/lifecycle/test_dlm.py
@@ -58,7 +58,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             manager.addDrop(drop)
 
     def test_dropCompleteTriggersReplication(self):
-        with dlm.DataLifecycleManager() as manager:
+        with dlm.DataLifecycleManager(enable_drop_replication=True) as manager:
             drop = FileDROP("oid:A", "uid:A1", expectedSize=1)
             manager.addDrop(drop)
             self._writeAndClose(drop)

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -113,7 +113,6 @@ class NMTestsMixIn(object):
     def _start_dm(self, threads=0, **kwargs):
         host, events_port, rpc_port = nm_conninfo(len(self._dms))
         nm = NodeManager(
-            useDLM=False,
             host=host,
             events_port=events_port,
             rpc_port=rpc_port,


### PR DESCRIPTION
This set of commits implement a change in how the DLM can be configured. While previously it could be either fully enabled or fully disabled, it now can be started in such a way that users can select which of its features should be on or off. These features are:
 * Automatic data replication
 * Automatic data expiration
 * Automatic data deletion (needs the former to work)

These changes are reflected not only in the DLM API, but also on the usage of new command-line switches for the `dlg nm` command. The old `--no-dlm` switch is still present but deprecated, and translates to disabling all features on the DLM.

Now that more fine-grained behavior can be used, the default is to *enable* data expiration and deletion, but keep data replication disabled. This is in the spirit of keeping system resource usage low throughout graph executions.

Finally, I've changed the `InMemoryDROP` class so that it is *never* flagged as "precious". The preciousness flag affects whether the DLM can expire and delete a data drop, with precious data never being deleted. Since in-memory drops are volatile in nature it makes no sense to keep them around after they are fully used, so they can be automatically removed.

This implements https://jira.skatelescope.org/browse/YAN-999. See the ticket for a small video demonstrating this feature.