### PR TITLE
Session status view now updates with session status correctly.

### DIFF
--- a/daliuge-engine/dlg/manager/web/static/js/dm.js
+++ b/daliuge-engine/dlg/manager/web/static/js/dm.js
@@ -623,7 +623,7 @@ function startGraphStatusUpdates(serverUrl, sessionId, selectedNode, delay,
 
 			var allCompleted = statuses.reduce(function(prevVal, curVal, idx, arr) {
 				var cur_status = get_status_name(curVal);
-				return prevVal && (cur_status == 'completed' || cur_status == 'finished' || cur_status == 'error' || cur_status == 'cancelled' || cur_status == 'skipped');
+				return prevVal && (cur_status == 'completed' || cur_status == 'finished' || cur_status == 'error' || cur_status == 'cancelled' || cur_status == 'skipped' || cur_status == 'deleted' || cur_status == 'expired');
 			}, true);
 			if (!allCompleted) {
 				updateStatesDelayTimer = d3.timer(updateStates, delay);


### PR DESCRIPTION
reduce function now accepts 'expired', 'deleted' drops contributing to a 'finished' status - which is in fact the case but was not showing as such before.