### PR TITLE
YAN-1048 Remove memory leaks

### DIFF
--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -269,19 +269,22 @@ class RandomArrayApp(BarrierAppDROP):
     size = dlg_int_param("size", 100)
     marray = []
 
-    def initialize(self, **kwargs):
+    def initialize(self, keep_array=False, **kwargs):
         super(RandomArrayApp, self).initialize(**kwargs)
+        self._keep_array = keep_array
 
     def run(self):
         # At least one output should have been added
         outs = self.outputs
         if len(outs) < 1:
             raise Exception("At least one output should have been added to %r" % self)
-        self.generateRandomArray()
+        marray = self.generateRandomArray()
+        if self._keep_array:
+            self.marray = marray
         for o in outs:
-            d = pickle.dumps(self.marray)
+            d = pickle.dumps(marray)
             o.len = len(d)
-            o.write(pickle.dumps(self.marray))
+            o.write(d)
 
     def generateRandomArray(self):
         if self.integer:
@@ -292,7 +295,7 @@ class RandomArrayApp(BarrierAppDROP):
             # generate an array of self.size floats with numbers between
             # self.low and self.high
             marray = (np.random.random(size=self.size) + self.low) * self.high
-        self.marray = marray
+        return marray
 
     def _getArray(self):
         return self.marray

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -456,6 +456,16 @@ class DataLifecycleManager:
         #       perform this task, like using threading.Timers (probably not) or
         #       any other that doesn't mean looping over all DROPs
 
+    def remove_drops(self, drop_oids):
+        """
+        Remove drops from DLM's monitoring
+        """
+        self._drops = {
+            oid: drop
+            for oid, drop in self._drops.items()
+            if oid not in drop_oids
+        }
+
     def handleOpenedDrop(self, oid, uid):
         drop = self._drops[uid]
         if drop.status == DROPStates.COMPLETED:

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -307,6 +307,7 @@ class NodeManagerBase(DROPManager):
         session = self._sessions.pop(sessionId)
         if hasattr(self, "_memoryManager"):
             self._memoryManager.shutdown_session(sessionId)
+        self._dlm.remove_drops(session.drops)
         session.destroy()
 
     def getSessionIds(self):

--- a/daliuge-engine/test/apps/test_simple.py
+++ b/daliuge-engine/test/apps/test_simple.py
@@ -113,7 +113,7 @@ class TestSimpleApps(unittest.TestCase):
 
     def test_randomarrayapp(self):
         i = NullDROP("i", "i")
-        c = RandomArrayApp("c", "c")
+        c = RandomArrayApp("c", "c", keep_array=True)
         o = InMemoryDROP("o", "o")
         c.addInput(i)
         c.addOutput(o)


### PR DESCRIPTION
These commits remove memory leaks present in some daliuge built-in applications. In particular the RandomArray and PyFunc apps held some data in the drop instance. In the case of the former this was used for unit testing, so I've left the behavior in, but under a new component parameter (defaulting to *not* keep the data around). In the latter case holding onto the data was unnecessary.

We also evidenced an effect where deleting a session wouldn't release all the memory associated to all its drops, even though drops should be all destroyed by that time. This turned out to be a side-effect of turning on the DLM: even after a session was deleted, its drops would still be tracked by the DLM. I have therefore added the necessary code to untrack drops from sessions that are about to be destroyed, which in turn should cause them to be deleted when the session goes away.