### PR TITLE
Update merklelib to support Python3.10

### DIFF
--- a/daliuge-common/setup.py
+++ b/daliuge-common/setup.py
@@ -49,7 +49,7 @@ def do_versioning():
 
 install_requires = [
     "gputil>=1.4.0",
-    "merklelib>=1.0",
+    "merklelib@git+https://github.com/pritchardn/merklelib",
     "pyzmq==25.1.0",
     "pydantic==1.10.7",
     "boto3",


### PR DESCRIPTION
# Issue

The version of `merklelib` [currently stored on Pypi](https://pypi.org/project/merklelib) is not up-to-date with the repository, which means we do not have changes that make it compatible with Python 3.10 (https://github.com/vpaliy/merklelib/pull/10). 

# Solution

We could point to the GitHub repository instead of trying for the Pypi project, but unfortunately there are outstanding issues with the setup.py that have not been remedied (https://github.com/vpaliy/merklelib/pull/11). 

@pritchardn has a repository that is up-to-date with the original/base repository, and we have merged a fix for the setup.py script (see https://github.com/pritchardn/merklelib/pull/1). 

We will use this version of the merkelib moving forward and pull it directly from GitHub when installing DALiuGE. 

# Testing 

Confirmed the installation works as expected using `pip install`: 

```
Obtaining file:///home/rwb/github/daliuge/daliuge-common
  Preparing metadata (setup.py) ... done
Collecting merklelib@ git+https://github.com/pritchardn/merklelib
  Cloning https://github.com/pritchardn/merklelib to /tmp/pip-install-h11un0nu/merklelib_cf7d9f0b4d414cabbb0e72858fad6307
  Running command git clone --filter=blob:none --quiet https://github.com/pritchardn/merklelib /tmp/pip-install-h11un0nu/merklelib_cf7d9f0b4d414cabbb0e72858fad6307
  Resolved https://github.com/pritchardn/merklelib to commit 2c69dd09a677287bb93136efcb36a86de7f4e641
  Preparing metadata (setup.py) ... done
```

Translator tests now pass as expected. 

```python
======== 181 passed, 27 skipped, 3 warnings in 57.71s =======

```