### PR TITLE
Bug fix - Temporary solution to address positional arguments not working

### DIFF
--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -135,7 +135,7 @@ def identify_named_ports(
                 value = parser(port_dict[keys[i]]["drop"])
             pargsDict.update({key: value})
             logger.debug("Using %s '%s' for parg %s", mode, value, key)
-            portargs.update({key: value})
+            # portargs.update({key: value}) # TODO identify more permanent fix for updating portargs
             posargs.pop(posargs.index(key))
         elif key in keyargs:
             if parser:
@@ -221,8 +221,6 @@ def replace_named_ports(
     outputs_dict = collections.OrderedDict()
     for uid, drop in oitems:
         outputs_dict[uid] = {"path": drop.path if hasattr(drop, "path") else ""}
-    # logger.debug("appArgs: %s", appArgs)
-    # get positional args
     posargs = [arg for arg in appArgs if appArgs[arg]["positional"]]
     # get kwargs
     keyargs = {
@@ -231,6 +229,7 @@ def replace_named_ports(
     # we will need an ordered dict for all positional arguments
     # thus we create it here and fill it with values
     portPosargsDict = collections.OrderedDict(zip(posargs, [None] * len(posargs)))
+    print(portPosargsDict)
     logger.debug(
         "posargs: %s; keyargs: %s, %s",
         posargs,
@@ -294,9 +293,11 @@ def replace_named_ports(
     keyargs = {
         arg: appArgs[arg]["value"] for arg in appArgs if not appArgs[arg]["positional"]
     }
+    logger.debug("keyargs: %s", keyargs)
     for k, v in portkeyargs.items():
         if v not in [None, ""]:
             keyargs.update({k: v})
+    logger.debug("keyargs: %s", keyargs)
     for k, v in portPosargsDict.items():
         logger.debug("port posarg %s has value %s", k, v)
         # logger.debug("default posarg %s has value %s", k, posargs[k])

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -221,6 +221,8 @@ def replace_named_ports(
     outputs_dict = collections.OrderedDict()
     for uid, drop in oitems:
         outputs_dict[uid] = {"path": drop.path if hasattr(drop, "path") else ""}
+    # logger.debug("appArgs: %s", appArgs)
+    # get positional args
     posargs = [arg for arg in appArgs if appArgs[arg]["positional"]]
     # get kwargs
     keyargs = {
@@ -229,7 +231,6 @@ def replace_named_ports(
     # we will need an ordered dict for all positional arguments
     # thus we create it here and fill it with values
     portPosargsDict = collections.OrderedDict(zip(posargs, [None] * len(posargs)))
-    print(portPosargsDict)
     logger.debug(
         "posargs: %s; keyargs: %s, %s",
         posargs,
@@ -293,11 +294,9 @@ def replace_named_ports(
     keyargs = {
         arg: appArgs[arg]["value"] for arg in appArgs if not appArgs[arg]["positional"]
     }
-    logger.debug("keyargs: %s", keyargs)
     for k, v in portkeyargs.items():
         if v not in [None, ""]:
             keyargs.update({k: v})
-    logger.debug("keyargs: %s", keyargs)
     for k, v in portPosargsDict.items():
         logger.debug("port posarg %s has value %s", k, v)
         # logger.debug("default posarg %s has value %s", k, posargs[k])


### PR DESCRIPTION
**Bug**

The positional parameter option currently does not work for Docker and Bash applications. For example, the **wsclean_data_local.graph** has the Docker-contained `wsclean` with the following input parameter that is marked as a positional parameter: 

![image](https://github.com/ICRAR/daliuge/assets/5227425/2da42249-4c16-4496-8c1f-f8121627c324)

However, the graph fails on deployment because the `msname` property is incorrectly processed as a keyword argument, even thought it is set as **"positional"** in the UI above. This leads to the `-msname` property being passed to `wsclean` as opposed to just the file name: 

```
/bin/bash -c "wsclean -size 512 512 -scale 0.7amin -pol I -spws 0 -niter 10000 -auto-threshold 3 -padding 1 -msname /home/rwb/dlg/workspace/wsclean_data_local12_2024-04-26T12-00-40.261395/MWA-single-timeslot.ms
```

**Root cause**

This is due to us populating the cleaned `keyargs` dictionary with any `portkeyargs` that have been identified: 

https://github.com/ICRAR/daliuge/blob/ba9760831016e0d4f8a7b0f78911a41ec17f195b/daliuge-engine/dlg/named_port_utils.py#L294-L299

The code correctly initialises `keyargs` by ensuring there are no `"positional"` arguments; however, if the `portkeyargs` contains any positional arguments that are _also_ port names (such as in the case of `msname`), then those arguments will be added to `keyargs`. 

Why is this issue suddenly happening now? `portkeyargs` is populated by `identify_named_ports()`. Previously, there was code that commented out adding positional port arguments to the returned `portargs` variable, which was uncommented in ad3d520404132f6ec5159708f972a55a6a796b4e: 
![image](https://github.com/ICRAR/daliuge/assets/5227425/52de2029-de8a-47c6-8ba2-ee308073de85)

**Solution**

As a temporary fix, I've removed the code that was un-commented to return us to previous functionality. 
Moving forward, we will want to consider a more holistic fix to update the way we coordinate named ports and keyword arguments.  
