### PR TITLE
Pins pyarrow to 9.0.0 to sidestep deprecation.

### DIFF
--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -131,7 +131,7 @@ install_requires = [
     "overrides",
     "paramiko",
     "psutil",
-    "pyarrow",
+    "pyarrow == 9.0.0",
     "python-daemon",
     "pyzmq ~= 22.3.0",
     "scp",


### PR DESCRIPTION
Following the [deprecation of pyarrow](https://arrow.apache.org/docs/python/plasma.html), to avoid further build errors, we pin pyarrow to 9.0.0