### PR TITLE
LIU-322: Catch async exceptions

### DIFF
--- a/daliuge-engine/dlg/data/drops/parset_drop.py
+++ b/daliuge-engine/dlg/data/drops/parset_drop.py
@@ -21,7 +21,6 @@
 #
 import io
 import os
-from abc import abstractmethod
 
 from dlg.drop import DataDROP, DEFAULT_INTERNAL_PARAMETERS
 from dlg.data.io import MemoryIO
@@ -53,7 +52,6 @@ class ParameterSetDROP(DataDROP):
 
     mode = dlg_string_param("mode", None)
 
-    @abstractmethod
     def serialize_parameters(self, parameters: dict, mode):
         """
         Returns a string representing a serialization of the parameters.
@@ -64,7 +62,6 @@ class ParameterSetDROP(DataDROP):
         # Add more formats (.ini for example)
         return "\n".join(f"{x}={y}" for x, y in parameters.items())
 
-    @abstractmethod
     def filter_parameters(self, parameters: dict, mode):
         """
         Returns a dictionary of parameters, with daliuge-internal or other parameters filtered out

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -56,7 +56,7 @@ from .ddap_protocol import (
     DROPStates,
     DROPRel,
 )
-from dlg.event import EventFirer
+from dlg.event import EventFirer, EventHandler
 from dlg.exceptions import InvalidDropException, InvalidRelationshipException
 from dlg.data.io import (
     DataIO,
@@ -129,7 +129,7 @@ track_current_drop = object_tracking("drop")
 # ===============================================================================
 
 
-class AbstractDROP(EventFirer):
+class AbstractDROP(EventFirer, EventHandler):
     """
     Base class for all DROP implementations.
 
@@ -734,7 +734,7 @@ class AbstractDROP(EventFirer):
         contained in the dropspec dictionaries held in the session.
         """
 
-    def _fire(self, eventType, **kwargs):
+    def _fire(self, eventType: str, **kwargs):
         """
         Delivers an event of `eventType` to all interested listeners.
 

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -1199,7 +1199,7 @@ class PathBasedDrop(object):
 # @param dataclass Data Class/my.awesome.data.Component/String/ComponentParameter/readonly//False/False/The python class that implements this data component
 # @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data 
+# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
 # @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
 # @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
@@ -1931,11 +1931,18 @@ class InputFiredAppDROP(AppDROP):
         # Return immediately, but schedule the execution of this app
         # If we have been given a thread pool use that
         if hasattr(self, "_tp"):
-            self._tp.apply_async(self.execute)
+            self._tp.apply_async(self._execute_and_log_exception)
         else:
-            t = threading.Thread(target=self.execute)
+            t = threading.Thread(target=self._execute_and_log_exception)
             t.daemon = 1
             t.start()
+            return t
+
+    def _execute_and_log_exception(self):
+        try:
+            self.execute()
+        except:
+            logger.exception("Unexpected exception during drop (%r) execution", self)
 
     _dlg_proc_lock = threading.Lock()
 

--- a/daliuge-engine/test/test_event.py
+++ b/daliuge-engine/test/test_event.py
@@ -1,0 +1,43 @@
+from typing import Optional
+from dlg.event import EventFirer, EventHandler, Event
+import pytest
+
+
+class MockEventSource(EventFirer):
+    def fireEvent(self, eventType, **kwargs):
+        self._fireEvent(eventType, **kwargs)
+
+
+class MockThrowingEventHandler(EventHandler):
+    def __init__(self) -> None:
+        self.wasCalled = False
+
+    def handleEvent(self, e: Event) -> None:
+        self.wasCalled = True
+        raise RuntimeError("MockThrow", e)
+
+
+class MockEventHandler(EventHandler):
+    def __init__(self) -> None:
+        self.lastEvent: Optional[Event] = None
+
+    def handleEvent(self, e: Event) -> None:
+        self.lastEvent = e
+
+
+def test_listener_exception_interrupts_later_handlers():
+    eventSource = MockEventSource()
+    handler1 = MockEventHandler()
+    handler2 = MockEventHandler()
+    throwingHandler = MockThrowingEventHandler()
+    eventSource.subscribe(handler1, "raise")
+    eventSource.subscribe(throwingHandler, "raise")
+    eventSource.subscribe(handler2, "raise")
+
+    with pytest.raises(RuntimeError):
+        eventSource.fireEvent("raise", prop="value")
+
+    assert throwingHandler.wasCalled
+    assert handler1.lastEvent is not None
+    assert getattr(handler1.lastEvent, "prop") == "value"
+    assert handler2.lastEvent is None

--- a/daliuge-engine/test/test_input_fired_app_drop.py
+++ b/daliuge-engine/test/test_input_fired_app_drop.py
@@ -1,0 +1,42 @@
+import threading
+from dlg.drop import InputFiredAppDROP
+from dlg.event import Event, EventHandler
+import pytest
+
+
+class MockThrowingDrop(InputFiredAppDROP):
+    def run():
+        raise RuntimeError("Drop throw")
+
+
+class MockThrowingHandler(EventHandler):
+    def handleEvent(self, e: Event) -> None:
+        raise RuntimeError("Handler throw")
+
+
+def test_async_execute_catches_and_logs_unexpected_exception(
+    caplog: pytest.LogCaptureFixture,
+):
+    drop = MockThrowingDrop("t", "t", n_effective_inputs=1)
+    handler = MockThrowingHandler()
+    drop.subscribe(handler)
+
+    thread = drop.async_execute()
+    assert isinstance(thread, threading.Thread)
+    thread.join()
+
+    assert "Handler throw" in caplog.text
+    # execute should handle exceptions in the run method
+    assert "Drop throw" not in caplog.text
+
+
+def test_execute_propogates_unexpected_exception():
+    drop = MockThrowingDrop("t", "t", n_effective_inputs=1)
+    handler = MockThrowingHandler()
+    drop.subscribe(handler)
+
+    with pytest.raises(RuntimeError) as e:
+        drop.execute()
+
+    assert "Handler throw" in str(e.value)
+    assert "Drop throw" not in str(e.value)


### PR DESCRIPTION
Alright, attempt no. 2: now with correct ticket numbers. This supersedes #214.

I've retained the type-hints and one of the tests I originally added in #214 as there were no functional changes there and there's no point throwing away those enhancements (plus it was useful for adding further tests below).

Exception handling is now encapsulated around the invocation of `execute()` in `async_execute()` with a helper method which wraps the call in `try/except`. 

I didn't realise this until I went to write the tests, but this logic only occurs in a `InputFiredAppDROP` which means I've only fixed this case for drops of that type. I expected this logic to be on `AbstractDrop` which is why I suspect I may have originally led myself to do this handling in the `EventFirer`. Though now I think about it this makes sense since not all drops execute code (just `AppDrop`s if I'm not mistaken), so I think we're OK there. Hopefully you can follow my though process there :sweat_smile: 