### PR TITLE
LIU-322: Log exceptions during event handling

### DIFF
--- a/daliuge-engine/dlg/data/drops/parset_drop.py
+++ b/daliuge-engine/dlg/data/drops/parset_drop.py
@@ -21,7 +21,6 @@
 #
 import io
 import os
-from abc import abstractmethod
 
 from dlg.drop import DataDROP, DEFAULT_INTERNAL_PARAMETERS
 from dlg.data.io import MemoryIO
@@ -51,7 +50,6 @@ class ParameterSetDROP(DataDROP):
 
     mode = dlg_string_param("mode", None)
 
-    @abstractmethod
     def serialize_parameters(self, parameters: dict, mode):
         """
         Returns a string representing a serialization of the parameters.
@@ -62,7 +60,6 @@ class ParameterSetDROP(DataDROP):
         # Add more formats (.ini for example)
         return "\n".join(f"{x}={y}" for x, y in parameters.items())
 
-    @abstractmethod
     def filter_parameters(self, parameters: dict, mode):
         """
         Returns a dictionary of parameters, with daliuge-internal or other parameters filtered out

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -56,7 +56,7 @@ from .ddap_protocol import (
     DROPStates,
     DROPRel,
 )
-from dlg.event import EventFirer
+from dlg.event import EventFirer, EventHandler
 from dlg.exceptions import InvalidDropException, InvalidRelationshipException
 from dlg.data.io import (
     DataIO,
@@ -129,7 +129,7 @@ track_current_drop = object_tracking("drop")
 # ===============================================================================
 
 
-class AbstractDROP(EventFirer):
+class AbstractDROP(EventFirer, EventHandler):
     """
     Base class for all DROP implementations.
 
@@ -734,7 +734,7 @@ class AbstractDROP(EventFirer):
         contained in the dropspec dictionaries held in the session.
         """
 
-    def _fire(self, eventType, **kwargs):
+    def _fire(self, eventType: str, **kwargs):
         """
         Delivers an event of `eventType` to all interested listeners.
 

--- a/daliuge-engine/dlg/event.py
+++ b/daliuge-engine/dlg/event.py
@@ -123,4 +123,8 @@ class EventFirer(object):
             setattr(e, k, v)
 
         for l in listeners:
-            l.handleEvent(e)
+            try:
+                l.handleEvent(e)
+            except:
+                logger.exception("Exception in listener %s while handling event %s", l, e)
+                raise

--- a/daliuge-engine/test/test_event.py
+++ b/daliuge-engine/test/test_event.py
@@ -1,0 +1,54 @@
+from typing import Optional
+from dlg.event import EventFirer, EventHandler, Event
+import pytest
+
+
+class MockEventSource(EventFirer):
+    def fireEvent(self, eventType, **kwargs):
+        self._fireEvent(eventType, **kwargs)
+
+
+class MockThrowingEventHandler(EventHandler):
+    def __init__(self) -> None:
+        self.wasCalled = False
+
+    def handleEvent(self, e: Event) -> None:
+        self.wasCalled = True
+        raise RuntimeError("MockThrow", e)
+
+
+class MockEventHandler(EventHandler):
+    def __init__(self) -> None:
+        self.lastEvent: Optional[Event] = None
+
+    def handleEvent(self, e: Event) -> None:
+        self.lastEvent = e
+
+
+def test_listener_exception_interrupts_later_handlers():
+    eventSource = MockEventSource()
+    handler1 = MockEventHandler()
+    handler2 = MockEventHandler()
+    throwingHandler = MockThrowingEventHandler()
+    eventSource.subscribe(handler1, "raise")
+    eventSource.subscribe(throwingHandler, "raise")
+    eventSource.subscribe(handler2, "raise")
+
+    with pytest.raises(RuntimeError):
+        eventSource.fireEvent("raise", prop="value")
+
+    assert throwingHandler.wasCalled
+    assert handler1.lastEvent is not None
+    assert getattr(handler1.lastEvent, "prop") == "value"
+    assert handler2.lastEvent is None
+
+
+def test_listener_exception_is_logged(caplog: pytest.LogCaptureFixture):
+    eventSource = MockEventSource()
+    eventSource.subscribe(MockThrowingEventHandler(), "raise")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        eventSource.fireEvent("raise")
+
+    assert "MockThrow" in str(excinfo.value)
+    assert "MockThrow" in caplog.text, "Expected exception to have been logged"


### PR DESCRIPTION
Tracing @awicenec's stack in the ticket, an error is thrown at the end of `AbstractDrop.execute()`, after the core logic has executed and outside the existing try/except blocks. This seems to be the top level of execution, so the exception has no other chance to be caught & logged. The actual exception is bubbles up from an event handler and I wouldn't expect this high level code to know about any possible exceptions that might occur in the handlers.

As a result I have simply added a try/except around event handler invocations (in `EventFirer`), logged the exception and propagated the exception. I initially tried altering the behaviour by swallowing any exceptions in event handlers, logging them and continuing to the next handler. However this resulted in a functional change and some tests failed (expecting a handler's exception to be propagated). Since this is a bugfix ticket, we probably don't want to be changing behaviour's anyway, but I would typically expect event handlers not to be able to affect each other like this. An alternative could be to execute all handlers and wrap any exceptions in an `AggregateError` (this is similar to how C# handles this sort of thing). Anyway I have added tests which at least communicate that the existing behaviour is expected. I would appreciate any thoughts on this.