### PR TITLE
Added avahi to all targets

### DIFF
--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -141,7 +141,7 @@ def zmq_safe(host_or_addr):
     # The catch-all IP address, ZMQ needs a *
     if host_or_addr == "0.0.0.0":
         return "*"
-
+    host_or_addr = host_or_addr.split(":")[0]
     # Return otherwise always an IP address
     return socket.gethostbyname(host_or_addr)
 

--- a/daliuge-common/docker/Dockerfile
+++ b/daliuge-common/docker/Dockerfile
@@ -7,8 +7,9 @@ FROM ubuntu:20.04
 ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl git sudo && \
+    apt-get install -y avahi-utils gcc python3 python3.8-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl git sudo && \
     apt-get clean
 
 COPY / /daliuge

--- a/daliuge-common/docker/Dockerfile.casa
+++ b/daliuge-common/docker/Dockerfile.casa
@@ -7,7 +7,8 @@ FROM kernsuite/base:7
 ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
-RUN apt-get update && apt-get install -y gcc python3-pip python3-venv wget && \
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update && apt-get install -y avahi-utils gcc python3-pip python3-venv wget && \
     pip3 install -U pip
 
 # add_arrow_repo: 
@@ -38,4 +39,3 @@ RUN cd /daliuge && \
     . ~/dlg/bin/activate && \
     pip3 install numpy && \
     pip3 install .
-    

--- a/daliuge-common/docker/Dockerfile.devcuda
+++ b/daliuge-common/docker/Dockerfile.devcuda
@@ -7,8 +7,9 @@ FROM ubuntu:20.04
 ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y gcc python3 python3.8-venv python3-pip python3-distutils libmetis-dev curl git sudo && \
+    apt-get install -y avahi-utils gcc python3 python3.8-venv python3-pip python3-distutils libmetis-dev curl git sudo && \
     apt-get clean
 
 COPY / /daliuge

--- a/daliuge-common/docker/Dockerfile.ray
+++ b/daliuge-common/docker/Dockerfile.ray
@@ -7,7 +7,8 @@ FROM rayproject/ray:74cbf0-py38
 ARG BUILD_ID
 LABEL stage=builder
 LABEL build=$BUILD_ID
-RUN sudo apt-get update && sudo apt-get install -y gcc
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN sudo apt-get update && sudo apt-get install -y avahi-utils gcc
 
 COPY / /daliuge
 

--- a/daliuge-engine/build_engine.sh
+++ b/daliuge-engine/build_engine.sh
@@ -43,12 +43,17 @@ case "$1" in
         docker build --build-arg USER=${USER} --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-engine.big:${VCS_TAG} -f docker/Dockerfile .
         echo "Build finished! Slimming the image now"
         echo ">>>>> docker-slim output <<<<<<<<<"
-        docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
+        # docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
+        #     --include-path /etc --include-path /usr/local/lib --include-path /usr/local/bin --include-path /usr/lib/python3.8 \
+        #     --include-path /usr/lib/python3 --include-path /usr/bin/hostname --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
+        #     --http-probe=true --tag=icrar/daliuge-engine:${VCS_TAG}\
+        #     icrar/daliuge-engine.big:${VCS_TAG} \
+        slim build --include-shell \
             --include-path /etc --include-path /usr/local/lib --include-path /usr/local/bin --include-path /usr/lib/python3.8 \
-            --include-path /usr/lib/python3 --include-path /usr/bin/hostname --include-path /dlg --include-path /daliuge --publish-exposed-ports=true \
-            --http-probe=true --tag=icrar/daliuge-engine:${VCS_TAG}\
-            icrar/daliuge-engine.big:${VCS_TAG} \
-	    ;;
+            --include-path /usr/lib/python3 --include-bin /usr/bin/hostname --include-path /dlg --include-path /daliuge \
+            --include-bin /usr/sbin/service --publish-exposed-ports=true \
+            --http-probe=false --tag=icrar/daliuge-engine.slim:${VCS_TAG}\
+            icrar/daliuge-engine.big:${VCS_TAG};;
     *)
         echo "Usage: build_engine.sh <dep|dev|devall|slim>"
         exit 0;;

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -221,7 +221,10 @@ def loadDropSpecs(dropSpecList):
                 # relationship list but doesn't exist in the list of DROPs
                 for oid in dropSpec[rel]:
                     oid = list(oid.keys())[0] if isinstance(oid, dict) else oid
-                    dropSpecs[oid]
+                    if oid in dropSpecs:
+                        dropSpecs[oid]
+                    else:
+                        continue
 
             # N-1 relationships
             elif rel in __TOONE:
@@ -277,7 +280,10 @@ def createGraphFromDropSpecList(dropSpecList, session=None):
                 link = __TOMANY[attr]
                 for rel in dropSpec[attr]:
                     oid = list(rel.keys())[0] if isinstance(rel, dict) else rel
-                    lhDrop = drops[oid]
+                    if oid in drops:
+                        lhDrop = drops[oid]
+                    else:
+                        continue
                     relFuncName = LINKTYPE_1TON_APPEND_METHOD[link]
                     try:
                         relFunc = getattr(drop, relFuncName)

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -220,9 +220,9 @@ class CompositeManager(DROPManager):
     def addDmHost(self, host):
         if ":" not in host:
             if self._subDmId == "node":
-                host += constants.NODE_DEFAULT_REST_PORT
+                host += f":{constants.NODE_DEFAULT_REST_PORT}"
             elif self._subDmId == "island":
-                host += constants.ISLAND_DEFAULT_REST_PORT
+                host += f":{constants.ISLAND_DEFAULT_REST_PORT}"
         if host not in self._dmHosts:
             self._dmHosts.append(host)
         else:
@@ -304,6 +304,7 @@ class CompositeManager(DROPManager):
         thrExs = {}
         iterable = iterable or self._dmHosts
         port = port or self._dmPort
+        logger.debug("Hosts: %s", iterable)
         self._tp.map(
             functools.partial(
                 self._do_in_host, action, sessionId, thrExs, f, collect, port

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -304,7 +304,7 @@ class CompositeManager(DROPManager):
         thrExs = {}
         iterable = iterable or self._dmHosts
         port = port or self._dmPort
-        logger.debug("Hosts: %s", iterable)
+        # logger.debug("Hosts: %s", iterable)
         self._tp.map(
             functools.partial(
                 self._do_in_host, action, sessionId, thrExs, f, collect, port

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -248,6 +248,8 @@ class CompositeManager(DROPManager):
 
     def check_dm(self, host, port=None, timeout=10):
         port = port or self._dmPort
+        if ":" in host:
+            host, port = host.split(":")
         logger.debug("Checking DM presence at %s:%d", host, port)
         dm_is_there = portIsOpen(host, port, timeout)
         return dm_is_there

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -435,6 +435,8 @@ class NodeManagerBase(DROPManager):
                 host, events_port, _ = nodesub
 
             # TODO: we also have to unsubscribe from them at some point
+            host = host.split(":")[0]
+            logger.debug("Sending subscription to %s", f"{host}:{events_port}")
             self.subscribe(host, events_port)
 
     def has_method(self, sessionId, uid, mname):

--- a/daliuge-engine/dlg/manager/rest.py
+++ b/daliuge-engine/dlg/manager/rest.py
@@ -80,7 +80,7 @@ def daliuge_aware(func):
                 origin = bottle.request.headers.raw("Origin")
                 logger.debug("CORS request comming from: %s", origin)
                 if origin is None or re.match(
-                    r"http://dlg-trans.local:80[0-9][0-9]", origin
+                    r"http://(dlg-trans.local:80[0-9][0-9]|dlg-trans.icrar.org)", origin
                 ):
                     origin = "http://dlg-trans.local:8084"
                 elif re.match(r"http://((localhost)|(127.0.0.1)):80[0-9][0-9]", origin):

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -287,6 +287,7 @@ class Session(object):
         self.status = SessionStates.BUILDING
 
         # This will check the consistency of each dropSpec
+        logger.debug("Trying to add graphSpec: %s", [[x['oid'],x['node']] for x in graphSpec])
         graphSpecDict, self._graphreprodata = graph_loader.loadDropSpecs(
             graphSpec
         )

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -144,7 +144,7 @@ class ZeroRPCClient(RPCClientBase):
         endpoint = (host, port)
 
         with self._zrpcclient_acquisition_lock:
-            if endpoint in self._zrpcclinents:
+            if endpoint in self._zrpcclients:
                 return self._zrpcclients[endpoint]
 
             # We start the new client on its own thread so it uses gevent, etc.
@@ -215,7 +215,7 @@ class ZeroRPCClient(RPCClientBase):
         async_result.rawlink(lambda x: self.process_response(req, x))
 
     def get_rpc_client(self, hostname, port):
-        # hostname = hostname.split(":")[0] 
+        # hostname = hostname.split(":")[0]
         client = self.get_client_for_endpoint(hostname, port)
         # No closing function since clients are long-lived
         return client, lambda: None
@@ -337,7 +337,7 @@ class DropProxy(object):
             self._proxy_info.port,
             self._proxy_info.session_id,
             self.uid,
-            name
+            name,
         )
 
     def __repr__(self):

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -55,6 +55,8 @@ class RPCClientBase(RPCObject):
 
     def get_drop_attribute(self, hostname, port, session_id, uid, name):
 
+        hostname = hostname.split(":")[0]
+
         logger.debug(
             "Getting attribute %s for drop %s of session %s at %s:%d",
             name,
@@ -63,6 +65,7 @@ class RPCClientBase(RPCObject):
             hostname,
             port,
         )
+        hostname = hostname.split(":")[0]
 
         client, closer = self.get_rpc_client(hostname, port)
 
@@ -93,7 +96,7 @@ class RPCServerBase(RPCObject):
     """Base class for all RPC server"""
 
     def __init__(self, host, port):
-        self._rpc_host = host
+        self._rpc_host = host.split(":")[0]
         self._rpc_port = port
 
 
@@ -137,10 +140,11 @@ class ZeroRPCClient(RPCClientBase):
 
     def get_client_for_endpoint(self, host, port):
 
+        host = host.split(":")[0]
         endpoint = (host, port)
 
         with self._zrpcclient_acquisition_lock:
-            if endpoint in self._zrpcclients:
+            if endpoint in self._zrpcclinents:
                 return self._zrpcclients[endpoint]
 
             # We start the new client on its own thread so it uses gevent, etc.
@@ -179,6 +183,7 @@ class ZeroRPCClient(RPCClientBase):
             return client
 
     def run_zrpcclient(self, host, port, req_queue):
+        host = host.split(":")[0]
         client = zerorpc.Client("tcp://%s:%d" % (host, port), context=self._context)
 
         forwarder = gevent.spawn(self.forward_requests, req_queue, client)
@@ -210,6 +215,7 @@ class ZeroRPCClient(RPCClientBase):
         async_result.rawlink(lambda x: self.process_response(req, x))
 
     def get_rpc_client(self, hostname, port):
+        # hostname = hostname.split(":")[0] 
         client = self.get_client_for_endpoint(hostname, port)
         # No closing function since clients are long-lived
         return client, lambda: None

--- a/daliuge-engine/docker/Dockerfile
+++ b/daliuge-engine/docker/Dockerfile
@@ -1,12 +1,10 @@
 ARG VCS_TAG
-ARG USER
 # We need the base image we build with the other Dockerfile
 FROM icrar/daliuge-common:${VCS_TAG:-latest}
 
 # RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 
-USER ${USER}
 COPY / /daliuge
 RUN . /dlg/bin/activate && pip install wheel && cd /daliuge && \
     pip install . 

--- a/daliuge-engine/docker/Dockerfile.casa
+++ b/daliuge-engine/docker/Dockerfile.casa
@@ -8,6 +8,7 @@ FROM icrar/daliuge-common:master-casa
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends tzdata \
     gnupg2 software-properties-common wget git git-lfs gcc g++ make tmux python3-pip cmake libboost1.71-all-dev
+RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
 
 # install casacore
 RUN mkdir -p /code && cd /code &&\

--- a/daliuge-engine/docker/Dockerfile.dev
+++ b/daliuge-engine/docker/Dockerfile.dev
@@ -1,12 +1,10 @@
 ARG VCS_TAG
-ARG USER
 # We need the base image we build with the other Dockerfile
 FROM icrar/daliuge-common:${VCS_TAG:-latest}
 
 # RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
-RUN useradd --create-home awicenec
 COPY / /daliuge
 RUN . /dlg/bin/activate && pip install --upgrade pip && pip install wheel && cd /daliuge && \
     pip install . 

--- a/daliuge-engine/docker/Dockerfile.devall
+++ b/daliuge-engine/docker/Dockerfile.devall
@@ -1,5 +1,4 @@
 ARG VCS_TAG
-ARG USER
 # We need the base image we build with the other Dockerfile
 FROM icrar/daliuge-common:${VCS_TAG:-latest}
 
@@ -9,7 +8,8 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 RUN apt-get update &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc curl python3-pip python3-numpy
 
-USER ${USER}
+RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
+# USER ${USER}
 COPY / /daliuge
 RUN . /dlg/bin/activate && pip install wheel && cd /daliuge && \
     pip install .

--- a/daliuge-engine/docker/Dockerfile.ray
+++ b/daliuge-engine/docker/Dockerfile.ray
@@ -6,6 +6,7 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 
 RUN sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends gcc python3-pip curl
+RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
 
 COPY / /daliuge
 RUN . /home/ray/dlg/bin/activate && \

--- a/daliuge-engine/docker/Dockerfile_incontext
+++ b/daliuge-engine/docker/Dockerfile_incontext
@@ -4,6 +4,7 @@ FROM icrar/daliuge-base:latest
 # Get the local DALiuGE sources and install them in the system
 COPY / /daliuge
 RUN pip install wheel && cd ~/daliuge && pip install .
+RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
 
 # Second stage build taking what's required from first stage
 FROM icrar/daliuge-base:latest

--- a/daliuge-engine/run_engine.sh
+++ b/daliuge-engine/run_engine.sh
@@ -45,6 +45,7 @@ case "$1" in
             echo "docker run -td "${DOCKER_OPTS}"  icrar/daliuge-engine:${VCS_TAG}"
             docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${VCS_TAG}
             sleep 3
+            docker exec -u root daliuge-engine bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1"
             ENGINE_NAME=`docker exec daliuge-engine sh -c "hostname"`
             ENGINE_IP=`docker exec daliuge-engine sh -c "hostname --ip-address"`
             # exit 0
@@ -60,7 +61,7 @@ case "$1" in
         ENGINE_NAME=`docker exec daliuge-engine sh -c "hostname"`
         ENGINE_IP=`docker exec daliuge-engine sh -c "hostname --ip-address"`
         curl -X POST http://${ENGINE_IP}:9000/managers/island/start
-        curl -X POST http://${ENGINE_IP}:8001/api/node/dlg-engine.local;;
+        curl -X POST http://${ENGINE_IP}:8001/api/node/dlg-engine.local:8000;;
         # exit 0;;
     "casa")
         DLG_ROOT="/tmp/dlg"
@@ -71,6 +72,7 @@ case "$1" in
         echo "docker run -td ${DOCKER_OPTS}  ${CONTAINER_NM}"
         docker run -td ${DOCKER_OPTS}  ${CONTAINER_NM}
         sleep 3
+        docker exec -u root daliuge-engine bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1"
         ENGINE_NAME=`docker exec daliuge-engine sh -c "hostname"`
         ENGINE_IP=`docker exec daliuge-engine sh -c "hostname --ip-address"`
         curl -X POST http://${ENGIONE_IP}:9000/managers/island/start;;
@@ -79,12 +81,14 @@ case "$1" in
         export DLG_ROOT="$HOME/dlg"
         common_prep
         echo "Running Engine development version in background..."
-        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${VCS_TAG}"
-        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine:${VCS_TAG}
+        echo "docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim:${VCS_TAG}"
+        docker run -td ${DOCKER_OPTS}  icrar/daliuge-engine.slim:${VCS_TAG}
         sleep 3
+        docker exec -u root daliuge-engine bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1"
         ENGINE_NAME=`docker exec daliuge-engine sh -c "hostname"`
         ENGINE_IP=`docker exec daliuge-engine sh -c "hostname --ip-address"`
-        curl -X POST http://${ENGINE_IP}:9000/managers/island/start;;
+        curl -X POST http://${ENGINE_IP}:9000/managers/island/start
+        curl -X POST http://${ENGINE_IP}:8001/api/node/dlg-engine.local:8000;;
         # exit 0;;
     "local")
         common_prep
@@ -102,5 +106,5 @@ case "$1" in
         exit 0;;
 esac
 echo
-echo "Engine NAME/IP address: ${ENGINE_NAME}/${ENGINE_IP}"
+echo "Engine NAME/IP address: http://${ENGINE_NAME}.local:8000 / ${ENGINE_IP}"
 

--- a/daliuge-translator/build_translator.sh
+++ b/daliuge-translator/build_translator.sh
@@ -46,9 +46,12 @@ case "$1" in
         echo ""
         echo ""
         echo ">>>>> docker-slim output <<<<<<<<<"
-        docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
+        # docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock dslim/docker-slim build --include-shell \
+        # --include-path /usr/bin/hostname --include-path /usr/local/lib --include-path /usr/local/bin --include-path /daliuge --include-path /dlg \
+        # --http-probe=false --tag=icrar/daliuge-translator:${VCS_TAG} icrar/daliuge-translator.big:${VCS_TAG}
+        slim build --include-shell \
         --include-path /usr/bin/hostname --include-path /usr/local/lib --include-path /usr/local/bin --include-path /daliuge --include-path /dlg \
-        --http-probe=false --tag=icrar/daliuge-translator:${VCS_TAG} icrar/daliuge-translator.big:${VCS_TAG}
+        --include-bin /usr/sbin/service --include-bin /usr/bin/hostname --http-probe=false --tag=icrar/daliuge-translator.slim:${VCS_TAG} icrar/daliuge-translator.big:${VCS_TAG}
 	    ;;
     *)
         echo "Usage: build_translator.sh <dep|dev|slim>"

--- a/daliuge-translator/dlg/dropmake/pgt.py
+++ b/daliuge-translator/dlg/dropmake/pgt.py
@@ -228,15 +228,22 @@ class PGT(object):
             where the daliuge system is started up afer submission (e.g. SLURM)
         """
         logger.debug(
-            "# worker nodes: %s, node_list(incl. DIM): %s",
+            ">>>>>> node_list type: %s, %d, %d",
+            type(node_list),
+            len(node_list),
             tpl_nodes_len,
-            node_list,
         )
         if len(node_list) == 0 and tpl_nodes_len > 0:  # generate pg_spec template
             node_list = range(tpl_nodes_len)  # create a fake list for now
             tpl_fl = True
         else:
             tpl_fl = False
+        logger.debug(
+            "# worker nodes: %s, node_list(incl. DIM), tpl_fl: %s, %s",
+            tpl_nodes_len,
+            node_list,
+            tpl_fl,
+        )
 
         if 0 == self._num_parts_done:
             raise GPGTException("The graph has not been partitioned yet")
@@ -275,20 +282,17 @@ class PGT(object):
                 raise GPGTException(
                     "Insufficient number of nodes: {0}".format(nodes_len)
                 )
-            is_list = node_list
-            nm_list = (
-                [node_list[1]] + node_list[1:]
-                if isinstance(node_list, list) and len(node_list) > 1
-                else node_list
-            )
+            is_list = node_list[0:num_islands]
+            nm_list = node_list[num_islands:]
+            logger.debug("NM list: %s", node_list)
         nm_len = len(nm_list)
         logger.info(
-            "Drops count: %d, partitions count: %d, nodes count: %d, island count: %d %s",
+            "Drops count: %d, partitions count: %d, NM count: %d, island count: %d %s",
             len(drop_list),
             num_parts,
-            nodes_len,
+            len(nm_list),
             len(is_list),
-            co_host_dim,
+            form_island,
         )
 
         if form_island:

--- a/daliuge-translator/dlg/dropmake/pgt.py
+++ b/daliuge-translator/dlg/dropmake/pgt.py
@@ -227,41 +227,42 @@ class PGT(object):
             The pg_spec template is what needs to be send to a deferred deployemnt
             where the daliuge system is started up afer submission (e.g. SLURM)
         """
+        if num_islands < 1:
+            num_islands = 1  # need at least one island manager
         logger.debug(
             ">>>>>> node_list type: %s, %d, %d",
             type(node_list),
             len(node_list),
-            tpl_nodes_len,
+            num_islands,
         )
         if len(node_list) == 0 and tpl_nodes_len > 0:  # generate pg_spec template
-            node_list = range(tpl_nodes_len)  # create a fake list for now
+            node_list = range(tpl_nodes_len + num_islands)  # create a fake list for now
             tpl_fl = True
         else:
             tpl_fl = False
         logger.debug(
-            "# worker nodes: %s, node_list(incl. DIM), tpl_fl: %s, %s",
+            "# worker nodes: %s, node_list(incl. DIM): %s, tpl_fl: %s",
             tpl_nodes_len,
             node_list,
             tpl_fl,
         )
-
-        if 0 == self._num_parts_done:
-            raise GPGTException("The graph has not been partitioned yet")
-
-        if node_list is None or 0 == len(node_list):
-            raise GPGTException("Node list is empty!")
         nodes_len = len(node_list)
 
         try:
             num_islands = int(num_islands)
         except:
             raise GPGTException("Invalid num_islands spec: {0}".format(num_islands))
-        if num_islands < 1:
-            num_islands = 1  # need at least one island manager
         if num_islands > nodes_len:
             raise GPGTException(
                 "Number of islands must be <= number of specified nodes!"
             )
+
+        if 0 == self._num_parts_done:
+            raise GPGTException("The graph has not been partitioned yet")
+
+        if node_list is None or 0 == len(node_list):
+            raise GPGTException("Node list is empty!")
+
         form_island = num_islands > 1
         if nodes_len < 1:  # we allow to run everything on a single node now!
             raise GPGTException("Too few nodes: {0}".format(nodes_len))
@@ -284,7 +285,7 @@ class PGT(object):
                 )
             is_list = node_list[0:num_islands]
             nm_list = node_list[num_islands:]
-            logger.debug("NM list: %s", node_list)
+            logger.debug("NM list: %s", nm_list)
         nm_len = len(nm_list)
         logger.info(
             "Drops count: %d, partitions count: %d, NM count: %d, island count: %d %s",

--- a/daliuge-translator/dlg/dropmake/web/translator_rest.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_rest.py
@@ -86,6 +86,7 @@ from dlg.dropmake.web.translator_utils import (
     get_mgr_deployment_methods,
     parse_mgr_url,
 )
+from dlg import constants
 
 APP_DESCRIPTION = """
 DALiuGE LG Web interface translates and deploys logical graphs.
@@ -582,6 +583,7 @@ def gen_pg(
             (mhost, mport) = mparse.netloc.split(":")
             mport = int(mport)
         except:
+            logger.debug("URL parsing error of: %s", dlg_mgr_url)
             mhost = mparse.netloc
             if mparse.scheme == "http":
                 mport = 80
@@ -634,6 +636,7 @@ def gen_pg(
         )
         # 1. get a list of nodes
         node_list = mgr_client.nodes()
+        logger.debug("Calling mapping to nodes: %s", node_list)
         # 2. mapping PGTP to resources (node list)
         pg_spec = pgtp.to_pg_spec(node_list, ret_str=False)
 
@@ -694,7 +697,7 @@ def gen_pg_spec(
     """
     try:
         if manager_host == "localhost":
-            manager_host = "localhost"
+            manager_host = f"localhost:{constants.ISLAND_DEFAULT_REST_PORT}"
         logger.debug("pgt_id: %s", str(pgt_id))
         # logger.debug("node_list: %s", str(node_list))
     except Exception as ex:
@@ -715,6 +718,7 @@ def gen_pg_spec(
         raise HTTPException(status_code=500, detail="Must specify DALiuGE nodes list")
 
     try:
+        logger.debug("Calling mapping to host: %s", [manager_host] + node_list)
         pg_spec = pgtp.to_pg_spec(
             [manager_host] + node_list,
             tpl_nodes_len=tpl_nodes_len,

--- a/daliuge-translator/docker/Dockerfile
+++ b/daliuge-translator/docker/Dockerfile
@@ -12,6 +12,10 @@ LABEL build=$BUILD_ID
 #     apt-get clean && \
 #     apt install -y gcc python3-venv python3-distutils
 
+RUN service avahi-daemon stop && \
+    service dbus start && \
+    service avahi-daemon start && \
+    avahi-set-host-name dlg-trans
 COPY / /daliuge
 
 RUN . /dlg/bin/activate && \

--- a/daliuge-translator/docker/Dockerfile.ray
+++ b/daliuge-translator/docker/Dockerfile.ray
@@ -8,6 +8,10 @@ LABEL stage=builder
 LABEL build=$BUILD_ID
 RUN sudo apt-get update && sudo apt-get install -y python3-pip gcc && sudo apt-get clean
 
+RUN service avahi-daemon stop && \
+    service dbus start && \
+    service avahi-daemon start && \
+    avahi-set-host-name dlg-trans
 COPY / /daliuge
 
 RUN . ~/dlg/bin/activate && \

--- a/daliuge-translator/run_translator.sh
+++ b/daliuge-translator/run_translator.sh
@@ -1,19 +1,34 @@
 #!/usr/bin/env bash
+if [ $2 ]
+then
+	export VCS_TAG=$2
+	export C_TAG=$VCS_TAG
+else
+	export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+	export C_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
+fi
 case "$1" in
     "dep")
-        VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
         echo "Running Translator deployment version in background..."
-        docker run -h dlg-trans --name daliuge-translator --rm -td -p 8084:8084 icrar/daliuge-translator:${VCS_TAG};;
+        docker run -h dlg-trans --name daliuge-translator --rm -td -p 8084:8084 icrar/daliuge-translator:${VCS_TAG}
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
     "dev")
-        export VCS_TAG=`git rev-parse --abbrev-ref HEAD| tr '[:upper:]' '[:lower:]'`
         echo "Running Translator development version in background..."
         docker run -d -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator:${VCS_TAG}
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
+    "slim")
+        echo "Running Translator development version in background..."
+        docker run -d -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator.slim:${VCS_TAG}
         sleep 3
         docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
     "casa")
         export VCS_TAG=`git rev-parse --abbrev-ref HEAD| tr '[:upper:]' '[:lower:]'`-casa
         echo "Running Translator development version in foreground..."
-        docker run -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator:${VCS_TAG};;
+        docker run -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator:${VCS_TAG}
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
     *)
         echo "Usage run_translator.sh <dep|dev|casa>"
         exit 0;;

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -94,7 +94,7 @@ class TestPGGen(unittest.TestCase):
             "chiles_simple.graph",
         ]
         tgt_partnum = [15, 15, 10, 10, 5]
-        node_list = ["10.128.0.11", "10.128.0.12", "10.128.0.13"]
+        node_list = ["10.128.0.11", "10.128.0.11", "10.128.0.12", "10.128.0.13"]
         for i, lgn in enumerate(lgnames):
             fp = get_lg_fname(lgn)
             lg = LG(fp)
@@ -190,9 +190,7 @@ class TestPGGen(unittest.TestCase):
             nb_islands = 2
             # print(lgn)
             try:
-                pgtp.merge_partitions(
-                    len(node_list) - nb_islands, form_island=False
-                )
+                pgtp.merge_partitions(len(node_list) - nb_islands, form_island=False)
             except GPGTNoNeedMergeException as ge:
                 continue
             pg_spec = pgtp.to_pg_spec(node_list, num_islands=nb_islands)

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -103,6 +103,7 @@ class TestPGGen(unittest.TestCase):
             # pgtp.json
             pgtp.to_gojs_json(visual=False)
             pg_spec = pgtp.to_pg_spec(node_list)
+
             # with open('/tmp/met_{0}_pgspec.graph'.format(lgn.split('.')[0]), 'w') as f:
             #     f.write(pg_spec)
 


### PR DESCRIPTION
This pull requests adds avahi ( mDNS/DNS-SD) to all docker targets. This allows the images to announce themselves as dlg-trans.local and dlg-engine.local, respectively and makes managing the internal connections easier. These names have also been added to the CORS configurations, including OOD.