### PR TITLE
Liu 343

### DIFF
--- a/.github/workflows/create-palettes.yml
+++ b/.github/workflows/create-palettes.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Create palettes
         run: |
-          # python3 tools/xml2palette/xml2palette.py -t daliuge -r ./ $OUTPUT_FILENAME.palette
-          # python3 tools/xml2palette/xml2palette.py -t template -r ./ $OUTPUT_FILENAME-template.palette
           dlg_paletteGen -r -t daliuge ./ $OUTPUT_FILENAME.palette
           dlg_paletteGen -r -t template ./ $OUTPUT_FILENAME-template.palette
 

--- a/.github/workflows/create-palettes.yml
+++ b/.github/workflows/create-palettes.yml
@@ -24,19 +24,25 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y doxygen xsltproc
           pip install BlockDAG
+          pip install dlg_paletteGen
 
       - name: Configure git
         run: |
           git config --global user.name $GITHUB_USERNAME
           git config --global user.email $GITHUB_USERNAME@gmail.com
+
+      - name: Environment variables
+        run: |
           OUTPUT_FILENAME=$PROJECT_NAME-${GITHUB_REF_NAME/\//_}
           echo "PROJECT_VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "OUTPUT_FILENAME=$OUTPUT_FILENAME" >> $GITHUB_ENV
 
       - name: Create palettes
         run: |
-          python3 tools/xml2palette/xml2palette.py -t daliuge -r ./ $OUTPUT_FILENAME.palette
-          python3 tools/xml2palette/xml2palette.py -t template -r ./ $OUTPUT_FILENAME-template.palette
+          # python3 tools/xml2palette/xml2palette.py -t daliuge -r ./ $OUTPUT_FILENAME.palette
+          # python3 tools/xml2palette/xml2palette.py -t template -r ./ $OUTPUT_FILENAME-template.palette
+          dlg_paletteGen -r -t daliuge ./ $OUTPUT_FILENAME.palette
+          dlg_paletteGen -r -t template ./ $OUTPUT_FILENAME-template.palette
 
       - name: Commit palettes to EAGLE
         env:

--- a/daliuge-engine/dlg/apps/archiving.py
+++ b/daliuge-engine/dlg/apps/archiving.py
@@ -83,20 +83,20 @@ class ExternalStoreApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param dropclass Application Class/dlg.apps.archiving.NgasArchivingApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param ngasSrv NGAS Server URL/localhost/String/ApplicationArgument/readwrite//False/False/URL of the NGAS Server
-# @param ngasPort NGAS Server Port/7777/Integer/ApplicationArgument/readwrite//False/False/TCP/IP Port on the NGAS Server
-# @param ngasMime NGAS Mime Type/"application/octet-stream"/String/ApplicationArgument/readwrite//False/False/Mime-type of the NGAS payload
-# @param ngasTimeout NGAS Server Timeout/2/Integer/ApplicationArgument/readonly//False/False/Archiving request timeout
-# @param ngasConnectTimeout NGAS Server Connect Timeout/2/Integer/ApplicationArgument/readonly//False/False/NGAS Server connection timeout
-# @param fileObject File Object//Object.File/InputPort/readwrite//False/False/Input File Object
+# @param dropclass dlg.apps.archiving.NgasArchivingApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param ngasSrv localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/URL of the NGAS Server
+# @param ngasPort 7777/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/"TCP/IP Port on the NGAS Server"
+# @param ngasMime "application/octet-stream"/String/ApplicationArgument/NoPort/ReadWrite//False/False/Mime-type of the NGAS payload
+# @param ngasTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/Archiving request timeout
+# @param ngasConnectTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/NGAS Server connection timeout
+# @param fileObject /Object.File/ApplicationArgument/InputPort/ReadWrite//False/False/Input File Object
 # @par EAGLE_END
 class NgasArchivingApp(ExternalStoreApp):
     """

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -381,20 +381,20 @@ class StreamingInputBashAppBase(BashShellBase, AppDROP):
 # @par EAGLE_START
 # @param category BashShellApp
 # @param tag template
-# @param command Command//String/ComponentParameter/readwrite//False/False/The command to be executed
-# @param input_redirection Input Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the input into this application
-# @param output_redirection Output Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the output from this application
-# @param command_line_arguments Command Line Arguments//String/ComponentParameter/readwrite//False/False/Additional command line arguments to be added to the command line to be executed
-# @param paramValueSeparator Param value separator/ /String/ComponentParameter/readwrite//False/False/Separator character(s) between parameters on the command line
-# @param argumentPrefix Argument prefix/"--"/String/ComponentParameter/readwrite//False/False/Prefix to each keyed argument on the command line
-# @param dropclass dropclass/dlg.apps.bash_shell_app.BashShellApp/String/ComponentParameter/readwrite//False/False/Drop class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param command /String/ComponentParameter/NoPort/ReadWrite//False/False/The command to be executed
+# @param input_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the input into this application
+# @param output_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the output from this application
+# @param command_line_arguments /String/ComponentParameter/NoPort/ReadWrite//False/False/Additional command line arguments to be added to the command line to be executed
+# @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters on the command line
+# @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param dropclass dlg.apps.bash_shell_app.BashShellApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @par EAGLE_END
 class BashShellApp(BashShellBase, BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -17,6 +17,7 @@ from dlg.exceptions import InvalidDropException
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dummy_input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/Dummy input port
 # @param dummy0 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @param dummy1 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @par EAGLE_END

--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -9,16 +9,16 @@ from dlg.exceptions import InvalidDropException
 # @par EAGLE_START
 # @param category Branch
 # @param tag template
-# @param dropclass Application Class/dlg.apps.simple.SimpleBranch/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dummy0 dummy0//Object/OutputPort/readwrite//False/False/Dummy output port
-# @param dummy1 dummy1//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dropclass dlg.apps.simple.SimpleBranch/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dummy0 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
+# @param dummy1 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @par EAGLE_END
 class BranchAppDrop(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/constructs.py
+++ b/daliuge-engine/dlg/apps/constructs.py
@@ -7,8 +7,8 @@ from dlg.apps.app_base import BarrierAppDROP
 # @par EAGLE_START
 # @param category Scatter
 # @param tag template
-# @param num_of_copies Scatter dimension/4/Integer/ConstructParameter/readwrite//False/False/Specifies the number of replications of the content of the scatter construct
-# @param dropclass dropclass/dlg.apps.constructs.ScatterDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param num_of_copies 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Specifies the number of replications of the content of the scatter construct
+# @param dropclass dlg.apps.constructs.ScatterDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class ScatterDrop(BarrierAppDROP):
     """
@@ -24,9 +24,9 @@ class ScatterDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category Gather
 # @param tag template
-# @param num_of_inputs No. of inputs/2/Integer/ConstructParameter/readwrite//False/False/Number of inputs
-# @param gather_axis Index of gather axis/0/Integer/ApplicationArgument/readwrite//False/False/Index of gather axis
-# @param dropclass dropclass/dlg.apps.constructs.GatherDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param num_of_inputs 2/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Number of inputs
+# @param gather_axis 0/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Index of gather axis
+# @param dropclass dlg.apps.constructs.GatherDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class GatherDrop(BarrierAppDROP):
     """
@@ -42,8 +42,8 @@ class GatherDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category Loop
 # @param tag template
-# @param num_of_iter No. of iterations/2/Integer/ConstructParameter/readwrite//False/False/Number of iterations
-# @param dropclass dropclass/dlg.apps.constructs.LoopDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param num_of_iter 2/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Number of iterations
+# @param dropclass dlg.apps.constructs.LoopDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class LoopDrop(BarrierAppDROP):
     """
@@ -59,8 +59,8 @@ class LoopDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category MKN
 # @param tag template
-# @param k K/1/Integer/ConstructParameter/readwrite//False/False/Internal multiplicity
-# @param dropclass dropclass/dlg.apps.constructs.MKNDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param k 1/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Internal multiplicity
+# @param dropclass dlg.apps.constructs.MKNDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class MKNDrop(BarrierAppDROP):
     """
@@ -76,9 +76,9 @@ class MKNDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category GroupBy
 # @param tag template
-# @param num_of_inputs No. of inputs/2/Integer/ConstructParameter/readwrite//False/False/Number of inputs
-# @param gather_axis Index of gather axis/0/Integer/ApplicationArgument/readwrite//False/False/Index of gather axis
-# @param dropclass dropclass/dlg.apps.constructs.GroupByDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param num_of_inputs 2/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Number of inputs
+# @param gather_axis 0/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Index of gather axis
+# @param dropclass dlg.apps.constructs.GroupByDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class GroupByDrop(BarrierAppDROP):
     """
@@ -93,7 +93,7 @@ class GroupByDrop(BarrierAppDROP):
 # @details A SubGraph template drop
 # @par EAGLE_START
 # @param category SubGraph
-# @param dropclass dropclass/dlg.apps.constructs.SubGraphDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param dropclass dlg.apps.constructs.SubGraphDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param tag template
 # @par EAGLE_END
 class SubGraphDrop(BarrierAppDROP):
@@ -109,7 +109,7 @@ class SubGraphDrop(BarrierAppDROP):
 # @details A comment template drop
 # @par EAGLE_START
 # @param category Comment
-# @param dropclass dropclass/dlg.apps.constructs.CommentDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param dropclass dlg.apps.constructs.CommentDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param tag template
 # @par EAGLE_END
 class CommentDrop(BarrierAppDROP):
@@ -125,7 +125,7 @@ class CommentDrop(BarrierAppDROP):
 # @details A description template drop
 # @par EAGLE_START
 # @param category Description
-# @param dropclass dropclass/dlg.apps.constructs.DescriptionDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param dropclass dlg.apps.constructs.DescriptionDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param tag template
 # @par EAGLE_END
 class DescriptionDrop(BarrierAppDROP):
@@ -141,7 +141,7 @@ class DescriptionDrop(BarrierAppDROP):
 # @details An Exclusive Force Node
 # @par EAGLE_START
 # @param category ExclusiveForceNode
-# @param dropclass dropclass/dlg.apps.constructs.ExclusiveForceDrop/String/ComponentParameter/readwrite//False/False/Drop class
+# @param dropclass dlg.apps.constructs.ExclusiveForceDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param tag template
 # @par EAGLE_END
 class ExclusiveForceDrop(BarrierAppDROP):

--- a/daliuge-engine/dlg/apps/constructs.py
+++ b/daliuge-engine/dlg/apps/constructs.py
@@ -7,7 +7,7 @@ from dlg.apps.app_base import BarrierAppDROP
 # @par EAGLE_START
 # @param category Scatter
 # @param tag template
-# @param num_of_copies Scatter dimension/4/Integer/ComponentParameter/readwrite//False/False/Specifies the number of replications of the content of the scatter construct
+# @param num_of_copies Scatter dimension/4/Integer/ConstructParameter/readwrite//False/False/Specifies the number of replications of the content of the scatter construct
 # @param dropclass dropclass/dlg.apps.constructs.ScatterDrop/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END
 class ScatterDrop(BarrierAppDROP):
@@ -24,7 +24,7 @@ class ScatterDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category Gather
 # @param tag template
-# @param num_of_inputs No. of inputs/2/Integer/ApplicationArgument/readwrite//False/False/Number of inputs
+# @param num_of_inputs No. of inputs/2/Integer/ConstructParameter/readwrite//False/False/Number of inputs
 # @param gather_axis Index of gather axis/0/Integer/ApplicationArgument/readwrite//False/False/Index of gather axis
 # @param dropclass dropclass/dlg.apps.constructs.GatherDrop/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END
@@ -42,7 +42,7 @@ class GatherDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category Loop
 # @param tag template
-# @param num_of_iter No. of iterations/2/Integer/ApplicationArguments/readwrite//False/False/Number of iterations
+# @param num_of_iter No. of iterations/2/Integer/ConstructParameter/readwrite//False/False/Number of iterations
 # @param dropclass dropclass/dlg.apps.constructs.LoopDrop/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END
 class LoopDrop(BarrierAppDROP):
@@ -59,7 +59,7 @@ class LoopDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category MKN
 # @param tag template
-# @param k K/1/Integer/ApplicationArgument/readwrite//False/False/Internal multiplicity
+# @param k K/1/Integer/ConstructParameter/readwrite//False/False/Internal multiplicity
 # @param dropclass dropclass/dlg.apps.constructs.MKNDrop/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END
 class MKNDrop(BarrierAppDROP):
@@ -76,7 +76,7 @@ class MKNDrop(BarrierAppDROP):
 # @par EAGLE_START
 # @param category GroupBy
 # @param tag template
-# @param num_of_inputs No. of inputs/2/Integer/ApplicationArgument/readwrite//False/False/Number of inputs
+# @param num_of_inputs No. of inputs/2/Integer/ConstructParameter/readwrite//False/False/Number of inputs
 # @param gather_axis Index of gather axis/0/Integer/ApplicationArgument/readwrite//False/False/Index of gather axis
 # @param dropclass dropclass/dlg.apps.constructs.GroupByDrop/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END

--- a/daliuge-engine/dlg/apps/crc.py
+++ b/daliuge-engine/dlg/apps/crc.py
@@ -86,15 +86,15 @@ class CRCApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param dropclass Application Class/dlg.apps.crc.CRCStreamApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param data Data//String/OutputPort/readwrite//False/False/Input data stream
+# @param dropclass dlg.apps.crc.CRCStreamApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param data /String/ApplicationArgument/OutputPort/ReadWrite//False/False/Input data stream
 # @par EAGLE_END
 class CRCStreamApp(AppDROP):
     """

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -79,28 +79,28 @@ class ContainerIpWaiter(object):
 # @par EAGLE_START
 # @param category Docker
 # @param tag template
-# @param image Image//String/ComponentParameter/readwrite//False/False/The name of the docker image to be used for this application
-# @param tag Tag/1.0/String/ComponentParameter/readwrite//False/False/The tag of the docker image to be used for this application
-# @param digest Digest//String/ComponentParameter/readwrite//False/False/The hexadecimal hash (long version) of the docker image to be used for this application
-# @param command Command//String/ComponentParameter/readwrite//False/False/The command line to run within the docker instance. The specified command will be executed in a bash shell. That means that images will need a bash shell.
-# @param input_redirection Input Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the input into this application
-# @param output_redirection Output Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the output from this application
-# @param command_line_arguments Command Line Arguments//String/ComponentParameter/readwrite//False/False/Additional command line arguments to be added to the command line to be executed
-# @param paramValueSeparator Param value separator/ /String/ComponentParameter/readwrite//False/False/Separator character(s) between parameters and their respective values on the command line
-# @param argumentPrefix Argument prefix/"--"/String/ComponentParameter/readwrite//False/False/Prefix to each keyed argument on the command line
-# @param dropclass dropclass/dlg.apps.dockerapp.DockerApp/String/ComponentParameter/readwrite//False/False/Drop class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param user User//String/ComponentParameter/readwrite//False/False/Username of the user who will run the application within the docker image
-# @param ensureUserAndSwitch Ensure User And Switch/False/Boolean/ComponentParameter/readwrite//False/False/Make sure the user specified in the User parameter exists and then run the docker container as that user
-# @param removeContainer Remove Container/True/Boolean/ComponentParameter/readwrite//False/False/Instruct Docker engine to delete the container after execution is complete
-# @param additionalBindings Additional Bindings//String/ComponentParameter/readwrite//False/False/Directories which will be visible inside the container during run-time. Format is srcdir_on_host:trgtdir_on_container. Multiple entries can be separated by commas.
-# @param portMappings Port Mappings//String/ComponentParameter/readwrite//False/False/Port mappings on the host machine
+# @param image /String/ComponentParameter/NoPort/ReadWrite//False/False/The name of the docker image to be used for this application
+# @param tag 1.0/String/ComponentParameter/NoPort/ReadWrite//False/False/The tag of the docker image to be used for this application
+# @param digest /String/ComponentParameter/NoPort/ReadWrite//False/False/The hexadecimal hash (long version) of the docker image to be used for this application
+# @param command /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line to run within the docker instance. The specified command will be executed in a bash shell. That means that images will need a bash shell.
+# @param input_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the input into this application
+# @param output_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the output from this application
+# @param command_line_arguments /String/ComponentParameter/NoPort/ReadWrite//False/False/Additional command line arguments to be added to the command line to be executed
+# @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters and their respective values on the command line
+# @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param dropclass dlg.apps.dockerapp.DockerApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param user /String/ComponentParameter/NoPort/ReadWrite//False/False/Username of the user who will run the application within the docker image
+# @param ensureUserAndSwitch False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Make sure the user specified in the User parameter exists and then run the docker container as that user
+# @param removeContainer True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Instruct Docker engine to delete the container after execution is complete
+# @param additionalBindings /String/ComponentParameter/NoPort/ReadWrite//False/False/Directories which will be visible inside the container during run-time. Format is srcdir_on_host:trgtdir_on_container. Multiple entries can be separated by commas.
+# @param portMappings /String/ComponentParameter/NoPort/ReadWrite//False/False/Port mappings on the host machine
 # @par EAGLE_END
 class DockerApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -80,8 +80,8 @@ class ContainerIpWaiter(object):
 # @param category Docker
 # @param tag template
 # @param image /String/ComponentParameter/NoPort/ReadWrite//False/False/The name of the docker image to be used for this application
-# @param tag 1.0/String/ComponentParameter/NoPort/ReadWrite//False/False/The tag of the docker image to be used for this application
-# @param digest /String/ComponentParameter/NoPort/ReadWrite//False/False/The hexadecimal hash (long version) of the docker image to be used for this application
+# @param docker_tag 1.0/String/ComponentParameter/NoPort/ReadWrite//False/False/The tag of the docker image to be used for this application
+# @param docker_digest /String/ComponentParameter/NoPort/ReadWrite//False/False/The hexadecimal hash (long version) of the docker image to be used for this application
 # @param command /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line to run within the docker instance. The specified command will be executed in a bash shell. That means that images will need a bash shell.
 # @param input_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the input into this application
 # @param output_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the output from this application

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -482,6 +482,7 @@ def get_from_subprocess(proc, q):
 # @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
 # @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dropclass dropclass/dlg.apps.dynlib.DynlibProcApp/String/ComponentParameter/readwrite//False/False/Drop class
 # @par EAGLE_END
 class DynlibProcApp(BarrierAppDROP):
     """Loads a dynamic library in a different process and runs it"""

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -381,13 +381,13 @@ class DynlibStreamApp(DynlibAppBase, AppDROP):
 # @par EAGLE_START
 # @param category DynlibApp
 # @param tag template
-# @param libpath Library Path//String/ComponentParameter/readwrite//False/False/The location of the shared object/DLL that implements this application
-# @param dropclass dropclass/dlg.apps.dynlib.DynlibApp/String/ComponentParameter/readwrite//False/False/Drop class
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param libpath /String/ComponentParameter/NoPort/ReadWrite//False/False/"The location of the shared object/DLL that implements this application"
+# @param dropclass dlg.apps.dynlib.DynlibApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @par EAGLE_END
 class DynlibApp(DynlibAppBase, BarrierAppDROP):
     """Loads a dynamic library into the current process and runs it"""
@@ -476,13 +476,13 @@ def get_from_subprocess(proc, q):
 # @par EAGLE_START
 # @param category DynlibProcApp
 # @param tag template
-# @param libpath Library Path//String/ComponentParameter/readwrite//False/False/The location of the shared object/DLL that implements this application
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dropclass dropclass/dlg.apps.dynlib.DynlibProcApp/String/ComponentParameter/readwrite//False/False/Drop class
+# @param libpath /String/ComponentParameter/NoPort/ReadWrite//False/False/"The location of the shared object/DLL that implements this application"
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dropclass dlg.apps.dynlib.DynlibProcApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @par EAGLE_END
 class DynlibProcApp(BarrierAppDROP):
     """Loads a dynamic library in a different process and runs it"""

--- a/daliuge-engine/dlg/apps/mpi.py
+++ b/daliuge-engine/dlg/apps/mpi.py
@@ -38,21 +38,21 @@ logger = logging.getLogger(__name__)
 # @par EAGLE_START
 # @param category Mpi
 # @param tag template
-# @param num_of_procs Num procs/1/Integer/ComponentParameter/readwrite//False/False/Number of processes used for this application
-# @param command Command//String/ComponentParameter/readwrite//False/False/The command to be executed
-# @param input_redirection Input Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the input into this application
-# @param output_redirection Output Redirection//String/ComponentParameter/readwrite//False/False/The command line argument that specifies the output from this application
-# @param command_line_arguments Command Line Arguments//String/ComponentParameter/readwrite//False/False/Additional command line arguments to be added to the command line to be executed
-# @param paramValueSeparator Param value separator/ /String/ComponentParameter/readwrite//False/False/Separator character(s) between parameters on the command line
-# @param argumentPrefix Argument prefix/"--"/String/ComponentParameter/readwrite//False/False/Prefix to each keyed argument on the command line
-# @param dropclass dropclass/dlg.apps.mpi.MPIApp/String/ComponentParameter/readwrite//False/False/Drop class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param num_of_procs 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Number of processes used for this application
+# @param command /String/ComponentParameter/NoPort/ReadWrite//False/False/The command to be executed
+# @param input_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the input into this application
+# @param output_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the output from this application
+# @param command_line_arguments /String/ComponentParameter/NoPort/ReadWrite//False/False/Additional command line arguments to be added to the command line to be executed
+# @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters on the command line
+# @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param dropclass dlg.apps.mpi.MPIApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @par EAGLE_END
 class MPIApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -161,19 +161,19 @@ class DropParser(Enum):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag template
-# @param func_name Function Name//String/ApplicationArgument/readwrite//False/False/Python function name
-# @param func_code Function Code//String/ApplicationArgument/readwrite//False/False/Python function code, e.g. 'def function_name(args): return args'
-# @param dropclass Application Class/dlg.apps.pyfunc.PyFuncApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/The allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param func_name /String/ApplicationArgument/NoPort/ReadWrite//False/False/Python function name
+# @param func_code /String/ApplicationArgument/NoPort/ReadWrite//False/False/Python function code, e.g. 'def function_name(args): return args'
+# @param dropclass dlg.apps.pyfunc.PyFuncApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/The allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 #     \~English Mapping from argname to default value. Should match only the last part of the argnames list.
 #               Values are interpreted as Python code literals and that means string values need to be quoted.
-# @param func_arg_mapping Function Arguments Mapping//String/ApplicationArgument/readwrite//False/False/
+# @param func_arg_mapping /String/ApplicationArgument/NoPort/ReadWrite//False/False/
 #     \~English Mapping between argument name and input drop uids
 # @par EAGLE_END
 class PyFuncApp(BarrierAppDROP):

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -42,18 +42,18 @@ from dlg.meta import (
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param dropclass Application Class/dlg.apps.scp.ScpApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param remoteUser Remote User//String/ApplicationArgument/readwrite//False/False/Remote user address
-# @param pkeyPath Private Key Path//String/ApplicationArgument/readwrite//False/False/Private key path
-# @param timeout Timeout/60/Float/ApplicationArgument/readwrite//False/False/Connection timeout in seconds
-# @param file File//Object.PathBasedDrop/InputOutput/readwrite//False/False/File path
+# @param dropclass dlg.apps.scp.ScpApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param remoteUser /String/ApplicationArgument/NoPort/ReadWrite//False/False/Remote user address
+# @param pkeyPath /String/ApplicationArgument/NoPort/ReadWrite//False/False/Private key path
+# @param timeout 60/Float/ApplicationArgument/NoPort/ReadWrite//False/False/Connection timeout in seconds
+# @param file /Object.PathBasedDrop/ApplicationArgument/InputOutput/ReadWrite//False/False/File path
 # @par EAGLE_END
 class ScpApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -53,8 +53,7 @@ from dlg.meta import (
 # @param remoteUser Remote User//String/ApplicationArgument/readwrite//False/False/Remote user address
 # @param pkeyPath Private Key Path//String/ApplicationArgument/readwrite//False/False/Private key path
 # @param timeout Timeout/60/Float/ApplicationArgument/readwrite//False/False/Connection timeout in seconds
-# @param file File//Object.PathBasedDrop/InputPort/readwrite//False/False/Input file path
-# @param file File//Object.PathBasedDrop/OutputPort/readwrite//False/False/Output file path
+# @param file File//Object.PathBasedDrop/InputOutput/readwrite//False/False/File path
 # @par EAGLE_END
 class ScpApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -76,10 +76,10 @@ class NullBarrierApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag template
-# @param dropclass Application Class/PythonApp/String/ComponentParameter/readonly//False/False/Application class
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
+# @param dropclass PythonApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @par EAGLE_END
 class PythonApp(BarrierAppDROP):
     """A placeholder BarrierAppDrop that just aids the generation of the palette component"""
@@ -95,11 +95,11 @@ class PythonApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param sleep_time sleep_time/5/Integer/ApplicationArgument/readwrite//False/False/The number of seconds to sleep
-# @param dropclass dropclass/dlg.apps.simple.SleepApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
+# @param sleep_time 5/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/The number of seconds to sleep
+# @param dropclass dlg.apps.simple.SleepApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @par EAGLE_END
 class SleepApp(BarrierAppDROP):
     """A BarrierAppDrop that sleeps the specified amount of time (0 by default)"""
@@ -142,15 +142,15 @@ class SleepApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param bufsize buffer size/65536/Integer/ApplicationArgument/readwrite//False/False/Buffer size
-# @param dropclass dropclass/dlg.apps.simple.CopyApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param bufsize 65536/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Buffer size
+# @param dropclass dlg.apps.simple.CopyApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class CopyApp(BarrierAppDROP):
     """
@@ -203,13 +203,13 @@ class CopyApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param sleep_time sleep_time/5/Integer/ApplicationArgument/readwrite//False/False/The number of seconds to sleep
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param dropclass dropclass/dlg.apps.simple.SleepAndCopyApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
+# @param sleep_time 5/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/The number of seconds to sleep
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param dropclass dlg.apps.simple.SleepAndCopyApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @par EAGLE_END
 class SleepAndCopyApp(SleepApp, CopyApp):
     """A combination of the SleepApp and the CopyApp. It sleeps, then copies"""
@@ -228,17 +228,17 @@ class SleepAndCopyApp(SleepApp, CopyApp):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param size size/100/Integer/ApplicationArgument/readwrite//False/False/The size of the array
-# @param low low/0/Float/ApplicationArgument/readwrite//False/False/Low value of range in array [inclusive]
-# @param high high/1/Float/ApplicationArgument/readwrite//False/False/High value of range of array [exclusive]
-# @param integer integer/True/Boolean/ApplicationArgument/readwrite//False/False/Generate integer array?
-# @param dropclass dropclass/dlg.apps.simple.RandomArrayApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param array array//Object.Array/OutputPort/readwrite//False/False/Port carrying the averaged array
+# @param size 100/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/The size of the array
+# @param low 0/Float/ApplicationArgument/NoPort/ReadWrite//False/False/Low value of range in array [inclusive]
+# @param high 1/Float/ApplicationArgument/NoPort/ReadWrite//False/False/High value of range of array [exclusive]
+# @param integer True/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/Generate integer array?
+# @param dropclass dlg.apps.simple.RandomArrayApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param array /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the averaged array
 # @par EAGLE_END
 class RandomArrayApp(BarrierAppDROP):
     """
@@ -314,14 +314,14 @@ class RandomArrayApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param method method/mean/Select/ApplicationArgument/readwrite/mean,median/False/False/The method used for averaging
-# @param dropclass dropclass/dlg.apps.simple.AverageArraysApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param array Array//Object.Array/InputOutput/readwrite//False/False/Port for the array(s)
+# @param method mean/Select/ApplicationArgument/NoPort/ReadWrite/mean,median/False/False/The method used for averaging
+# @param dropclass dlg.apps.simple.AverageArraysApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param array /Object.Array/ApplicationArgument/InputOutput/ReadWrite//False/False/Port for the array(s)
 # @par EAGLE_END
 class AverageArraysApp(BarrierAppDROP):
     """
@@ -412,15 +412,15 @@ class AverageArraysApp(BarrierAppDROP):
 # @param category PythonApp
 # @param construct Gather
 # @param tag daliuge
-# @param num_of_inputs num_of_inputs/4/Integer/ConstructParameter/readwrite//False/False/The Gather “width”, stating how many inputs each Gather instance will handle
-# @param dropclass dropclass/dlg.apps.simple.GenericGatherApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input input//Object/InputPort/readwrite//False/False/0-base placeholder port for inputs
-# @param output output//Object/OutputPort/readwrite//False/False/Placeholder port for outputs
+# @param num_of_inputs 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/The Gather “width”, stating how many inputs each Gather instance will handle
+# @param dropclass dlg.apps.simple.GenericGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/0-base placeholder port for inputs
+# @param output /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Placeholder port for outputs
 # @par EAGLE_END
 class GenericGatherApp(BarrierAppDROP):
     def readWriteData(self):
@@ -441,26 +441,26 @@ class GenericGatherApp(BarrierAppDROP):
 
 ##
 # @brief GenericNpyGatherApp
-# @details A BarrierAppDrop that combines one or more inputs using cummulative operations.
+# @details A BarrierAppDrop that combines one or more inputs using cumulative operations.
 # @par EAGLE_START
 # @param category PythonApp
 # @param construct Gather
 # @param tag daliuge
-# @param num_of_inputs num_of_inputs/4/Integer/ConstructParameter/readwrite//False/False/The Gather “width”, stating how many inputs each Gather instance will handle
-# @param function function/sum/Select/ApplicationArgument/readwrite/sum,prod,min,max,add,multiply,maximum,minimum/False/False/The function used for gathering
-# @param reduce_axes reduce_axes/None/String/ApplicationArgument/readonly//False/False/The ndarray axes to reduce, None reduces all axes for sum, prod, max, min functions
-# @param dropclass dropclass/dlg.apps.simple.GenericNpyGatherApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param array_in array_in//Object.Array/InputPort/readwrite//False/False/Port for the input array(s)
-# @param array_out array_out//Object.Array/OutputPort/readwrite//False/False/Port carrying the reduced array
+# @param num_of_inputs 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/The Gather “width”, stating how many inputs each Gather instance will handle
+# @param function sum/Select/ApplicationArgument/NoPort/ReadWrite/sum,prod,min,max,add,multiply,maximum,minimum/False/False/The function used for gathering
+# @param reduce_axes None/String/ApplicationArgument/NoPort/ReadOnly//False/False/The array axes to reduce, None reduces all axes for sum, prod, max, min functions
+# @param dropclass dlg.apps.simple.GenericNpyGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/Port for the input array(s)
+# @param array_out /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the reduced array
 # @par EAGLE_END
 class GenericNpyGatherApp(BarrierAppDROP):
     """
-    A BarrierAppDrop that reduces then gathers one or more inputs using cummulative operations.
+    A BarrierAppDrop that reduces then gathers one or more inputs using cumulative operations.
     function:  string <'sum'|'prod'|'min'|'max'|'add'|'multiply'|'maximum'|'minimum'>.
 
     """
@@ -557,14 +557,14 @@ class GenericNpyGatherApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param greet greet/World/String/ApplicationArgument/readwrite//False/False/What appears after 'Hello '
-# @param dropclass dropclass/dlg.apps.simple.HelloWorldApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param hello hello/"world"/Object/OutputPort/readwrite//False/False/The port carrying the message produced by the app.
+# @param greet World/String/ApplicationArgument/NoPort/ReadWrite//False/False/What appears after 'Hello '
+# @param dropclass dlg.apps.simple.HelloWorldApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param hello "world"/Object/ApplicationArgument/OutputPort/ReadWrite//False/False/The port carrying the message produced by the app.
 # @par EAGLE_END
 class HelloWorldApp(BarrierAppDROP):
     """
@@ -620,14 +620,14 @@ class HelloWorldApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param url url/"https://eagle.icrar.org"/String/ApplicationArgument/readwrite//False/False/The URL to retrieve
-# @param dropclass dropclass/dlg.apps.simple.UrlRetrieveApp/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param content content//String/OutputPort/readwrite//False/False/The port carrying the content read from the URL
+# @param url "https://eagle.icrar.org"/String/ApplicationArgument/NoPort/ReadWrite//False/False/The URL to retrieve
+# @param dropclass dlg.apps.simple.UrlRetrieveApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param content /String/ApplicationArgument/OutputPort/ReadWrite//False/False/The port carrying the content read from the URL
 # @par EAGLE_END
 class UrlRetrieveApp(BarrierAppDROP):
     """
@@ -677,16 +677,16 @@ class UrlRetrieveApp(BarrierAppDROP):
 # @param category PythonApp
 # @param construct Scatter
 # @param tag daliuge
-# @param num_of_copies num_of_copies/4/Integer/ConstructParameter/readwrite//False/False/Specifies the number of replications of the content of the scatter construct
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param n_tries n_tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dropclass dropclass/dlg.apps.simple.GenericScatterApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param array_in array_in//Object.Array/InputPort/readwrite//False/False/A numpy array of arrays, where the first axis is of length <numSplit>
-# @param array_out array_out//Object.Array/OutputPort/readwrite//False/False/Port carrying the reduced array
+# @param num_of_copies 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Specifies the number of replications of the content of the scatter construct
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/A numpy array of arrays, where the first axis is of length <numSplit>
+# @param array_out /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the reduced array
 # @par EAGLE_END
 class GenericScatterApp(BarrierAppDROP):
     """
@@ -743,16 +743,16 @@ class GenericScatterApp(BarrierAppDROP):
 # @param construct Scatter
 # @param category PythonApp
 # @param tag daliuge
-# @param num_of_copies num_of_copies/4/Integer/ConstructParameter/readwrite//False/False/Specifies the number of replications of the content of the scatter construct
-# @param scatter_axes scatter_axes//String/ApplicationArgument/readwrite//False/False/The axes to split input ndarrays on, e.g. [0,0,0], length must match the number of input ports
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param dropclass dropclass/dlg.apps.simple.GenericNpyScatterApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param array_in array_in//Object.Array/InputPort/readwrite//False/False/A numpy array of arrays
-# @param array_out array_out//Object.Array/OutputPort/readwrite//False/False/Port carrying the reduced array
+# @param num_of_copies 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Specifies the number of replications of the content of the scatter construct
+# @param scatter_axes /String/ApplicationArgument/NoPort/ReadWrite//False/False/The axes to split input ndarrays on, e.g. [0,0,0], length must match the number of input ports
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param dropclass dlg.apps.simple.GenericNpyScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/A numpy array of arrays
+# @param array_out /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the reduced array
 # @par EAGLE_END
 class GenericNpyScatterApp(BarrierAppDROP):
     """
@@ -825,15 +825,14 @@ class SimpleBranch(BranchAppDrop, NullBarrierApp):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param dropclass dropclass/dlg.apps.simple.PickOne/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param rest_array_in rest_array//Object.array/InputPort/readwrite//False/FalseList of elements
-# @param rest_array_out rest_array//Object.array/OutputPort/readwrite//False/False/Port carrying the rest array
-# @param element element//Object.element/OutputPort/readwrite//False/False/Port carrying the first element of input array
+# @param dropclass dlg.apps.simple.PickOne/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param rest_array /Object.array/ApplicationArgument/InputOutput/ReadWrite//False/False/List of elements
+# @param element /Object.element/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the first element of input array
 # @par EAGLE_END
 class PickOne(BarrierAppDROP):
     """
@@ -889,14 +888,14 @@ class PickOne(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param size size/100/Integer/ApplicationArgument/readwrite//False/False/the size of the array
-# @param dropclass dropclass/dlg.apps.simple.ListAppendThrashingApp/String/ComponentParameter/readonly//False/False/Application class
-# @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
-# @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param array array//Object.Array/OutputPort/readwrite//False/False/Port carrying the random array.
+# @param size 100/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/the size of the array
+# @param dropclass dlg.apps.simple.ListAppendThrashingApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param input_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
+# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param array /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/Port carrying the random array.
 # @par EAGLE_END
 class ListAppendThrashingApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -148,8 +148,7 @@ class SleepApp(BarrierAppDROP):
 # @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
 # @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
 # @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dummy_in dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy_out dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @param input_parser Input Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
 # @param output_parser Output Parser/pickle/Select/ApplicationArgument/readwrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
@@ -322,8 +321,7 @@ class RandomArrayApp(BarrierAppDROP):
 # @param execution_time execution_time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
 # @param num_cpus num_cpus/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
 # @param group_start group_start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param array_in Array//Object.Array/InputPort/readwrite//False/False/Port for the input array(s)
-# @param array_out Array//Object.Array/OutputPort/readwrite//False/False/Port carrying the averaged array
+# @param array Array//Object.Array/InputOutput/readwrite//False/False/Port for the array(s)
 # @par EAGLE_END
 class AverageArraysApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/socket_listener.py
+++ b/daliuge-engine/dlg/apps/socket_listener.py
@@ -56,17 +56,17 @@ logger = logging.getLogger(__name__)
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param dropclass Application Class/dlg.apps.socket_listener.SocketListener/String/ComponentParameter/readonly//False/False/Application class
-# @param execution_time Execution Time/5/Float/ComponentParameter/readonly//False/False/Estimated execution time
-# @param num_cpus No. of CPUs/1/Integer/ComponentParameter/readonly//False/False/Number of cores used
-# @param group_start Group start/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the start of a group?
-# @param input_error_threshold "Input error rate (%)"/0/Integer/ComponentParameter/readwrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries Number of tries/1/Integer/ComponentParameter/readwrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param host Host/localhost/String/ApplicationArgument/readwrite//False/False/Host address
-# @param port Port/1111/Integer/ApplicationArgument/readwrite//False/False/Host port
-# @param bufsize Buffer Size/4096/String/ApplicationArgument/readwrite//False/False/Receive buffer size
-# @param reuseAddr Reuse Address/False/Boolean/ApplicationArgument/readwrite//False/False/
-# @param data Data//String/OutputPort/readwrite//False/False/
+# @param dropclass dlg.apps.socket_listener.SocketListener/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param execution_time 5/Float/ComponentParameter/NoPort/ReadOnly//False/False/Estimated execution time
+# @param num_cpus 1/Integer/ComponentParameter/NoPort/ReadOnly//False/False/Number of cores used
+# @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
+# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
+# @param host localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/Host address
+# @param port 1111/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Host port
+# @param bufsize 4096/String/ApplicationArgument/NoPort/ReadWrite//False/False/Receive buffer size
+# @param reuseAddr False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/
+# @param data /String/ApplicationArgument/OutputPort/ReadWrite//False/False/
 # @par EAGLE_END
 class SocketListenerApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -59,12 +59,12 @@ logger = logging.getLogger(__name__)
 # @par EAGLE_START
 # @param category Data
 # @param tag template
-# @param dropclass Data Class/my.awesome.data.Component/String/ComponentParameter/readonly//False/False/The python class that implements this data component
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param dropclass my.awesome.data.Component/String/ComponentParameter/NoPort/ReadOnly//False/False/The python class that implements this data component
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class DataDROP(AbstractDROP):
     """
@@ -408,9 +408,10 @@ class PathBasedDrop(object):
 # @par EAGLE_START
 # @param category Memory
 # @param tag daliuge
-# @param dropclass dropclass/dlg.data.drops.data_base.NullDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param dropclass dlg.data.drops.data_base.NullDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class NullDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -64,8 +64,7 @@ logger = logging.getLogger(__name__)
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class DataDROP(AbstractDROP):
     """
@@ -411,8 +410,7 @@ class PathBasedDrop(object):
 # @param tag daliuge
 # @param dropclass dropclass/dlg.data.drops.data_base.NullDROP/String/ComponentParameter/readwrite//False/False/Drop class
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class NullDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/directorycontainer.py
+++ b/daliuge-engine/dlg/data/drops/directorycontainer.py
@@ -33,8 +33,8 @@ from dlg.meta import dlg_bool_param
 logger = logging.getLogger(__name__)
 
 
-##
 # TODO: This needs some more work
+##
 # @brief Directory
 # @details A ContainerDROP that represents a filesystem directory. It only allows
 # FileDROPs and DirectoryContainers to be added as children. Children
@@ -43,12 +43,12 @@ logger = logging.getLogger(__name__)
 # @par EAGLE_START
 # @param category Directory
 # @param tag future
-# @param dropclass dropclass/dlg.data.drops.directorycontainer.DirectoryContainer/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param check_exists Check path exists/True/Boolean/ApplicationArgument/readwrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
-# @param dirname Directory name//String/ApplicationArgument/readwrite//False/False/"Directory name/path"
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dropclass dlg.data.drops.directorycontainer.DirectoryContainer/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param check_exists True/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
+# @param dirname /String/ApplicationArgument/NoPort/ReadWrite//False/False/"Directory name/path"
+# @param dummy /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @par EAGLE_END
 class DirectoryContainer(PathBasedDrop, ContainerDROP):
     """

--- a/daliuge-engine/dlg/data/drops/environmentvar_drop.py
+++ b/daliuge-engine/dlg/data/drops/environmentvar_drop.py
@@ -66,10 +66,10 @@ def _filter_parameters(parameters: dict):
 # @par EAGLE_START
 # @param category EnvironmentVariables
 # @param tag daliuge
-# @param dropclass dropclass/dlg.data.drops.environmentvar_drop.EnvironmentVarDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dropclass dlg.data.drops.environmentvar_drop.EnvironmentVarDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @par EAGLE_END
 class EnvironmentVarDROP(AbstractDROP, KeyValueDROP):
     """

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -39,14 +39,14 @@ from typing import Union
 # @par EAGLE_START
 # @param category File
 # @param tag daliuge
-# @param filepath File Path//String/ApplicationArgument/readwrite//False/False/File path for this file. In many cases this does not need to be specified. If it has a \/ at the end it will be treated as a directory name and the filename will be generated. If it does not have a \/, the last part will be treated as a filename. If filepath does not start with \/ (relative path) then the session directory will be prepended to make the path absolute.
-# @param check_filepath_exists Check existence/False/Boolean/ComponentParameter/readwrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
-# @param dropclass dropclass/dlg.data.drops.file.FileDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/True/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param filepath /String/ApplicationArgument/NoPort/ReadWrite//False/False/"File path for this file. In many cases this does not need to be specified. If it has a \/ at the end it will be treated as a directory name and the filename will be generated. If it does not have a \/, the last part will be treated as a filename. If filepath does not start with \/ (relative path) then the session directory will be prepended to make the path absolute.""
+# @param check_filepath_exists False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
+# @param dropclass dlg.data.drops.file.FileDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class FileDROP(DataDROP, PathBasedDrop):
     """

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -46,8 +46,7 @@ from typing import Union
 # @param persist Persist/True/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
 # @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class FileDROP(DataDROP, PathBasedDrop):
     """

--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -37,12 +37,12 @@ from dlg.data.io import SharedMemoryIO, MemoryIO
 # @par EAGLE_START
 # @param category Memory
 # @param tag daliuge
-# @param dropclass dropclass/dlg.data.drops.memory.InMemoryDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param dropclass dlg.data.drops.memory.InMemoryDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class InMemoryDROP(DataDROP):
     """
@@ -101,12 +101,12 @@ class InMemoryDROP(DataDROP):
 # @par EAGLE_START
 # @param category SharedMemory
 # @param tag daliuge
-# @param dropclass dropclass/dlg.data.drops.memory.SharedMemoryDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param dropclass dlg.data.drops.memory.SharedMemoryDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class SharedMemoryDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -42,8 +42,7 @@ from dlg.data.io import SharedMemoryIO, MemoryIO
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class InMemoryDROP(DataDROP):
     """
@@ -107,8 +106,7 @@ class InMemoryDROP(DataDROP):
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class SharedMemoryDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/ngas.py
+++ b/daliuge-engine/dlg/data/drops/ngas.py
@@ -31,18 +31,18 @@ from dlg.meta import dlg_string_param, dlg_int_param
 # @par EAGLE_START
 # @param category NGAS
 # @param tag daliuge
-# @param ngasSrv NGAS Server/localhost/String/ComponentParameter/readwrite//False/False/The URL of the NGAS Server
-# @param ngasPort NGAS Port/7777/Integer/ComponentParameter/readwrite//False/False/The port of the NGAS Server
-# @param ngasFileId File ID//String/ComponentParameter/readwrite//False/False/File ID on NGAS (for retrieval only)
-# @param ngasConnectTimeout Connection timeout/2/Integer/ComponentParameter/readwrite//False/False/Timeout for connecting to the NGAS server
-# @param ngasMime NGAS mime-type/"text/ascii"/String/ComponentParameter/readwrite//False/False/Mime-type to be used for archiving
-# @param ngasTimeout NGAS timeout/2/Integer/ComponentParameter/readwrite//False/False/Timeout for receiving responses for NGAS
-# @param dropclass dropclass/dlg.data.drops.ngas.NgasDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param ngasSrv localhost/String/ComponentParameter/NoPort/ReadWrite//False/False/The URL of the NGAS Server
+# @param ngasPort 7777/Integer/ComponentParameter/NoPort/ReadWrite//False/False/The port of the NGAS Server
+# @param ngasFileId /String/ComponentParameter/NoPort/ReadWrite//False/False/File ID on NGAS (for retrieval only)
+# @param ngasConnectTimeout 2/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Timeout for connecting to the NGAS server
+# @param ngasMime "text/ascii"/String/ComponentParameter/NoPort/ReadWrite//False/False/Mime-type to be used for archiving
+# @param ngasTimeout 2/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Timeout for receiving responses for NGAS
+# @param dropclass dlg.data.drops.ngas.NgasDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class NgasDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/ngas.py
+++ b/daliuge-engine/dlg/data/drops/ngas.py
@@ -42,8 +42,7 @@ from dlg.meta import dlg_string_param, dlg_int_param
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class NgasDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/parset_drop.py
+++ b/daliuge-engine/dlg/data/drops/parset_drop.py
@@ -34,15 +34,14 @@ from dlg.meta import dlg_string_param
 # @par EAGLE_START
 # @param category ParameterSet
 # @param tag daliuge
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param mode Parset mode/"YANDA"/String/ComponentParameter/readonly//False/False/To what standard DALiuGE should filter and serialize the parameters.
-# @param config_data ConfigData/""/String/ComponentParameter/readwrite//False/False/Additional configuration information to be mixed in with the initial data
-# @param dropclass dropclass/dlg.data.drops.parset_drop.ParameterSetDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dropclass dropclass//dlg.data.drops.parset_drop.ParameterSetDROP//readonly//False/False/default class for this DROP
-# @param Config ConfigFile//Object.File/OutputPort/readwrite//False/False/The output configuration file
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param mode "YANDA"/String/ComponentParameter/NoPort/ReadOnly//False/False/To what standard DALiuGE should filter and serialize the parameters.
+# @param config_data ""/String/ComponentParameter/NoPort/ReadWrite//False/False/Additional configuration information to be mixed in with the initial data
+# @param dropclass dlg.data.drops.parset_drop.ParameterSetDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param Config /Object.File/ApplicationArgument/OutputPort/ReadWrite//False/False/The output configuration file
 # @par EAGLE_END
 class ParameterSetDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/plasma.py
+++ b/daliuge-engine/dlg/data/drops/plasma.py
@@ -36,13 +36,13 @@ from dlg.meta import dlg_string_param, dlg_bool_param
 # @par EAGLE_START
 # @param category Plasma
 # @param tag daliuge
-# @param plasma_path Plasma Path//String/ApplicationArgument/readwrite//False/False/Path to the local plasma store
-# @param object_id Object Id//String/ApplicationArgument/readwrite//False/False/PlasmaId of the object for all compute nodes
-# @param dropclass dropclass/dlg.data.drops.plasma.PlasmaDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param use_staging Use Staging/False/Boolean/ComponentParameter/readwrite//False/False/Enables writing to a dynamically resizeable staging buffer
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param plasma_path /String/ApplicationArgument/NoPort/ReadWrite//False/False/Path to the local plasma store
+# @param object_id /String/ApplicationArgument/NoPort/ReadWrite//False/False/PlasmaId of the object for all compute nodes
+# @param dropclass dlg.data.drops.plasma.PlasmaDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param use_staging False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Enables writing to a dynamically resizeable staging buffer
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class PlasmaDROP(DataDROP):
     """
@@ -87,13 +87,13 @@ class PlasmaDROP(DataDROP):
 # @par EAGLE_START
 # @param category PlasmaFlight
 # @param tag daliuge
-# @param plasma_path Plasma Path//String/ApplicationArgument/readwrite//False/False/Path to the local plasma store
-# @param object_id Object Id//String/ApplicationArgument/readwrite//False/False/PlasmaId of the object for all compute nodes
-# @param dropclass dropclass/dlg.data.drops.plasma.PlasmaFlightDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param flight_path Flight Path//String/ComponentParameter/readwrite//False/False/IP and flight port of the drop owner
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param plasma_path /String/ApplicationArgument/NoPort/ReadWrite//False/False/Path to the local plasma store
+# @param object_id /String/ApplicationArgument/NoPort/ReadWrite//False/False/PlasmaId of the object for all compute nodes
+# @param dropclass dlg.data.drops.plasma.PlasmaFlightDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param flight_path /String/ComponentParameter/NoPort/ReadWrite//False/False/IP and flight port of the drop owner
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class PlasmaFlightDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/plasma.py
+++ b/daliuge-engine/dlg/data/drops/plasma.py
@@ -42,9 +42,7 @@ from dlg.meta import dlg_string_param, dlg_bool_param
 # @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param use_staging Use Staging/False/Boolean/ComponentParameter/readwrite//False/False/Enables writing to a dynamically resizeable staging buffer
-# @param dropclass dropclass/dlg.data.drops.plasma.PlasmaDROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class PlasmaDROP(DataDROP):
     """
@@ -95,8 +93,7 @@ class PlasmaDROP(DataDROP):
 # @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
 # @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
 # @param flight_path Flight Path//String/ComponentParameter/readwrite//False/False/IP and flight port of the drop owner
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class PlasmaFlightDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/rdbms.py
+++ b/daliuge-engine/dlg/data/drops/rdbms.py
@@ -35,15 +35,15 @@ from dlg.utils import prepare_sql
 # @par EAGLE_START
 # @param category RDBMS
 # @param tag daliuge
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param dbmodule Python DB module//String/ComponentParameter/readwrite//False/False/Load path for python DB module
-# @param dbtable DB table name//String/ComponentParameter/readwrite//False/False/The name of the table to use
-# @param vals Values dictionary/{}/Json/ComponentParameter/readwrite//False/False/Json encoded values dictionary used for INSERT. The keys of ``vals`` are used as the column names.
-# @param condition Whats used after WHERE//String/ComponentParameter/readwrite//False/False/Condition for SELECT. For this the WHERE statement must be written using the "{X}" or "{}" placeholders
-# @param selectVals values for WHERE/{}/Json/ComponentParameter/readwrite//False/False/Values for the WHERE statement
-# @param dropclass dropclass/dlg.data.drops.rdbms.RDBMSDrop/String/ComponentParameter/readwrite//False/False/Drop class
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param dbmodule /String/ComponentParameter/NoPort/ReadWrite//False/False/Load path for python DB module
+# @param dbtable /String/ComponentParameter/NoPort/ReadWrite//False/False/The name of the table to use
+# @param vals {}/Json/ComponentParameter/NoPort/ReadWrite//False/False/Json encoded values dictionary used for INSERT. The keys of ``vals`` are used as the column names.
+# @param condition /String/ComponentParameter/NoPort/ReadWrite//False/False/Condition for SELECT. For this the WHERE statement must be written using the "{X}" or "{}" placeholders
+# @param selectVals {}/Json/ComponentParameter/NoPort/ReadWrite//False/False/Values for the WHERE statement
+# @param dropclass dlg.data.drops.rdbms.RDBMSDrop/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class RDBMSDrop(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/rdbms.py
+++ b/daliuge-engine/dlg/data/drops/rdbms.py
@@ -43,8 +43,7 @@ from dlg.utils import prepare_sql
 # @param condition Whats used after WHERE//String/ComponentParameter/readwrite//False/False/Condition for SELECT. For this the WHERE statement must be written using the "{X}" or "{}" placeholders
 # @param selectVals values for WHERE/{}/Json/ComponentParameter/readwrite//False/False/Values for the WHERE statement
 # @param dropclass dropclass/dlg.data.drops.rdbms.RDBMSDrop/String/ComponentParameter/readwrite//False/False/Drop class
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class RDBMSDrop(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/s3_drop.py
+++ b/daliuge-engine/dlg/data/drops/s3_drop.py
@@ -55,16 +55,16 @@ from dlg.named_port_utils import identify_named_ports, check_ports_dict
 # @par EAGLE_START
 # @param category S3
 # @param tag daliuge
-# @param data_volume Data volume/5/Float/ComponentParameter/readwrite//False/False/Estimated size of the data contained in this node
-# @param group_end Group end/False/Boolean/ComponentParameter/readwrite//False/False/Is this node the end of a group?
-# @param Bucket Bucket//String/ComponentParameter/readwrite//False/False/The S3 Bucket
-# @param Key Key//String/ComponentParameter/readwrite//False/False/The S3 object key
-# @param profile_name Profile Name//String/ComponentParameter/readwrite//False/False/The S3 profile name
-# @param endpoint_url Endpoint URL//String/ComponentParameter/readwrite//False/False/The URL exposing the S3 REST API
-# @param dropclass dropclass/dlg.data.drops.s3_drop.S3DROP/String/ComponentParameter/readwrite//False/False/Drop class
-# @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
-# @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
+# @param data_volume 5/Float/ComponentParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
+# @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
+# @param Bucket /String/ComponentParameter/NoPort/ReadWrite//False/False/The S3 Bucket
+# @param Key /String/ComponentParameter/NoPort/ReadWrite//False/False/The S3 object key
+# @param profile_name /String/ComponentParameter/NoPort/ReadWrite//False/False/The S3 profile name
+# @param endpoint_url /String/ComponentParameter/NoPort/ReadWrite//False/False/The URL exposing the S3 REST API
+# @param dropclass dlg.data.drops.s3_drop.S3DROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
+# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class S3DROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/s3_drop.py
+++ b/daliuge-engine/dlg/data/drops/s3_drop.py
@@ -61,11 +61,10 @@ from dlg.named_port_utils import identify_named_ports, check_ports_dict
 # @param Key Key//String/ComponentParameter/readwrite//False/False/The S3 object key
 # @param profile_name Profile Name//String/ComponentParameter/readwrite//False/False/The S3 profile name
 # @param endpoint_url Endpoint URL//String/ComponentParameter/readwrite//False/False/The URL exposing the S3 REST API
-# @param dropclass dropclass/dlg.data.drops.s3_drop.S3DROP/String/ComponentParameter/readwrite//False/False/The URL exposing the S3 REST API
+# @param dropclass dropclass/dlg.data.drops.s3_drop.S3DROP/String/ComponentParameter/readwrite//False/False/Drop class
 # @param streaming Streaming/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component streams input and output data
 # @param persist Persist/False/Boolean/ComponentParameter/readwrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy dummy//Object/InputPort/readwrite//False/False/Dummy input port
-# @param dummy dummy//Object/OutputPort/readwrite//False/False/Dummy output port
+# @param dummy dummy//Object/InputOutput/readwrite//False/False/Dummy port
 # @par EAGLE_END
 class S3DROP(DataDROP):
     """


### PR DESCRIPTION
Modifies the CI workflow to use dlg_paletteGen to create the daliuge palettes.

Updated doxygen for components that:

- Uses ConstructParameter where appropriate
- Adds a 'dropclass' field where missing
- Combines separate 'dummy' input and output ports into a single 'InputOutput' port

These changes are not supported by dlg_paletteGen, and sometimes cause warnings, but dlg_paletteGen still creates a valid palette, and EAGLE handles the palette correctly.