### PR TITLE
Drop MultiProcessing

### DIFF
--- a/daliuge-engine/dlg/apps/app_base.py
+++ b/daliuge-engine/dlg/apps/app_base.py
@@ -105,6 +105,15 @@ class AppDROP(ContainerDROP):
     an streaming input); for these cases see the `BarrierAppDROP`.
     """
 
+    def __getstate__(self):
+        state = super().__getstate__()
+        del state["_drop_runner"]
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._drop_runner = _SYNC_DROP_RUNNER
+
     def initialize(self, **kwargs):
         super(AppDROP, self).initialize(**kwargs)
 

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -258,8 +258,8 @@ class BashShellBase(object):
         # Pass down daliuge-specific information to the subprocesses as environment variables
         env = os.environ.copy()
         env.update({"DLG_UID": self._uid})
-        if self._dlg_session:
-            env.update({"DLG_SESSION_ID": self._dlg_session.sessionId})
+        if self._dlg_session_id:
+            env.update({"DLG_SESSION_ID": self._dlg_session_id})
 
         env.update({"DLG_ROOT": utils.getDlgDir()})
 

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -364,9 +364,7 @@ class DockerApp(BarrierAppDROP):
             "WorkingDir", None
         )
         # self.workdir = None
-        self._sessionId = (
-            self._dlg_session.sessionId if self._dlg_session else ""
-        )
+        self._sessionId = self._dlg_session_id
         if not self.workdir:
             default_workingdir = os.path.join(
                 utils.getDlgWorkDir(), self._sessionId
@@ -492,8 +490,8 @@ class DockerApp(BarrierAppDROP):
             # deal with environment variables
             env = {}
             env.update({"DLG_UID": self._uid})
-            if self._dlg_session:
-                env.update({"DLG_SESSION_ID": self._dlg_session.sessionId})
+            if self._dlg_session_id:
+                env.update({"DLG_SESSION_ID": self._dlg_session_id})
             if self._user is not None:
                 env.update({"USER": self._user, "DLG_ROOT": utils.getDlgDir()})
             if self._env is not None:

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -26,9 +26,8 @@ import logging
 import multiprocessing
 import queue
 import threading
-import six
 
-from .. import rpc, utils
+from .. import rpc
 from ..ddap_protocol import AppDROPStates
 from ..apps.app_base import AppDROP, BarrierAppDROP
 from ..exceptions import InvalidDropException
@@ -496,7 +495,7 @@ class DynlibProcApp(BarrierAppDROP):
         self.proc = None
 
     def run(self):
-        if not hasattr(self, "_rpc_endpoint"):
+        if self._rpc_endpoint is None:
             raise Exception("DynlibProcApp can only run within an RPC server")
 
         # On the sub-process we create DropProxy objects, so we need to extract

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -440,9 +440,7 @@ def _do_run_in_proc(queue, libname, oid, uid, params, inputs, outputs):
         client.start()
 
         def setup_drop_proxies(inputs, outputs):
-            to_drop_proxy = lambda x: rpc.DropProxy(
-                client, x[0], x[1], x[2], x[3]
-            )
+            to_drop_proxy = lambda proxy_info: rpc.DropProxy(client, proxy_info)
             inputs = [to_drop_proxy(i) for i in inputs]
             outputs = [to_drop_proxy(o) for o in outputs]
             return inputs, outputs
@@ -505,8 +503,8 @@ class DynlibProcApp(BarrierAppDROP):
         # from our inputs/outputs their contact point (RPC-wise) information.
         # If one of our inputs/outputs is a DropProxy we already have this
         # information; otherwise we must figure it out.
-        inputs = [self._get_proxy_info(i) for i in self.inputs]
-        outputs = [self._get_proxy_info(o) for o in self.outputs]
+        inputs = [rpc.ProxyInfo.from_data_drop(i) for i in self.inputs]
+        outputs = [rpc.ProxyInfo.from_data_drop(o) for o in self.outputs]
 
         logger.info("Starting new process to run the dynlib on")
         queue = multiprocessing.Queue()
@@ -536,18 +534,6 @@ class DynlibProcApp(BarrierAppDROP):
                     raise error
         finally:
             self.proc.join(self.timeout)
-
-    def _get_proxy_info(self, x):
-        if isinstance(x, rpc.DropProxy):
-            return x.hostname, x.port, x.session_id, x.uid
-
-        # TODO: we can't use the NodeManager's host directly here, as that
-        #       indicates the address the different servers *bind* to
-        #       (and, for example, can be 0.0.0.0)
-        rpc_server = x._rpc_server
-        host, port = rpc_server._rpc_host, rpc_server._rpc_port
-        host = utils.to_externally_contactable_host(host, prefer_local=True)
-        return (host, port, x._dlg_session.sessionId, x.uid)
 
     def cancel(self):
         BarrierAppDROP.cancel(self)

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -496,7 +496,7 @@ class DynlibProcApp(BarrierAppDROP):
         self.proc = None
 
     def run(self):
-        if not hasattr(self, "_rpc_server"):
+        if not hasattr(self, "_rpc_endpoint"):
             raise Exception("DynlibProcApp can only run within an RPC server")
 
         # On the sub-process we create DropProxy objects, so we need to extract

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -360,8 +360,8 @@ class PyFuncApp(BarrierAppDROP):
 
         env = os.environ.copy()
         env.update({"DLG_UID": self._uid})
-        if self._dlg_session:
-            env.update({"DLG_SESSION_ID": self._dlg_session.sessionId})
+        if self._dlg_session_id:
+            env.update({"DLG_SESSION_ID": self._dlg_session_id})
 
         self._applicationArgs = self._popArg(kwargs, "applicationArgs", {})
 

--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -385,7 +385,7 @@ class PathBasedDrop(object):
             return dirname
 
         parts = []
-        if self._dlg_session:
+        if self._dlg_session_id:
             parts.append(".")
         else:
             parts.append("/tmp/daliuge_tfiles")

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -164,6 +164,10 @@ class AbstractDROP(EventFirer, EventHandler):
     #  - Subclasses implement methods decorated with @abstractmethod
     __metaclass__ = ABCMeta
 
+    # Matcher used to validate environment_variable_syntax
+    _env_var_matcher = re.compile(r"\$[A-z|\d]+\..+")
+    _dlg_var_matcher = re.compile(r"\$DLG_.+")
+
     @track_current_drop
     def __init__(self, oid, uid, **kwargs):
         """
@@ -220,10 +224,6 @@ class AbstractDROP(EventFirer, EventHandler):
         self._consumers = ListAsDict(self._consumers_uids)
         self._producers_uids = set()
         self._producers = ListAsDict(self._producers_uids)
-
-        # Matcher used to validate environment_variable_syntax
-        self._env_var_matcher = re.compile(r"\$[A-z|\d]+\..+")
-        self._dlg_var_matcher = re.compile(r"\$DLG_.+")
 
         # Set holding the state of the producers that have finished their
         # execution. Once all producers have finished, this DROP moves

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -197,11 +197,11 @@ class AbstractDROP(EventFirer, EventHandler):
         # by the drop category when generating the drop spec
         self._type = self._popArg(kwargs, "categoryType", None)
 
-        # The Session owning this drop, if any
+        # The ID of the session owning this drop, if any
         # In most real-world situations this attribute will be set, but in
         # general it cannot be assumed it will (e.g., unit tests create drops
         # directly outside the context of a session).
-        self._dlg_session = self._popArg(kwargs, "dlg_session", None)
+        self._dlg_session_id = self._popArg(kwargs, "dlg_session_id", "")
 
         # A simple name that the Drop might receive
         # This is usually set in the Logical Graph Editor,
@@ -775,9 +775,7 @@ class AbstractDROP(EventFirer, EventHandler):
         """
         kwargs["oid"] = self.oid
         kwargs["uid"] = self.uid
-        kwargs["session_id"] = (
-            self._dlg_session.sessionId if self._dlg_session else ""
-        )
+        kwargs["session_id"] = self._dlg_session_id
         kwargs["name"] = self.name
         kwargs["lg_key"] = self.lg_key
         self._fireEvent(eventType, **kwargs)

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -23,6 +23,7 @@
 Module containing the core DROP classes.
 """
 import ast
+import collections
 import inspect
 import logging
 import os
@@ -31,6 +32,7 @@ import time
 import re
 import sys
 from abc import ABCMeta
+from typing import Optional, Tuple
 
 from dlg.common.reproducibility.constants import (
     ReproducibilityFlags,
@@ -167,6 +169,29 @@ class AbstractDROP(EventFirer, EventHandler):
     # Matcher used to validate environment_variable_syntax
     _env_var_matcher = re.compile(r"\$[A-z|\d]+\..+")
     _dlg_var_matcher = re.compile(r"\$DLG_.+")
+
+    _known_locks = ('_finishedProducersLock', '_refLock')
+    _known_rlocks = ('_statusLock',)
+
+    _rpc_endpoint: Optional[Tuple[str, int]] = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for attr_name in AbstractDROP._known_locks + AbstractDROP._known_rlocks:
+            del state[attr_name]
+        del state["_listeners"]
+        return state
+
+    def __setstate__(self, state):
+        for attr_name in AbstractDROP._known_locks:
+            state[attr_name] = threading.Lock()
+        for attr_name in AbstractDROP._known_rlocks:
+            state[attr_name] = threading.RLock()
+
+        self.__dict__.update(state)
+
+        self._listeners = collections.defaultdict(list)
+
 
     @track_current_drop
     def __init__(self, oid, uid, **kwargs):

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -259,7 +259,8 @@ def createGraphFromDropSpecList(dropSpecList, session=None):
         #     dropType = "dropclass"
 
         cf = __CREATION_FUNCTIONS[dropType.lower()]
-        drop = cf(dropSpec, session=session)
+        session_id = session.sessionId if session else ""
+        drop = cf(dropSpec, session_id=session_id)
         if session is not None:
             # Now using per-drop reproducibility setting.
             drop.reproducibility_level = ReproducibilityFlags(
@@ -315,7 +316,7 @@ def createGraphFromDropSpecList(dropSpecList, session=None):
     return roots
 
 
-def _createData(dropSpec, dryRun=False, session=None):
+def _createData(dropSpec, dryRun=False, session_id=None):
     oid, uid = _getIds(dropSpec)
     kwargs = _getKwargs(dropSpec)
 
@@ -357,10 +358,10 @@ def _createData(dropSpec, dryRun=False, session=None):
         return
     if "self" in kwargs:
         kwargs.pop("self")
-    return storageType(oid, uid, dlg_session=session, **kwargs)
+    return storageType(oid, uid, dlg_session_id=session_id, **kwargs)
 
 
-def _createContainer(dropSpec, dryRun=False, session=None):
+def _createContainer(dropSpec, dryRun=False, session_id=None):
     oid, uid = _getIds(dropSpec)
     kwargs = _getKwargs(dropSpec)
 
@@ -381,19 +382,19 @@ def _createContainer(dropSpec, dryRun=False, session=None):
     if dryRun:
         return
 
-    return containerType(oid, uid, dlg_session=session, **kwargs)
+    return containerType(oid, uid, dlg_session_id=session_id, **kwargs)
 
 
-def _createSocket(dropSpec, dryRun=False, session=None):
+def _createSocket(dropSpec, dryRun=False, session_id=None):
     oid, uid = _getIds(dropSpec)
     kwargs = _getKwargs(dropSpec)
 
     if dryRun:
         return
-    return SocketListenerApp(oid, uid, dlg_session=session, **kwargs)
+    return SocketListenerApp(oid, uid, dlg_session_id=session_id, **kwargs)
 
 
-def _createApp(dropSpec, dryRun=False, session=None):
+def _createApp(dropSpec, dryRun=False, session_id=None):
     oid, uid = _getIds(dropSpec)
     kwargs = _getKwargs(dropSpec)
 
@@ -417,7 +418,7 @@ def _createApp(dropSpec, dryRun=False, session=None):
 
     if dryRun:
         return
-    return appType(oid, uid, dlg_session=session, **kwargs)
+    return appType(oid, uid, dlg_session_id=session_id, **kwargs)
 
 
 def _getIds(dropSpec):

--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -413,7 +413,7 @@ def dlgNM(parser, args):
         action="store",
         type="int",
         dest="max_threads",
-        help="Max thread pool size used for executing drops. -1 means use all CPUs. 0 (default) means no threads.",
+        help="Max thread pool size used for executing drops. <= 0 means use all (physical) CPUs. Default is 0.",
         default=0,
     )
     (options, args) = parser.parse_args(args)

--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -416,6 +416,13 @@ def dlgNM(parser, args):
         help="Max thread pool size used for executing drops. <= 0 means use all (physical) CPUs. Default is 0.",
         default=0,
     )
+    parser.add_option(
+        "-p",
+        "--processes",
+        action="store_true",
+        dest="use_processes",
+        help="Use processes instead of threads to execute app drops, defaults to False",
+    )
     (options, args) = parser.parse_args(args)
 
     # No logging setup at this point yet
@@ -443,6 +450,7 @@ def dlgNM(parser, args):
             filter(None, options.event_listeners.split(":"))
         ),
         "max_threads": options.max_threads,
+        "use_processes": options.use_processes,
         "logdir": options.logdir,
     }
     options.dmAcronym = "NM"

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -184,7 +184,7 @@ class CompositeManager(DROPManager):
         self._dmCheckerThread.start()
 
     def stopDMChecker(self):
-        if not self._dmCheckerEvt.isSet():
+        if not self._dmCheckerEvt.is_set():
             self._dmCheckerEvt.set()
             self._dmCheckerThread.join()
 

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -437,7 +437,7 @@ class Session(object):
         )
         for host, port, local_uid, relname, remote_uid in self._proxyinfo:
             proxy = rpc.DropProxy(
-                self._nm, host, port, self._sessionId, remote_uid
+                self._nm, rpc.ProxyInfo(host, port, self._sessionId, remote_uid)
             )
             logger.debug(
                 "Attaching proxy to local %r via %s(proxy, False)",

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -387,11 +387,12 @@ class Session(object):
             # Register them
             self._drops[drop.uid] = drop
 
-            # Add a reference to the RPC server that exposes this drop,
+            # Add a reference to the RPC server endpoint that exposes this drop,
             # which is our containing Node Manager.
             # This information is usually not necessary, but there are cases in
             # which we actually need it (like in the DynlibProcApp)
-            drop._rpc_server = self._nm
+            if self._nm:
+                drop._rpc_endpoint = self._nm.rpc_endpoint
 
             # Register them with the error handler
             for l in event_listeners:

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -293,7 +293,7 @@ class ProxyInfo:
         rpc_server = drop._rpc_server
         host, port = rpc_server._rpc_host, rpc_server._rpc_port
         host = utils.to_externally_contactable_host(host, prefer_local=True)
-        return cls(host, port, drop._dlg_session.sessionId, drop.uid)
+        return cls(host, port, drop._dlg_session_id, drop.uid)
 
     def __repr__(self):
         return (

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -314,25 +314,9 @@ class DropProxy(object):
     """
 
     def __init__(self, rpc_client, proxy_info: ProxyInfo):
-        # The current version of multiprocessing support creates an RPCClient
-        # per DropProxy, disregarding the rpc_client parameter given here.
-        # This uses too many resources though, but is only needed if the NM is
-        # instructed to use multiprocessing support. To avoid this resource
-        # over-usage we then detect if the given rpc_client (an instance of
-        # NodeManagerBase) has been started with multiprocessing support (which
-        # is confusingly bound to there being a *thread* pool too) and only if
-        # we detect the situation we create our own RPCClient; otherwise we use
-        # the given rpc_client as is.
-        if hasattr(rpc_client, "_threadpool") and rpc_client._threadpool:
-            self.rpc_client = ZeroRPCClient()
-            self._own_rpc_client = True
-        else:
-            self.rpc_client = rpc_client
-            self._own_rpc_client = False
+        self.rpc_client = rpc_client
         self._proxy_info: ProxyInfo = proxy_info
         logger.debug("Created %r", self)
-        if self._own_rpc_client:
-            self.rpc_client.start()
 
     def handleEvent(self, evt):
         pass
@@ -352,7 +336,3 @@ class DropProxy(object):
 
     def __repr__(self):
         return f"<DropProxy with {self._proxy_info}"
-
-    def __del__(self):
-        if self._own_rpc_client:
-            self.rpc_client.shutdown()

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -223,6 +223,10 @@ class ZeroRPCServer(RPCServerBase):
         # This import can take a long time in big HPC deployments
         return zerorpc.Context()
 
+    @property
+    def rpc_endpoint(self):
+        return self._rpc_host, self._rpc_port
+
     def start(self):
         super(ZeroRPCServer, self).start()
 
@@ -287,13 +291,13 @@ class ProxyInfo:
         if isinstance(drop, DropProxy):
             return drop._proxy_info
 
-        # TODO: we can't use the NodeManager's host directly here, as that
+        # TODO: we can't use the RPC endpoint's host directly here, as that
         #       indicates the address the different servers *bind* to
         #       (and, for example, can be 0.0.0.0)
-        rpc_server = drop._rpc_server
-        host, port = rpc_server._rpc_host, rpc_server._rpc_port
-        host = utils.to_externally_contactable_host(host, prefer_local=True)
-        return cls(host, port, drop._dlg_session_id, drop.uid)
+        assert drop._rpc_endpoint
+        rpc_host, rpc_port = drop._rpc_endpoint
+        rpc_host = utils.to_externally_contactable_host(rpc_host, prefer_local=True)
+        return cls(rpc_host, rpc_port, drop._dlg_session_id, drop.uid)
 
     def __repr__(self):
         return (

--- a/daliuge-engine/dlg/runtime/__init__.py
+++ b/daliuge-engine/dlg/runtime/__init__.py
@@ -64,8 +64,8 @@ def setup_logger_class():
             # Do the same with the session_id, which can be found via the drop (if any)
             # or checking if there is a session currently executing something
             session_id = ""
-            if drop and hasattr(drop, "_dlg_session") and drop._dlg_session:
-                session_id = drop._dlg_session.sessionId
+            if drop:
+                session_id = drop._dlg_session_id
             else:
                 try:
                     session_id = session.track_current_session.tlocal.session.sessionId

--- a/daliuge-engine/lib64_dist.pth
+++ b/daliuge-engine/lib64_dist.pth
@@ -1,1 +1,0 @@
-/home/awicenec/.pyenv/versions/3.8.10/lib/python3.8/dist-packages

--- a/daliuge-engine/test/apps/test_bash.py
+++ b/daliuge-engine/test/apps/test_bash.py
@@ -97,13 +97,10 @@ class BashAppTests(unittest.TestCase):
         class dummy(object):
             pass
 
-        session = dummy()
-        session.sessionId = session_id
-
         def assert_envvar_is_there(varname, value):
             command = "echo -n $%s > %%o0" % (varname)
             a = BashShellApp(
-                app_uid, app_uid, dlg_session=session, command=command
+                app_uid, app_uid, dlg_session_id=session_id, command=command
             )
             b = FileDROP("b", "b")
             a.addOutput(b)

--- a/daliuge-engine/test/apps/test_docker.py
+++ b/daliuge-engine/test/apps/test_docker.py
@@ -160,7 +160,7 @@ class DockerTests(unittest.TestCase):
         msg = 'This is a message with a double quotes: "'
         assertMsgIsCorrect(msg, "echo -n '{0}' > %o0".format(msg))
 
-    # @unittest.skip
+    @unittest.skip
     def test_dataURLReference(self):
         """
         A test to check that DROPs other than FileDROPs and DirectoryContainers
@@ -168,7 +168,7 @@ class DockerTests(unittest.TestCase):
         """
         self._ngas_and_fs_io("echo -n '%iDataURL0' > %o0")
 
-    # @unittest.skip
+    @unittest.skip
     def test_refer_to_io_by_uid(self):
         """
         A test to check that input and output Drops can be referred to by their
@@ -181,7 +181,7 @@ class DockerTests(unittest.TestCase):
         a = NgasDROP(
             "HelloWorld_out.txt", "HelloWorld_out.txt"
         )  # not a filesystem-related DROP, we can reference its URL in the command-line
-        a.ngasSrv = "ngas.ddns.net"
+        a.ngasSrv = "ngas.icrar.org"
         b = DockerApp("b", "b", image="ubuntu:14.04", command=command)
         c = FileDROP("c", "c")
         b.addInput(a)

--- a/daliuge-engine/test/apps/test_dynlib.py
+++ b/daliuge-engine/test/apps/test_dynlib.py
@@ -108,7 +108,9 @@ class DynlibAppTest(unittest.TestCase):
         """Checks that we can cancel a long-running dynlib proc app"""
 
         a = DynlibProcApp("a", "a", lib=_libpath, sleep_seconds=10)
-        a._rpc_server = True
+        # we don't really end up using it, so it can be anything
+        dummy_rpc_endpoint = (None, None)
+        a._rpc_endpoint = dummy_rpc_endpoint
         with droputils.DROPWaiterCtx(self, (), timeout=0):
             a.async_execute()
 

--- a/daliuge-engine/test/apps/test_dynlib2.py
+++ b/daliuge-engine/test/apps/test_dynlib2.py
@@ -108,7 +108,9 @@ class DynlibAppTest(unittest.TestCase):
         """Checks that we can cancel a long-running dynlib proc app"""
 
         a = DynlibProcApp("a", "a", lib=_libpath, sleep_seconds=10)
-        a._rpc_server = True
+        # we don't really end up using it, so it can be anything
+        dummy_rpc_endpoint = (None, None)
+        a._rpc_endpoint = dummy_rpc_endpoint
         with droputils.DROPWaiterCtx(self, (), timeout=0):
             a.async_execute()
 

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -222,11 +222,11 @@ class TestPyFuncApp(unittest.TestCase):
 
     def test_func2(self):
         """Checks that func2 in this module works when wrapped"""
-        n = random.randint(0, 1e6)
+        n = random.randint(0, 1_000_000)
         self._test_simple_functions("func2", n, 2 * n)
 
     def test_inner_func(self):
-        n = random.randint(0, 1e6)
+        n = random.randint(0, 1_000_000)
 
         def f(x):
             return x + 2
@@ -234,11 +234,11 @@ class TestPyFuncApp(unittest.TestCase):
         self._test_simple_functions(f, n, n + 2)
 
     def test_lambda(self):
-        n = random.randint(0, 1e6)
+        n = random.randint(0, 1_000_000)
         self._test_simple_functions(lambda x: x / 2, n, n / 2)
 
     def test_inner_func_with_closure(self):
-        n = random.randint(0, 1e6)
+        n = random.randint(0, 1_000_000)
 
         def f(x):
             return x + n
@@ -246,7 +246,7 @@ class TestPyFuncApp(unittest.TestCase):
         self._test_simple_functions(f, n, n + n)
 
     def test_lambda_with_closure(self):
-        n = random.randint(0, 1e6)
+        n = random.randint(0, 1_000_000)
         self._test_simple_functions(lambda x: (x + n) / 2, n, (n + n) / 2)
 
     def _test_func3(self, output_drops, expected_outputs):

--- a/daliuge-engine/test/apps/test_simple.py
+++ b/daliuge-engine/test/apps/test_simple.py
@@ -175,14 +175,14 @@ class TestSimpleApps(unittest.TestCase):
                 droputils.allDropContents(f[i]),
             )
 
-    # @unittest.skip
+    @unittest.skip
     def test_ngasio(self):
         nd_in = NgasDROP("HelloWorld_out.txt", "HelloWorld_out.txt")
-        nd_in.ngasSrv = "ngas.ddns.net"
+        nd_in.ngasSrv = "ngas.icrar.org"
         b = CopyApp("b", "b")
         did = "HelloWorld-%f" % time.time()
         nd_out = NgasDROP(did, did, len=11)
-        nd_out.ngasSrv = "ngas.ddns.net"
+        nd_out.ngasSrv = "ngas.icrar.org"
         nd_out.len = nd_in.size
         d = CopyApp("d", "d")
         i = InMemoryDROP("i", "i")

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -207,7 +207,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
             memory("C", producers=["B"]),
         ]
         add_test_reprodata(g)
-        dm = self._start_dm(threads=self.nm_threads, **kwargs)
+        dm = self._start_dm(**kwargs)
         dm.createSession(sessionId)
         dm.addGraphSpec(sessionId, g)
         dm.deploySession(sessionId, ["A"])
@@ -258,7 +258,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
         a_data = os.urandom(32)
         c_data = str(crc32c(a_data, 0)).encode("utf8")
         node_managers = [
-            self._start_dm(threads=self.nm_threads) for _ in range(2)
+            self._start_dm() for _ in range(2)
         ]
         ids = [0] * repeats
         for n in range(repeats):
@@ -309,7 +309,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
 
         :see: `self.test_runGraphSingleDOPerDOM`
         """
-        dm1, dm2 = [self._start_dm(threads=self.nm_threads) for _ in range(2)]
+        dm1, dm2 = [self._start_dm() for _ in range(2)]
 
         sessionId = "s1"
         g1 = [
@@ -395,7 +395,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
         """
 
         dm1, dm2, dm3, dm4 = [
-            self._start_dm(threads=self.nm_threads) for _ in range(4)
+            self._start_dm() for _ in range(4)
         ]
 
         sessionId = f"s{random.randint(0, 1000)}"
@@ -496,7 +496,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
         =======    ====================
         """
 
-        dm1, dm2 = [self._start_dm(threads=self.nm_threads) for _ in range(2)]
+        dm1, dm2 = [self._start_dm() for _ in range(2)]
 
         sessionId = f"s{random.randint(0, 1000)}"
         N = 100
@@ -547,7 +547,7 @@ class NodeManagerTestsBase(NMTestsMixIn):
         ip_addr_1 = "8.8.8.8"
         ip_addr_2 = "8.8.8.9"
 
-        dm1, dm2 = [self._start_dm(threads=self.nm_threads) for _ in range(2)]
+        dm1, dm2 = [self._start_dm() for _ in range(2)]
 
         sessionId = f"s{random.randint(0, 1000)}"
         g1 = [
@@ -665,7 +665,6 @@ class NodeManagerTestsBase(NMTestsMixIn):
 
 
 class TestDM(NodeManagerTestsBase, unittest.TestCase):
-    nm_threads = 0
 
     def test_run_invalid_shmem_graph(self):
         """
@@ -692,11 +691,3 @@ class TestDM(NodeManagerTestsBase, unittest.TestCase):
             quickDeploy(dm, sessionID, graph)
             self.assertEqual(1, len(dm._sessions[sessionID].drops))
             dm.destroySession(sessionID)
-
-
-@unittest.skipUnless(
-    os.environ.get("DALIUGE_RUN_MP_TESTS", "0") == "1",
-    "Unstable multiprocessing tests not run by default",
-)
-class TestDMParallel(NodeManagerTestsBase, unittest.TestCase):
-    nm_threads = multiprocessing.cpu_count()

--- a/daliuge-engine/test/manager/test_dm.py
+++ b/daliuge-engine/test/manager/test_dm.py
@@ -113,6 +113,7 @@ class NMTestsMixIn(object):
     def __init__(self, *args, **kwargs):
         super(NMTestsMixIn, self).__init__(*args, **kwargs)
         self._dms = []
+        self.use_processes = False
 
     def _start_dm(self, threads=0, **kwargs):
         host, events_port, rpc_port = nm_conninfo(len(self._dms))
@@ -121,6 +122,7 @@ class NMTestsMixIn(object):
             events_port=events_port,
             rpc_port=rpc_port,
             max_threads=threads,
+            use_processes=self.use_processes,
             **kwargs,
         )
         self._dms.append(nm)
@@ -664,7 +666,10 @@ class NodeManagerTestsBase(NMTestsMixIn):
         self._test_runGraphInTwoNMs(g1, g2, rels, a_data, e_data, leaf_oid="E")
 
 
-class TestDM(NodeManagerTestsBase, unittest.TestCase):
+class TestDMMultiThreading(NodeManagerTestsBase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_processes = False
 
     def test_run_invalid_shmem_graph(self):
         """
@@ -691,3 +696,8 @@ class TestDM(NodeManagerTestsBase, unittest.TestCase):
             quickDeploy(dm, sessionID, graph)
             self.assertEqual(1, len(dm._sessions[sessionID].drops))
             dm.destroySession(sessionID)
+
+class TestDMMultiProcessing(NodeManagerTestsBase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_processes = True

--- a/daliuge-engine/test/test_input_fired_app_drop.py
+++ b/daliuge-engine/test/test_input_fired_app_drop.py
@@ -1,4 +1,4 @@
-import threading
+from concurrent.futures import Future
 from dlg.apps.app_base import InputFiredAppDROP
 from dlg.event import Event, EventHandler
 import pytest
@@ -21,9 +21,9 @@ def test_async_execute_catches_and_logs_unexpected_exception(
     handler = MockThrowingHandler()
     drop.subscribe(handler)
 
-    thread = drop.async_execute()
-    assert isinstance(thread, threading.Thread)
-    thread.join()
+    fut = drop.async_execute()
+    assert isinstance(fut, Future)
+    fut.result()
 
     assert "Handler throw" in caplog.text
     # execute should handle exceptions in the run method

--- a/daliuge-translator/dlg/dropmake/web/translator_rest.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_rest.py
@@ -90,7 +90,7 @@ from dlg.dropmake.web.translator_utils import (
 APP_DESCRIPTION = """
 DALiuGE LG Web interface translates and deploys logical graphs.
 
-The interface is split into two parts, refer to the main DALiuGE documentation 
+The interface is split into two parts, refer to the main DALiuGE documentation
 [DALiuGE documentation](https://daliuge.readthedocs.io/) for more information
 
 ### Original API
@@ -812,15 +812,15 @@ class AlgoParams(BaseModel):
     Refer to main documentation for more information.
     """
 
-    min_goal: Union[int, None]
-    ptype: Union[int, None]
-    max_load_imb: Union[int, None]
-    max_cpu: Union[int, None]
-    time_greedy: Union[int, None]
-    deadline: Union[int, None]
-    topk: Union[int, None]
-    swarm_size: Union[int, None]
-    max_mem: Union[int, None]
+    min_goal: Union[int, None] = None
+    ptype: Union[int, None] = None
+    max_load_imb: Union[int, None] = None
+    max_cpu: Union[int, None] = None
+    time_greedy: Union[int, None] = None
+    deadline: Union[int, None] = None
+    topk: Union[int, None] = None
+    swarm_size: Union[int, None] = None
+    max_mem: Union[int, None] = None
 
 
 class KnownAlgorithms(str, Enum):

--- a/daliuge-translator/test/dropmake/logical_graphs/nagsIo.graph
+++ b/daliuge-translator/test/dropmake/logical_graphs/nagsIo.graph
@@ -90,7 +90,7 @@
                     "readonly": false,
                     "text": "NGAS Server",
                     "type": "Unknown",
-                    "value": "ngas.ddns.net"
+                    "value": "ngas.icrar.org"
                 },
                 {
                     "defaultValue": "",
@@ -204,7 +204,7 @@
                     "readonly": false,
                     "text": "NGAS Server",
                     "type": "Unknown",
-                    "value": "ngas.ddns.net"
+                    "value": "ngas.icrar.org"
                 },
                 {
                     "defaultValue": "",


### PR DESCRIPTION
This builds off work that @rtobar started on in [multiproc-drop-apps](https://github.com/ICRAR/daliuge/compare/master...multiproc-drop-apps2), with some slight renaming and simplifying to use `ProcessPoolExecutor` instead of manually managing a pool of processes. I've also fixed some unrelated tests that started failing: NGAS (updated domain, and skipped tests) and `lgweb` (a newer version of Pydantic seems to be stricter). 

If no node manager is present, drops will run synchronously, otherwise they will use the provided `DropRunner`, which will either do work in threads or processes. To avoid complicated state synchronisation across processes, it's actually the drop's `run()` method that gets run in the `DropRunner`, not the whole `execute()` method. 

Unfortunately this complicates the implementation of  `AppDROP.async_execute()` which doesn't use the provided `DropRunner`. This is for two reasons: firstly we can encounter deadlocks e.g. In the case where the thread pool is of size 1 `async_execute()` submits to the pool, waiting for `execute()` to finish, but `execute()` can't run on the thread pool until there is a free slot. Secondly, running the drops using multiprocessing requires some `AppDROP` specific logic that doesn't generalise well for light waiting like `async_execute()` is trying to do. This is also why I renamed @rtobar's original `WorkerPool` to `DropRunner`.

I reverted to the previous logic (with some minor refactoring), running `async_execute()` as a daemon thread, however this is a problem since it is no longer running on the thread pool if it is available (since it might be a process pool now!) and this causes a memory leak that will scale as we execute new drops. I left it as is to push the multiprocessing through, but this should be probably addressed soon. Maybe the node manager has a secondary thread pool for this sort of thing, but it also seems wasteful to have a whole thread that essentially will block on the `run()` method (did somebody say asyncio?). Anyway, I figure that's probably a discussion to have outside of this PR.