### PR TITLE
Liu 277 - Changing colour of expired and deleted drops 

### DIFF
--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -361,8 +361,8 @@ def dlgNM(parser, args):
     parser.add_option(
         "--dlm-cleanup-period",
         type="float",
-        help="Time in seconds between background DLM drop automatic cleanups (defaults to 100)",
-        default=100
+        help="Time in seconds between background DLM drop automatic cleanups (defaults to 30)",
+        default=30
     )
     parser.add_option(
         "--dlm-enable-replication",

--- a/daliuge-engine/dlg/manager/web/static/css/progressBar.css
+++ b/daliuge-engine/dlg/manager/web/static/css/progressBar.css
@@ -19,7 +19,7 @@
   }
   
   .node.expired :first-child, rect.expired {
-    fill: #700000;
+    fill: #888888;
   }
   
   .node.cancelled :first-child, rect.cancelled {
@@ -31,7 +31,7 @@
   }
 
   .node.deleted :first-child, rect.deleted {
-    color: #700000;
+    color: #cccccc;
   }
   
   /* AppDROP states */


### PR DESCRIPTION
This MR changes the colours of expired and deleted drops to a dark grey and black with white font respectively.
Additionally, this PR reduces the default garbage collection period to 30 seconds (down from 100).

Attached is an imaging showing deleted, expired and cancelled drops for reference.

![DeletedExpiredCancelled](https://user-images.githubusercontent.com/30886786/177905689-8d36e3b4-12ea-4d36-b077-c239c63652a7.png)
