### PR TITLE
Yan 1070 - add data_hash and signature attributes from BlockDAG to EAGLE palette JSON

### DIFF
--- a/.github/workflows/create-palettes.yml
+++ b/.github/workflows/create-palettes.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y doxygen xsltproc
+          pip install BlockDAG
 
       - name: Configure git
         run: |

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -555,7 +555,7 @@ def create_palette_node_from_params(params):
 def write_palette_json(outputfile, nodes, gitrepo, version, block_dag):
     # add hashes from block_dag to the nodes
     for i in range(len(nodes)):
-        nodes[i].dataHash = block_dag[i].data_hash;
+        nodes[i].dataHash = block_dag[i]['data_hash'];
 
     # create the palette object
     palette = {

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -555,7 +555,7 @@ def create_palette_node_from_params(params):
 def write_palette_json(outputfile, nodes, gitrepo, version, block_dag):
     # add hashes from block_dag to the nodes
     for i in range(len(nodes)):
-        nodes[i].dataHash = block_dag[i]['data_hash'];
+        nodes[i]['dataHash'] = block_dag[i]['data_hash'];
 
     # create the palette object
     palette = {

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -14,6 +14,8 @@ import xml.etree.ElementTree as ET
 import math
 from enum import Enum
 
+from blockdag import build_block_dag
+
 next_key = -1
 
 # NOTE: not sure if all of these are actually required
@@ -71,6 +73,14 @@ KNOWN_FIELD_TYPES = [
     "ApplicationArgument",
     "InputPort",
     "OutputPort"
+]
+
+BLOCKDAG_DATA_FIELDS = [
+    "inputPorts",
+    "outputPorts",
+    "applicationArgs",
+    "category",
+    "fields"
 ]
 
 class Language(Enum):
@@ -542,7 +552,7 @@ def create_palette_node_from_params(params):
     )
 
 
-def write_palette_json(outputfile, nodes, gitrepo, version):
+def write_palette_json(outputfile, nodes, gitrepo, version, signature):
     palette = {
         "modelData": {
             "fileType": "palette",
@@ -553,6 +563,7 @@ def write_palette_json(outputfile, nodes, gitrepo, version):
             "filePath": outputfile,
             "sha": version,
             "git_url": gitrepo,
+            "signature": signature
         },
         "nodeDataArray": nodes,
         "linkDataArray": [],
@@ -1052,9 +1063,11 @@ if __name__ == "__main__":
                     if not alreadyPresent:
                         nodes.append(n)
 
+    # add signature for whole palette using BlockDAG
+    palette_signature = build_block_dag(nodes, [], data_fields=BLOCKDAG_DATA_FIELDS)
 
     # write the output json file
-    write_palette_json(outputfile, nodes, gitrepo, version)
+    write_palette_json(outputfile, nodes, gitrepo, version, palette_signature)
     logging.info("Wrote " + str(len(nodes)) + " component(s)")
 
     # cleanup the output directory

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -1064,7 +1064,10 @@ if __name__ == "__main__":
                         nodes.append(n)
 
     # add signature for whole palette using BlockDAG
-    palette_signature = build_block_dag(nodes, [], data_fields=BLOCKDAG_DATA_FIELDS)
+    vertices = {}
+    for i in range(len(nodes)):
+        vertices[i] = nodes[i]
+    palette_signature = build_block_dag(vertices, [], data_fields=BLOCKDAG_DATA_FIELDS)
 
     # write the output json file
     write_palette_json(outputfile, nodes, gitrepo, version, palette_signature)

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -1067,10 +1067,10 @@ if __name__ == "__main__":
     vertices = {}
     for i in range(len(nodes)):
         vertices[i] = nodes[i]
-    palette_signature = build_block_dag(vertices, [], data_fields=BLOCKDAG_DATA_FIELDS)
+    block_dag = build_block_dag(vertices, [], data_fields=BLOCKDAG_DATA_FIELDS)
 
     # write the output json file
-    write_palette_json(outputfile, nodes, gitrepo, version, palette_signature)
+    write_palette_json(outputfile, nodes, gitrepo, version, block_dag.signature)
     logging.info("Wrote " + str(len(nodes)) + " component(s)")
 
     # cleanup the output directory

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -407,8 +407,6 @@ def create_palette_node_from_params(params):
     outputLocalPorts = []
     fields = []
     applicationArgs = []
-    gitrepo = os.environ.get("GIT_REPO")
-    version = os.environ.get("PROJECT_VERSION")
 
     # process the params
     for param in params:
@@ -546,8 +544,10 @@ def create_palette_node_from_params(params):
             "outputAppFields": [],
             "fields": fields,
             "applicationArgs": applicationArgs,
-            "git_url": gitrepo,
-            "sha": version,
+            "repositoryUrl": gitrepo,
+            "commitHash": version,
+            "paletteDownloadUrl": "",
+            "dataHash": "",
         },
     )
 
@@ -566,9 +566,10 @@ def write_palette_json(outputfile, nodes, gitrepo, version, block_dag):
             "repo": "ICRAR/EAGLE_test_repo",
             "readonly": True,
             "filePath": outputfile,
-            "sha": version,
-            "git_url": gitrepo,
-            "signature": block_dag['signature']
+            "repositoryUrl": gitrepo,
+            "commitHash": version,
+            "downloadUrl": "",
+            "signature": block_dag['signature'],
         },
         "nodeDataArray": nodes,
         "linkDataArray": [],
@@ -890,10 +891,12 @@ def create_construct_node(type, node):
         + " component.",
         "fields": [],
         "applicationArgs": [],
-        "git_url": gitrepo,
+        "repositoryUrl": gitrepo,
+        "commitHash": version,
+        "paletteDownloadUrl": "",
+        "dataHash": "",
         "key": get_next_key(),
         "precious": False,
-        "sha": version,
         "streaming": False,
         "text": type + "/" + node["text"],
     }

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -1070,7 +1070,7 @@ if __name__ == "__main__":
     block_dag = build_block_dag(vertices, [], data_fields=BLOCKDAG_DATA_FIELDS)
 
     # write the output json file
-    write_palette_json(outputfile, nodes, gitrepo, version, block_dag.signature)
+    write_palette_json(outputfile, nodes, gitrepo, version, block_dag['signature'])
     logging.info("Wrote " + str(len(nodes)) + " component(s)")
 
     # cleanup the output directory

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -552,7 +552,12 @@ def create_palette_node_from_params(params):
     )
 
 
-def write_palette_json(outputfile, nodes, gitrepo, version, signature):
+def write_palette_json(outputfile, nodes, gitrepo, version, block_dag):
+    # add hashes from block_dag to the nodes
+    for i in range(len(nodes)):
+        nodes[i].dataHash = block_dag[i].data_hash;
+
+    # create the palette object
     palette = {
         "modelData": {
             "fileType": "palette",
@@ -563,12 +568,13 @@ def write_palette_json(outputfile, nodes, gitrepo, version, signature):
             "filePath": outputfile,
             "sha": version,
             "git_url": gitrepo,
-            "signature": signature
+            "signature": block_dag['signature']
         },
         "nodeDataArray": nodes,
         "linkDataArray": [],
     }
 
+    # write palette to file
     with open(outputfile, "w") as outfile:
         json.dump(palette, outfile, indent=4)
 
@@ -1070,7 +1076,7 @@ if __name__ == "__main__":
     block_dag = build_block_dag(vertices, [], data_fields=BLOCKDAG_DATA_FIELDS)
 
     # write the output json file
-    write_palette_json(outputfile, nodes, gitrepo, version, block_dag['signature'])
+    write_palette_json(outputfile, nodes, gitrepo, version, block_dag)
     logging.info("Wrote " + str(len(nodes)) + " component(s)")
 
     # cleanup the output directory


### PR DESCRIPTION
Add data_hash and signature data generated by BlockDAG module into palettes JSON. I use build_block_dag() to generate data for the palette that is being built. It largely follows the example use of build_block_dag() from within the BlockDAG code.

From the BlockDAG data:

- the "data_hash" attributes are copied to each component in the palette (as the attribute "dataHash")
- the "signature" attribute for the whole set of components is copied into the palette (as the attribute "signature")

The additional information will be used in EAGLE to update components within existing graphs.

I'll create a PR for the associated EAGLE work soon.