### PR TITLE
Patch daemon tests

### DIFF
--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -118,6 +118,7 @@ class lib64_path(install):
 install_requires = [
     "wheel",  # need to get wheel first...
     "bottle",
+    "boto3",
     "configobj",
     "crc32c",
     "daliuge-common==%s" % (VERSION,),

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     "scp",
     "pyyaml",
     # 0.19.0 requires netifaces < 0.10.5, exactly the opposite of what *we* need
-    "zeroconf >= 0.19.1",
+    "zeroconf ~= 0.38.4",
     # 0.6 brings python3 support plus other fixes
     "zerorpc ~= 0.6.3",
 ]

--- a/daliuge-engine/test/manager/test_daemon.py
+++ b/daliuge-engine/test/manager/test_daemon.py
@@ -30,8 +30,9 @@ from dlg.manager import constants
 from dlg.manager.client import MasterManagerClient
 from dlg.manager.proc_daemon import DlgDaemon
 
-_TIMEOUT = 10
+_TIMEOUT = 30
 IDENTITY = lambda x: x
+
 
 def wait_until(update_condition, test_condition=IDENTITY, timeout=_TIMEOUT, interval=0.1):
     timeout_time = time.time() + timeout
@@ -157,6 +158,7 @@ class TestDaemon(unittest.TestCase):
         if not disable_zeroconf:
             def _test_dims(dims):
                 return dims and dims["islands"]
+
             dims = _get_dims_from_client(mc, test_condition=_test_dims)
             self.assertIsNotNone(dims)
             return dims


### PR DESCRIPTION
Upon a recent MR, the test_daemon.py started failing. 
This is related to zeroconf 0.39.2 - for now, I'm pinning the version at ~=0.38.4 as a workaround, but we should try to support upgraded versions.
Additionally, this MR adds Boto3 as a dependency, since errors trying to find it were polluting the log files.