### PR TITLE
Catches unhandled NOTHING case in building reprodata

### DIFF
--- a/daliuge-common/dlg/common/reproducibility/reproducibility.py
+++ b/daliuge-common/dlg/common/reproducibility/reproducibility.py
@@ -848,6 +848,9 @@ def init_runtime_repro_data(runtime_graph: dict, reprodata: dict):
         # logger.warning("Requested reproducibility mode %s not yet implemented", str(rmode))
         level = REPRO_DEFAULT
         reprodata["rmode"] = str(level.value)
+    if level == ReproducibilityFlags.NOTHING:
+        runtime_graph["reprodata"] = reprodata
+        return runtime_graph
     for drop in runtime_graph.values():
         init_rg_repro_drop_data(drop)
     candidate_rmodes = []


### PR DESCRIPTION
When executing with the NOTHING rmode, there is no reprodata to append or process. At higher levels (pgt, pg, etc.) building the blockdag is skipped when executing with the NOTHING rmode, and the same should happen at the runtime level. This MR covers the missing case.