### PR TITLE
Refactors reprodata to make storage consistent

### DIFF
--- a/daliuge-engine/test/deploy/test_common.py
+++ b/daliuge-engine/test/deploy/test_common.py
@@ -33,15 +33,19 @@ from dlg.testutils import ManagerStarter
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN":{
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 

--- a/daliuge-engine/test/manager/test_dim.py
+++ b/daliuge-engine/test/manager/test_dim.py
@@ -19,16 +19,15 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-from asyncio.log import logger
 import codecs
 import json
 import os
 import time
 import unittest
+from asyncio.log import logger
 
 import pkg_resources
 
-from dlg import runtime
 from dlg import droputils
 from dlg import utils
 from dlg.common import tool, Categories
@@ -38,21 +37,23 @@ from dlg.manager.session import SessionStates
 from dlg.testutils import ManagerStarter
 from test.manager import testutils
 
-
 hostname = "localhost"
-
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 
@@ -384,7 +385,7 @@ class TestREST(LocalDimStarter, unittest.TestCase):
             # we need to add it manually before submitting -- otherwise it will
             # get rejected by the DIM.
             with pkg_resources.resource_stream(
-                "test", "graphs/complex.js"
+                    "test", "graphs/complex.js"
             ) as f:  # @UndefinedVariable
                 complexGraphSpec = json.load(codecs.getreader("utf-8")(f))
                 logger.debug(f"Loaded graph: {f}")
@@ -425,10 +426,10 @@ class TestREST(LocalDimStarter, unittest.TestCase):
             # Wait until the graph has finished its execution. We'll know
             # it finished by polling the status of the session
             while (
-                SessionStates.RUNNING
-                in testutils.get(
-                    self, "/sessions/%s/status" % (sessionId), restPort
-                ).values()
+                    SessionStates.RUNNING
+                    in testutils.get(
+                self, "/sessions/%s/status" % (sessionId), restPort
+            ).values()
             ):
                 time.sleep(0.2)
 

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -44,15 +44,19 @@ random.seed(42)
 hostname = "localhost"
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN":{
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN":{
+        "signature": "b",
+    }
 }
 
 

--- a/daliuge-engine/test/manager/test_mm.py
+++ b/daliuge-engine/test/manager/test_mm.py
@@ -41,15 +41,19 @@ hostname = "127.0.0.1"
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 

--- a/daliuge-engine/test/manager/test_rest.py
+++ b/daliuge-engine/test/manager/test_rest.py
@@ -36,15 +36,19 @@ from dlg.restutils import RestClient
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 
@@ -221,7 +225,7 @@ class TestRest(unittest.TestCase):
         c.addGraphSpec(sid, graph_spec)
         c.deploySession(sid, completed_uids=["a"])
         response = c.session_repro_data(sid)
-        self.assertIsNotNone(response["graph"]["a"]["reprodata"]["rg_blockhash"])
+        self.assertIsNotNone(response["graph"]["a"]["reprodata"]["RERUN"]["rg_blockhash"])
         self.assertIsNotNone(response["reprodata"])
         c.destroySession(sid)
         # Test without reprodata

--- a/daliuge-engine/test/manager/test_scalability.py
+++ b/daliuge-engine/test/manager/test_scalability.py
@@ -34,15 +34,19 @@ hostname = "localhost"
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 

--- a/daliuge-engine/test/reproducibility/test_lg_blockdag.py
+++ b/daliuge-engine/test/reproducibility/test_lg_blockdag.py
@@ -63,7 +63,7 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -76,9 +76,9 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -96,7 +96,7 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -108,7 +108,7 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -118,13 +118,13 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -135,10 +135,10 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -150,10 +150,10 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -164,10 +164,10 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -188,7 +188,7 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -201,9 +201,9 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -221,7 +221,7 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -233,7 +233,7 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -243,13 +243,13 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -260,10 +260,10 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -275,10 +275,10 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -289,10 +289,10 @@ class LogicalBlockdagRepeatTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -313,7 +313,7 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -326,9 +326,9 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -346,7 +346,7 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -358,7 +358,7 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -368,13 +368,13 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -385,10 +385,10 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -400,10 +400,10 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -414,10 +414,10 @@ class LogicalBlockdagRecomputeTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -439,7 +439,7 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -452,13 +452,13 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
-        sig0 = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
-        sig1 = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
-        sig2 = lgt["nodeDataArray"][2]["reprodata"]["lg_blockhash"]
+        sig0 = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
+        sig1 = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
+        sig2 = lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_blockhash"]
         self.assertTrue(
             len(leaves) == 1
             and len(parenthashes) == 0
@@ -476,7 +476,7 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -488,7 +488,7 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -498,13 +498,13 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -515,13 +515,13 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         sourcehashes = [
-            lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"],
-            lgt["nodeDataArray"][2]["reprodata"]["lg_blockhash"],
+            lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"],
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_blockhash"],
         ]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehashes == parenthashes and len(parenthashes) == 2)
 
@@ -533,10 +533,10 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -547,9 +547,9 @@ class LogicalBlockdagReproduceTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         # Not going to get anything out of this, since reproduce only cares about terminal data.
         self.assertEqual(0, len(parenthashes))
@@ -571,7 +571,7 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -584,9 +584,9 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -604,7 +604,7 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -616,7 +616,7 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -626,13 +626,13 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -643,10 +643,10 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -658,10 +658,10 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -672,10 +672,10 @@ class LogicalBlockdagReplicateSciTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -696,7 +696,7 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -709,9 +709,9 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -729,7 +729,7 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -741,7 +741,7 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -751,13 +751,13 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -768,10 +768,10 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -783,10 +783,10 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -797,10 +797,10 @@ class LogicalBlockdagReplicateCompTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -821,7 +821,7 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -834,9 +834,9 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(
             len(leaves) == 1
@@ -854,7 +854,7 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
@@ -866,7 +866,7 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
@@ -876,13 +876,13 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
@@ -893,10 +893,10 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -908,10 +908,10 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -922,10 +922,10 @@ class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+        lg_build_blockdag(lgt, self.rmode)
+        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
         parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
         )
         self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
 
@@ -945,7 +945,7 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
@@ -958,10 +958,10 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
         if self.rmode != ReproducibilityFlags.NOTHING:
             parenthashes = list(
-                lgt["nodeDataArray"][1]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             self.assertTrue(len(leaves) == 1)
             if self.rmode != ReproducibilityFlags.REPRODUCE:
@@ -970,7 +970,7 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
             else:
                 self.assertTrue(len(parenthashes) == 0)
         else:
-            self.assertNotIn("reprodata", lgt["nodeDataArray"][1])
+            self.assertIn("reprodata", lgt["nodeDataArray"][1])
 
     def test_twoend(self):
         """
@@ -982,8 +982,8 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
-        self.assertFalse(leaves[0] == leaves[1])
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
+        self.assertTrue(leaves[0] == leaves[1])
 
     def test_twolines(self):
         """
@@ -994,8 +994,8 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        leaves = lg_build_blockdag(lgt)[0]
-        self.assertTrue(leaves[0] != leaves[1])
+        leaves = lg_build_blockdag(lgt, self.rmode)[0]
+        self.assertTrue(leaves[0] == leaves[1])
 
     def test_data_fan(self):
         """
@@ -1004,17 +1004,17 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFan.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         if self.rmode == ReproducibilityFlags.NOTHING:
             for drop in lgt["nodeDataArray"]:
-                self.assertNotIn("reprodata", drop)
+                self.assertIn("reprodata", drop)
         else:
-            sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+            sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
             parenthash1 = list(
-                lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             parenthash2 = list(
-                lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             self.assertTrue(parenthash1 == parenthash2)
             if self.rmode != ReproducibilityFlags.REPRODUCE:
@@ -1027,14 +1027,14 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataFunnel.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         if self.rmode == ReproducibilityFlags.NOTHING:
             for drop in lgt["nodeDataArray"]:
-                self.assertNotIn("reprodata", drop)
+                self.assertIn("reprodata", drop)
         else:
-            sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+            sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
             parenthashes = list(
-                lgt["nodeDataArray"][3]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             if self.rmode == ReproducibilityFlags.REPRODUCE:
                 self.assertTrue(len(parenthashes) == 2)
@@ -1049,14 +1049,14 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/dataSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         if self.rmode == ReproducibilityFlags.NOTHING:
             for drop in lgt["nodeDataArray"]:
-                self.assertNotIn("reprodata", drop)
+                self.assertIn("reprodata", drop)
         else:
-            sourcehash = lgt["nodeDataArray"][0]["reprodata"]["lg_blockhash"]
+            sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
             parenthashes = list(
-                lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             self.assertTrue(len(parenthashes) == 1)
             if self.rmode != ReproducibilityFlags.REPRODUCE:
@@ -1071,14 +1071,14 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/computationSandwich.graph")
         init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
         init_lg_repro_data(lgt)
-        lg_build_blockdag(lgt)
+        lg_build_blockdag(lgt, self.rmode)
         if self.rmode == ReproducibilityFlags.NOTHING:
             for drop in lgt["nodeDataArray"]:
-                self.assertNotIn("reprodata", drop)
+                self.assertIn("reprodata", drop)
         else:
-            sourcehash = lgt["nodeDataArray"][1]["reprodata"]["lg_blockhash"]
+            sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
             parenthashes = list(
-                lgt["nodeDataArray"][2]["reprodata"]["lg_parenthashes"].values()
+                lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
             )
             if self.rmode != ReproducibilityFlags.REPRODUCE:
                 self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)

--- a/daliuge-engine/test/reproducibility/test_lg_blockdag.py
+++ b/daliuge-engine/test/reproducibility/test_lg_blockdag.py
@@ -29,6 +29,7 @@ Most of these tests will be asserting the obvious, with the exception of Reprodu
 
 import json
 import unittest
+
 import pkg_resources
 
 from dlg.common.reproducibility.constants import ReproducibilityFlags, ALL_RMODES
@@ -53,21 +54,12 @@ def _setup_lgt(filename: str, rmode: ReproducibilityFlags):
     return lgt, leaves
 
 
-class LogicalBlockdagRerunTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when rerunning.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.RERUN
+class LogicalBlockdagTests(unittest.TestCase):
 
     def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
+        for rmode in ALL_RMODES:
+            _, leaves = _setup_lgt("topoGraphs/testSingle.graph", rmode)
+            self.assertTrue(len(leaves) == 1, rmode.name)
 
     def test_twostart(self):
         """
@@ -76,15 +68,34 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
              C
         B -->
         """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
+        for rmode in ALL_RMODES:
+            lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", rmode)
+            parenthashes = list(
+                lgt["nodeDataArray"][1]["reprodata"][rmode.name]["lg_parenthashes"].values()
+            )
+            if rmode == ReproducibilityFlags.REPRODUCE:
+                parenthashes = list(
+                    lgt["nodeDataArray"][1]["reprodata"][rmode.name][
+                        "lg_parenthashes"].values()
+                )
+                sig0 = lgt["nodeDataArray"][0]["reprodata"][rmode.name]["lg_blockhash"]
+                sig1 = lgt["nodeDataArray"][1]["reprodata"][rmode.name]["lg_blockhash"]
+                sig2 = lgt["nodeDataArray"][2]["reprodata"][rmode.name]["lg_blockhash"]
+                self.assertTrue(
+                    len(leaves) == 1
+                    and len(parenthashes) == 0
+                    and sig0 == sig1
+                    and sig1 == sig2
+                    , rmode.name
+                )
+                self.assertTrue(len(parenthashes) == 0, rmode.name)
+            else:
+                self.assertTrue(
+                    len(leaves) == 1
+                    and len(parenthashes) == 2
+                    and parenthashes[0] == parenthashes[1]
+                    , rmode.name
+                )
 
     def test_twoend(self):
         """
@@ -93,8 +104,9 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         A
           --> C
         """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
+        for rmode in ALL_RMODES:
+            _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", rmode)
+            self.assertTrue(leaves[0] == leaves[1], rmode.name)
 
     def test_twolines(self):
         """
@@ -102,670 +114,91 @@ class LogicalBlockdagRerunTests(unittest.TestCase):
         A --> B
         C --> D
         """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
+        for rmode in ALL_RMODES:
+            _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", rmode)
+            self.assertTrue(leaves[0] == leaves[1], rmode.name)
 
     def test_data_fan(self):
         """
         Tests that a single data source scatters its signature to downstream data drops.
         """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
+        for rmode in ALL_RMODES:
+            lgt, leaves = _setup_lgt("topoGraphs/dataFan.graph", rmode)
+            if rmode != ReproducibilityFlags.REPRODUCE:
+                sourcehash = lgt["nodeDataArray"][0]["reprodata"][rmode.name]["lg_blockhash"]
+                parenthash1 = list(
+                    lgt["nodeDataArray"][2]["reprodata"][rmode.name]["lg_parenthashes"].values()
+                )
+                parenthash2 = list(
+                    lgt["nodeDataArray"][3]["reprodata"][rmode.name]["lg_parenthashes"].values()
+                )
+                self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash,
+                                rmode.name)
+            else:
+                sourcehash = lgt["nodeDataArray"][1]["reprodata"][rmode.name]["lg_blockhash"]
+                parenthash1 = list(
+                    lgt["nodeDataArray"][2]["reprodata"][rmode.name][
+                        "lg_parenthashes"].values()
+                )
+                parenthash2 = list(
+                    lgt["nodeDataArray"][3]["reprodata"][rmode.name][
+                        "lg_parenthashes"].values()
+                )
+                self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
 
     def test_data_funnel(self):
         """
         Tests that two data sources are collected in a single downstream data drop
         """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
+        for rmode in ALL_RMODES:
+            lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", rmode)
+            if rmode != ReproducibilityFlags.REPRODUCE:
+                sourcehash = lgt["nodeDataArray"][1]["reprodata"][rmode.name]["lg_blockhash"]
+                parenthashes = list(
+                    lgt["nodeDataArray"][3]["reprodata"][rmode.name]["lg_parenthashes"].values()
+                )
+                self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1,
+                                rmode.name)
+            else:
+                sourcehashes = [
+                    lgt["nodeDataArray"][0]["reprodata"][rmode.name]["lg_blockhash"],
+                    lgt["nodeDataArray"][2]["reprodata"][rmode.name]["lg_blockhash"],
+                ]
+                parenthashes = list(
+                    lgt["nodeDataArray"][3]["reprodata"][rmode.name][
+                        "lg_parenthashes"].values()
+                )
+                self.assertTrue(sourcehashes == parenthashes and len(parenthashes) == 2, rmode.name)
 
     def test_data_sandwich(self):
         """
         Tests two data drops with an interim computing drop
         :return:
         """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
+        for rmode in ALL_RMODES:
+            lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", rmode)
+            index = 0 if rmode != ReproducibilityFlags.REPRODUCE else 1
+            sourcehash = lgt["nodeDataArray"][index]["reprodata"][rmode.name]["lg_blockhash"]
+            parenthashes = list(
+                lgt["nodeDataArray"][2]["reprodata"][rmode.name]["lg_parenthashes"].values()
+            )
+            self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1, rmode.name)
 
     def test_computation_sandwich(self):
         """
         Tests that an internal data drop surrounded by computing drops is handled correctly.
         """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-
-class LogicalBlockdagRepeatTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when repeating.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.REPEAT
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-
-class LogicalBlockdagRecomputeTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when recomputing.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.RECOMPUTE
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-
-class LogicalBlockdagReproduceTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when reproducing.
-    Computing drops should be truncated out of the blockdag construction.
-    This means that the data tests will be very different.
-    """
-
-    rmode = ReproducibilityFlags.REPRODUCE
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        sig0 = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        sig1 = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        sig2 = lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_blockhash"]
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 0
-            and sig0 == sig1
-            and sig1 == sig2
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehashes = [
-            lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"],
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_blockhash"],
-        ]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehashes == parenthashes and len(parenthashes) == 2)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        # Not going to get anything out of this, since reproduce only cares about terminal data.
-        self.assertEqual(0, len(parenthashes))
-
-
-class LogicalBlockdagReplicateSciTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when replicating scientifically.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.REPLICATE_SCI
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-
-class LogicalBlockdagReplicateCompTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when replicating computationally.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.REPLICATE_COMP
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-
-class LogicalBlockdagReplicateTOTALTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when replicating totally.
-    In all cases all drops should be included at this stage.
-    """
-
-    rmode = ReproducibilityFlags.REPLICATE_TOTAL
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt, leaves = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
-        parenthashes = list(
-            lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(
-            len(leaves) == 1
-            and len(parenthashes) == 2
-            and parenthashes[0] == parenthashes[1]
-        )
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFan.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthash1 = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        parenthash2 = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(parenthash1 == parenthash2 and parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataFunnel.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][3]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt, _ = _setup_lgt("topoGraphs/dataSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][0]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
-        sourcehash = lgt["nodeDataArray"][1]["reprodata"][self.rmode.name]["lg_blockhash"]
-        parenthashes = list(
-            lgt["nodeDataArray"][2]["reprodata"][self.rmode.name]["lg_parenthashes"].values()
-        )
-        self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1)
+        for rmode in ALL_RMODES:
+            lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", rmode)
+            sourcehash = lgt["nodeDataArray"][1]["reprodata"][rmode.name]["lg_blockhash"]
+            parenthashes = list(
+                lgt["nodeDataArray"][2]["reprodata"][rmode.name]["lg_parenthashes"].values()
+            )
+            if rmode != ReproducibilityFlags.REPRODUCE:
+                self.assertTrue(sourcehash == parenthashes[0] and len(parenthashes) == 1,
+                                rmode.name)
+            else:
+                self.assertEqual(0, len(parenthashes), rmode.name)
 
 
 class LogicalBlockdagNothingTests(unittest.TestCase):
@@ -774,14 +207,6 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
     """
 
     rmode = ReproducibilityFlags.NOTHING
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        _, leaves = _setup_lgt("topoGraphs/testSingle.graph", self.rmode)
-        self.assertTrue(len(leaves) == 1)
 
     def test_twostart(self):
         """
@@ -793,25 +218,6 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt, _ = _setup_lgt("topoGraphs/testTwoStart.graph", self.rmode)
         self.assertIn("reprodata", lgt["nodeDataArray"][1])
 
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoEnd.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        _, leaves = _setup_lgt("topoGraphs/testTwoLines.graph", self.rmode)
-        self.assertTrue(leaves[0] == leaves[1])
-
     def test_data_fan(self):
         """
         Tests that a single data source scatters its signature to downstream data drops.
@@ -844,172 +250,3 @@ class LogicalBlockdagNothingTests(unittest.TestCase):
         lgt, _ = _setup_lgt("topoGraphs/computationSandwich.graph", self.rmode)
         for drop in lgt["nodeDataArray"]:
             self.assertIn("reprodata", drop)
-
-
-class LogicalBlockdagAllTests(unittest.TestCase):
-    """
-    Tests the logical blockdag construction behaviour when testing all standards.
-    """
-
-    rmode = ReproducibilityFlags.ALL
-
-    def test_single(self):
-        """
-        Tests a single drop
-        A
-        """
-        lgt = _init_graph("topoGraphs/testSingle.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            leaves = lg_build_blockdag(lgt, rmode)[0]
-            self.assertTrue(len(leaves) == 1)
-
-    def test_twostart(self):
-        """
-        A graph with two starts
-        A -->
-             C
-        B -->
-        """
-        lgt = _init_graph("topoGraphs/testTwoStart.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            leaves = lg_build_blockdag(lgt, rmode)[0]
-            parenthashes = list(
-                lgt["nodeDataArray"][1]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            self.assertTrue(len(leaves) == 1)
-            if rmode != ReproducibilityFlags.REPRODUCE:
-                self.assertTrue(len(parenthashes) == 2)
-                self.assertTrue(parenthashes[0] == parenthashes[1])
-            else:
-                self.assertTrue(len(parenthashes) == 0)
-
-    def test_twoend(self):
-        """
-        A graph with two ends
-          --> B
-        A
-          --> C
-        """
-        lgt = _init_graph("topoGraphs/testTwoEnd.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            leaves = lg_build_blockdag(lgt, rmode)[0]
-            self.assertTrue(leaves[0] == leaves[1])
-
-    def test_twolines(self):
-        """
-        A graph with two starts and two ends
-        A --> B
-        C --> D
-        """
-        lgt = _init_graph("topoGraphs/testTwoLines.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            leaves = lg_build_blockdag(lgt, rmode)[0]
-            self.assertTrue(leaves[0] == leaves[1])
-
-    def test_data_fan(self):
-        """
-        Tests that a single data source scatters its signature to downstream data drops.
-        """
-        lgt = _init_graph("topoGraphs/dataFan.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            lg_build_blockdag(lgt, rmode)
-            sourcehash = lgt["nodeDataArray"][0]["reprodata"][rmode.name][
-                "lg_blockhash"
-            ]
-            parenthash1 = list(
-                lgt["nodeDataArray"][2]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            parenthash2 = list(
-                lgt["nodeDataArray"][3]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            self.assertTrue(parenthash1 == parenthash2)
-            if rmode != ReproducibilityFlags.REPRODUCE:
-                self.assertTrue(parenthash1[0] == sourcehash)
-
-    def test_data_funnel(self):
-        """
-        Tests that two data sources are collected in a single downstream data drop
-        """
-        lgt = _init_graph("topoGraphs/dataFunnel.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            lg_build_blockdag(lgt, rmode)
-            sourcehash = lgt["nodeDataArray"][1]["reprodata"][rmode.name][
-                "lg_blockhash"
-            ]
-            parenthashes = list(
-                lgt["nodeDataArray"][3]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            if rmode != ReproducibilityFlags.REPRODUCE:
-                self.assertTrue(
-                    sourcehash == parenthashes[0] and len(parenthashes) == 1
-                )
-            else:
-                self.assertTrue(len(parenthashes) == 2)
-
-    def test_data_sandwich(self):
-        """
-        Tests two data drops with an interim computing drop
-        :return:
-        """
-        lgt = _init_graph("topoGraphs/dataSandwich.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            lg_build_blockdag(lgt, rmode)
-            sourcehash = lgt["nodeDataArray"][0]["reprodata"][rmode.name][
-                "lg_blockhash"
-            ]
-            parenthashes = list(
-                lgt["nodeDataArray"][2]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            self.assertTrue(len(parenthashes) == 1)
-            if rmode != ReproducibilityFlags.REPRODUCE:
-                self.assertTrue(sourcehash == parenthashes[0])
-            else:
-                self.assertTrue(sourcehash != parenthashes[0])
-
-    def test_computation_sandwich(self):
-        """
-        Tests that an internal data drop surrounded by computing drops is handled correctly.
-        """
-        lgt = _init_graph("topoGraphs/computationSandwich.graph")
-        init_lgt_repro_data(lgt, rmode=str(self.rmode.value))
-        init_lg_repro_data(lgt)
-        for rmode in ALL_RMODES:
-            lg_build_blockdag(lgt, rmode)
-            sourcehash = lgt["nodeDataArray"][1]["reprodata"][rmode.name][
-                "lg_blockhash"
-            ]
-            parenthashes = list(
-                lgt["nodeDataArray"][2]["reprodata"][rmode.name][
-                    "lg_parenthashes"
-                ].values()
-            )
-            if rmode != ReproducibilityFlags.REPRODUCE:
-                self.assertTrue(
-                    sourcehash == parenthashes[0] and len(parenthashes) == 1
-                )
-            else:
-                self.assertTrue(len(parenthashes) == 0)

--- a/daliuge-engine/test/reproducibility/test_toposort.py
+++ b/daliuge-engine/test/reproducibility/test_toposort.py
@@ -31,6 +31,7 @@ import unittest
 
 import pkg_resources
 
+from dlg.common.reproducibility.constants import ReproducibilityFlags
 from dlg.common.reproducibility.reproducibility import (
     init_lgt_repro_data,
     init_lg_repro_data,
@@ -42,15 +43,17 @@ _dummydrop = {
     "oid": 1,
     "reprodata": {
         "rmode": "1",
-        "lg_blockhash": "123",
-        "pgt_data": {"merkleroot": "456"},
-        "pgt_parenthashes": {},
-        "pgt_blockhash": "135",
-        "pg_data": {"merkleroot": "bogus"},
-        "pg_parenthashes": {},
-        "pg_blockhash": "246",
-        "rg_data": {"merkleroot": "bogus2"},
-        "rg_parenthashes": {},
+        "RERUN": {
+            "lg_blockhash": "123",
+            "pgt_data": {"merkleroot": "456"},
+            "pgt_parenthashes": {},
+            "pgt_blockhash": "135",
+            "pg_data": {"merkleroot": "bogus"},
+            "pg_parenthashes": {},
+            "pg_blockhash": "246",
+            "rg_data": {"merkleroot": "bogus2"},
+            "rg_parenthashes": {},
+        }
     },
 }
 
@@ -112,7 +115,7 @@ class ToposortTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testSingle.graph")
         init_lgt_repro_data(lgt, "1")
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [-1])
 
     def test_lg_blockdag_twostart(self):
@@ -125,7 +128,7 @@ class ToposortTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoStart.graph")
         init_lgt_repro_data(lgt, "1")
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [-3, -1, -2])
 
     def test_lg_blockdag_twoend(self):
@@ -138,7 +141,7 @@ class ToposortTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoEnd.graph")
         init_lgt_repro_data(lgt, "1")
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [-1, -3, -2])
 
     def test_lg_blockdag_twolines(self):
@@ -150,7 +153,7 @@ class ToposortTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testTwoLines.graph")
         init_lgt_repro_data(lgt, "1")
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [-2, -3, -1, -4])
 
     def test_lg_blockdag_empty(self):
@@ -160,7 +163,7 @@ class ToposortTests(unittest.TestCase):
         lgt = _init_graph("topoGraphs/testEmpty.graph")
         init_lgt_repro_data(lgt, "1")
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [])
 
     def test_pgt_blockdag_single(self):
@@ -169,7 +172,7 @@ class ToposortTests(unittest.TestCase):
         1
         """
         pgt = _init_pgraph_single()
-        visited = build_blockdag(pgt, "pgt")[1]
+        visited = build_blockdag(pgt, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1])
 
     def test_pgt_blockdag_twostart(self):
@@ -180,7 +183,7 @@ class ToposortTests(unittest.TestCase):
         2 -->
         """
         pgt = _init_pgraph_twostart()
-        visited = build_blockdag(pgt, "pgt")[1]
+        visited = build_blockdag(pgt, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 1, 2])
 
     def test_pgt_blockdag_twoend(self):
@@ -191,7 +194,7 @@ class ToposortTests(unittest.TestCase):
           --> 3
         """
         pgt = _init_pgraph_twoend()
-        visited = build_blockdag(pgt, "pgt")[1]
+        visited = build_blockdag(pgt, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1, 3, 2])
 
     def test_pgt_blockdag_twolines(self):
@@ -201,7 +204,7 @@ class ToposortTests(unittest.TestCase):
         3 --> 4
         """
         pgt = _init_pgraph_twolines()
-        visited = build_blockdag(pgt, "pgt")[1]
+        visited = build_blockdag(pgt, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 4, 1, 2])
 
     def test_pgt_blockdag_empty(self):
@@ -209,7 +212,7 @@ class ToposortTests(unittest.TestCase):
         Tests an empty graph. Should fail gracefully.
         """
         pgt = []
-        visited = build_blockdag(pgt, "pgt")[1]
+        visited = build_blockdag(pgt, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [])
 
     def test_pg_blockdag_single(self):
@@ -217,7 +220,7 @@ class ToposortTests(unittest.TestCase):
         Tests a single drop
         """
         pgr = _init_pgraph_single()
-        visited = build_blockdag(pgr, "pg")[1]
+        visited = build_blockdag(pgr, "pg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1])
 
     def test_pg_blockdag_twostart(self):
@@ -228,7 +231,7 @@ class ToposortTests(unittest.TestCase):
         2 -->
         """
         pgr = _init_pgraph_twostart()
-        visited = build_blockdag(pgr, "pg")[1]
+        visited = build_blockdag(pgr, "pg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 1, 2])
 
     def test_pg_blockdag_twoend(self):
@@ -239,7 +242,7 @@ class ToposortTests(unittest.TestCase):
           --> 3
         """
         pgr = _init_pgraph_twoend()
-        visited = build_blockdag(pgr, "pg")[1]
+        visited = build_blockdag(pgr, "pg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1, 3, 2])
 
     def test_pg_blockdag_twolines(self):
@@ -249,7 +252,7 @@ class ToposortTests(unittest.TestCase):
         3 --> 4
         """
         pgr = _init_pgraph_twolines()
-        visited = build_blockdag(pgr, "pgt")[1]
+        visited = build_blockdag(pgr, "pgt", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 4, 1, 2])
 
     def test_pg_blockdag_empty(self):
@@ -257,7 +260,7 @@ class ToposortTests(unittest.TestCase):
         Tests an empty graph. Should fail gracefully.
         """
         pgr = []
-        visited = build_blockdag(pgr, "pg")[1]
+        visited = build_blockdag(pgr, "pg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [])
 
     def test_rg_blockdag_single(self):
@@ -265,7 +268,7 @@ class ToposortTests(unittest.TestCase):
         Tests a single drop
         """
         rgr = _init_pgraph_single()
-        visited = build_blockdag(rgr, "rg")[1]
+        visited = build_blockdag(rgr, "rg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1])
 
     def test_rg_blockdag_twostart(self):
@@ -276,7 +279,7 @@ class ToposortTests(unittest.TestCase):
         2 -->
         """
         rgr = _init_pgraph_twostart()
-        visited = build_blockdag(rgr, "rg")[1]
+        visited = build_blockdag(rgr, "rg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 1, 2])
 
     def test_rg_blockdag_twoend(self):
@@ -287,7 +290,7 @@ class ToposortTests(unittest.TestCase):
           --> 3
         """
         rgr = _init_pgraph_twoend()
-        visited = build_blockdag(rgr, "rg")[1]
+        visited = build_blockdag(rgr, "rg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [1, 3, 2])
 
     def test_rg_blockdag_twolines(self):
@@ -297,7 +300,7 @@ class ToposortTests(unittest.TestCase):
         3 --> 4
         """
         rgr = _init_pgraph_twolines()
-        visited = build_blockdag(rgr, "rg")[1]
+        visited = build_blockdag(rgr, "rg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [3, 4, 1, 2])
 
     def test_rg_blockdag_empty(self):
@@ -305,5 +308,5 @@ class ToposortTests(unittest.TestCase):
         Tests an empty graph. Should fail gracefully.
         """
         rgr = []
-        visited = build_blockdag(rgr, "rg")[1]
+        visited = build_blockdag(rgr, "rg", ReproducibilityFlags.RERUN)[1]
         self.assertTrue(visited == [])

--- a/daliuge-engine/test/test_session.py
+++ b/daliuge-engine/test/test_session.py
@@ -19,28 +19,32 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-import unittest
 import json
+import unittest
+
 import pkg_resources
 
-from dlg import runtime, graph_loader
+from dlg.common import Categories
 from dlg.ddap_protocol import DROPLinkType, DROPStates, AppDROPStates
 from dlg.droputils import DROPWaiterCtx
 from dlg.exceptions import InvalidGraphException
 from dlg.manager.session import SessionStates, Session
-from dlg.common import Categories
 
 default_repro = {
     "rmode": "1",
-    "lg_blockhash": "x",
-    "pgt_blockhash": "y",
-    "pg_blockhash": "z",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    }
 }
 default_graph_repro = {
     "rmode": "1",
     "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
     "merkleroot": "a",
-    "signature": "b",
+    "RERUN": {
+        "signature": "b",
+    }
 }
 
 
@@ -125,7 +129,7 @@ class TestSession(unittest.TestCase):
 
     def test_addGraphSpec_namedPorts(self):
         with pkg_resources.resource_stream(
-            "test", "graphs/funcTestPG_namedPorts.graph"
+                "test", "graphs/funcTestPG_namedPorts.graph"
         ) as f:  # @UndefinedVariable
             graphSpec = json.load(f)
         # dropSpecs = graph_loader.loadDropSpecs(graphSpec)

--- a/daliuge-translator/test/reproducibility/test_accumulatedata.py
+++ b/daliuge-translator/test/reproducibility/test_accumulatedata.py
@@ -237,7 +237,7 @@ class AccumulatePGTUnrollRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -247,7 +247,7 @@ class AccumulatePGTUnrollRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -303,7 +303,7 @@ class AccumulatePGTPartitionRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -313,7 +313,7 @@ class AccumulatePGTPartitionRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -370,7 +370,7 @@ class AccumulatePGRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -380,7 +380,7 @@ class AccumulatePGRerunData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """
@@ -632,7 +632,7 @@ class AccumulatePGTUnrollRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -642,7 +642,7 @@ class AccumulatePGTUnrollRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -699,7 +699,7 @@ class AccumulatePGTPartitionRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -709,7 +709,7 @@ class AccumulatePGTPartitionRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -766,7 +766,7 @@ class AccumulatePGRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -776,7 +776,7 @@ class AccumulatePGRepeatData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """
@@ -1028,7 +1028,7 @@ class AccumulatePGTUnrollRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -1038,7 +1038,7 @@ class AccumulatePGTUnrollRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -1095,7 +1095,7 @@ class AccumulatePGTPartitionRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(sorted(expected), sorted(list(hash_data.keys())))
+            self.assertEqual(sorted(expected), sorted(list(hash_data[self.rmode.name].keys())))
 
     def test_data_accumulate(self):
         """
@@ -1105,7 +1105,7 @@ class AccumulatePGTPartitionRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(sorted(expected), sorted(list(hash_data.keys())))
+            self.assertEqual(sorted(expected), sorted(list(hash_data[self.rmode.name].keys())))
 
     def test_group_accumulate(self):
         """
@@ -1162,7 +1162,7 @@ class AccumulatePGRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -1172,7 +1172,7 @@ class AccumulatePGRecomputeData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -1231,6 +1231,7 @@ class AccumulateLGTReproduceData(unittest.TestCase):
         """
         for drop in enumerate(self.lgt_node_data):
             hash_data = accumulate_lgt_drop_data(drop[1], self.rmode)
+            print(hash_data)
             self.assertEqual(self.expected, hash_data.keys())
 
     def test_data_accumulate(self):
@@ -1398,7 +1399,7 @@ class AccumulatePGTUnrollReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -1408,7 +1409,7 @@ class AccumulatePGTUnrollReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -1465,7 +1466,7 @@ class AccumulatePGTPartitionReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, list(hash_data.keys()))
+            self.assertEqual(expected, list(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -1475,7 +1476,7 @@ class AccumulatePGTPartitionReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, list(hash_data.keys()))
+            self.assertEqual(expected, list(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """
@@ -1532,7 +1533,7 @@ class AccumulatePGReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -1542,7 +1543,7 @@ class AccumulatePGReproduceData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """
@@ -1720,7 +1721,7 @@ class AccumulatePGTUnrollReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -1730,7 +1731,7 @@ class AccumulatePGTUnrollReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -1787,7 +1788,7 @@ class AccumulatePGTPartitionReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -1797,7 +1798,7 @@ class AccumulatePGTPartitionReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -1854,7 +1855,7 @@ class AccumulatePGReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -1864,7 +1865,7 @@ class AccumulatePGReplicateSciData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """
@@ -2116,7 +2117,7 @@ class AccumulatePGTUnrollReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -2126,7 +2127,7 @@ class AccumulatePGTUnrollReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -2182,7 +2183,7 @@ class AccumulatePGTPartitionReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -2192,7 +2193,7 @@ class AccumulatePGTPartitionReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -2249,7 +2250,7 @@ class AccumulatePGReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -2259,7 +2260,7 @@ class AccumulatePGReplicateCompData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -2511,7 +2512,7 @@ class AccumulatePGTUnrollReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -2521,7 +2522,7 @@ class AccumulatePGTUnrollReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_unroll_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -2578,7 +2579,7 @@ class AccumulatePGTPartitionReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_data_accumulate(self):
         """
@@ -2588,7 +2589,7 @@ class AccumulatePGTPartitionReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pgt_partition_drop_data(drop[1])
-            self.assertEqual(expected, hash_data.keys())
+            self.assertEqual(expected, hash_data[self.rmode.name].keys())
 
     def test_group_accumulate(self):
         """
@@ -2645,7 +2646,7 @@ class AccumulatePGReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["apps"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_data_accumulate(self):
         """
@@ -2655,7 +2656,7 @@ class AccumulatePGReplicateTotalData(unittest.TestCase):
         self._setup()
         for drop in enumerate(self.graph_data["files"]):
             hash_data = accumulate_pg_drop_data(drop[1])
-            self.assertEqual(expected, dict(hash_data.keys()))
+            self.assertEqual(expected, dict(hash_data[self.rmode.name].keys()))
 
     def test_group_accumulate(self):
         """

--- a/daliuge-translator/test/reproducibility/test_repro_inits.py
+++ b/daliuge-translator/test/reproducibility/test_repro_inits.py
@@ -40,7 +40,7 @@ class InitReproTest(unittest.TestCase):
     def test_lgt_init(self):
         _graph = {}
         sig = init_lgt_repro_data(_graph, "0")
-        self.assertNotIn("reprodata", sig)
+        self.assertIn("reprodata", sig)
 
     def test_lg_init(self):
         _graph = {}

--- a/daliuge-translator/test/reproducibility/test_scatter_blockdag.py
+++ b/daliuge-translator/test/reproducibility/test_scatter_blockdag.py
@@ -97,19 +97,19 @@ class ScatterTest(unittest.TestCase):
         lgt = _init_graph("test/reproducibility/reproGraphs/simpleScatter.graph")
         init_lgt_repro_data(lgt, rmode=ReproducibilityFlags.RERUN.value)
         init_lg_repro_data(lgt)
-        visited = lg_build_blockdag(lgt)[1]
+        visited = lg_build_blockdag(lgt, ReproducibilityFlags.RERUN)[1]
         scatter_drop = lgt["nodeDataArray"][1]
         app_drop = lgt["nodeDataArray"][2]
         scatter_inter_drop = lgt["nodeDataArray"][3]
         # Checks that the input app drop is the parent of the main application
         self.assertEqual(
-            list(app_drop["reprodata"]["lg_parenthashes"].values())[0],
-            scatter_inter_drop["reprodata"]["lg_blockhash"],
+            list(app_drop["reprodata"][ReproducibilityFlags.RERUN.name]["lg_parenthashes"].values())[0],
+            scatter_inter_drop["reprodata"][ReproducibilityFlags.RERUN.name]["lg_blockhash"],
         )
         # Checks that the scatter drop is the parent of the input drop
         self.assertEqual(
-            list(scatter_inter_drop["reprodata"]["lg_parenthashes"].values())[0],
-            scatter_drop["reprodata"]["lg_blockhash"],
+            list(scatter_inter_drop["reprodata"][ReproducibilityFlags.RERUN.name]["lg_parenthashes"].values())[0],
+            scatter_drop["reprodata"][ReproducibilityFlags.RERUN.name]["lg_blockhash"],
         )
         self.assertEqual(visited, [-1, -2, -5, -3, -6, -7, -9])
 
@@ -147,6 +147,6 @@ class ScatterTest(unittest.TestCase):
         self.assertEqual(len(no_scatter_graph), 7)
         # Their signatures should in principal be identicle
         self.assertEqual(
-            scatter_graph[-1]["reprodata"]["pg_blockhash"],
-            no_scatter_graph[-1]["reprodata"]["pg_blockhash"],
+            scatter_graph[-1]["reprodata"][ReproducibilityFlags.RERUN.name]["pg_blockhash"],
+            no_scatter_graph[-1]["reprodata"][ReproducibilityFlags.RERUN.name]["pg_blockhash"],
         )


### PR DESCRIPTION
Originally, it was assumed that there would only be one rmode per graph, so the json was structured as {reprodata: {hash: x}} etc.
Allowing an 'ALL' mode added an extra layer to this - {reprodata: {RERUN: {hash: x}, REPEAT: {hash: x}}} etc.
This split the implementation into two branches - messy and difficult to follow.
This PR unifies the structure into {reprodata: {RMODE: {hash:x}}} even for a single rmode. 