### PR TITLE
LIU-368: Enable Drop persistence

### DIFF
--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -64,6 +64,7 @@ logger = logging.getLogger(__name__)
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
 # @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param expireAfterUse True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution#
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class DataDROP(AbstractDROP):

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -44,6 +44,7 @@ from typing import Union
 # @param dropclass dlg.data.drops.file.FileDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
 # @param persist True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param expireAfterUse True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -75,18 +75,15 @@ class FileDROP(DataDROP, PathBasedDrop):
         """
         Initialise default drop behaviour when it is completed with the following rules:
 
-            - "persist": Replicate and store the data in the specified persistent store
-            Files should be persistent by default.
+        - "expireAfterUse": Remove the data from the workspace once it has been used
+        by all consumers. This is independent of the "persist" flag. This is false
+       by default for FileDrops.
 
-            - "expireAfterUse": Remove the data from the workspace once it has been used
-            by all consumers. This is independent of the "persist" flag.
-
-            Use the default behaviour for expireAfterUse in AbstractDROP,
-            unless specified otherwise.
         """
 
-        if "persist" not in kwargs:
-            kwargs["persist"] = True
+        # 'lifespan' and 'expireAfterUse' are mutually exclusive
+        if "lifespan" not in kwargs and "expireAfterUse" not in kwargs:
+            kwargs["expireAfterUse"] = False
         self.is_dir = False
         super().__init__(*args, **kwargs)
 

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -70,13 +70,18 @@ class FileDROP(DataDROP, PathBasedDrop):
     check_filepath_exists = dlg_bool_param("check_filepath_exists", False)
     # is_dir = dlg_bool_param("is_dir", False)
 
+
     # Make sure files are not deleted by default and certainly not if they are
     # marked to be persisted no matter what expireAfterUse said
     def __init__(self, *args, **kwargs):
+        """
+        Initialze default drop behaviour when it is completed with the following rulse:
+
+            - "persist": Replicate and store the data in
+        """
+
         if "persist" not in kwargs:
             kwargs["persist"] = True
-        if kwargs["persist"] and "lifespan" not in kwargs:
-            kwargs["expireAfterUse"] = False
         self.is_dir = False
         super().__init__(*args, **kwargs)
 
@@ -158,7 +163,7 @@ class FileDROP(DataDROP, PathBasedDrop):
         self._wio = None
 
     def getIO(self):
-        return FileIO(self._path)
+            return FileIO(self._path)
 
     def delete(self):
         super().delete()

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -168,7 +168,7 @@ class FileDROP(DataDROP, PathBasedDrop):
         self._wio = None
 
     def getIO(self):
-            return FileIO(self._path)
+        return FileIO(self._path)
 
     def delete(self):
         super().delete()

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -71,14 +71,18 @@ class FileDROP(DataDROP, PathBasedDrop):
     check_filepath_exists = dlg_bool_param("check_filepath_exists", False)
     # is_dir = dlg_bool_param("is_dir", False)
 
-
-    # Make sure files are not deleted by default and certainly not if they are
-    # marked to be persisted no matter what expireAfterUse said
     def __init__(self, *args, **kwargs):
         """
-        Initialze default drop behaviour when it is completed with the following rulse:
+        Initialise default drop behaviour when it is completed with the following rules:
 
-            - "persist": Replicate and store the data in
+            - "persist": Replicate and store the data in the specified persistent store
+            Files should be persistent by default.
+
+            - "expireAfterUse": Remove the data from the workspace once it has been used
+            by all consumers. This is independent of the "persist" flag.
+
+            Use the default behaviour for expireAfterUse in AbstractDROP,
+            unless specified otherwise.
         """
 
         if "persist" not in kwargs:

--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -82,6 +82,7 @@ def parse_pydata(pd_dict: dict) -> bytes:
 # @param pydata None/String/ApplicationArgument/NoPort/ReadWrite//False/False/Data to be loaded into memory
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param expireAfterUse True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data

--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -98,8 +98,6 @@ class InMemoryDROP(DataDROP):
             kwargs["persist"] = False
         if "expireAfterUse" not in kwargs:
             kwargs["expireAfterUse"] = True
-        if kwargs["persist"]:
-            kwargs["expireAfterUse"] = False
         super().__init__(*args, **kwargs)
 
     def initialize(self, **kwargs):

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -373,11 +373,6 @@ class AbstractDROP(EventFirer, EventHandler):
         # No DROP should be persisted unless stated otherwise; used for replication
         self._persist: bool = self._popArg(kwargs, "persist", False)
 
-        # Non-persistent drops should expire after they are used
-        # If expirationDate is set, the drops will expire so we do not need to update
-        if not self._persist and self._expirationDate == -1:
-            self._expireAfterUse = True
-
         # Useful to have access to all EAGLE parameters without a prior knowledge
         self._parameters = dict(kwargs)
         self.autofill_environment_variables()

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -367,9 +367,11 @@ class AbstractDROP(EventFirer, EventHandler):
 
         # No DROP should be persisted unless stated otherwise; used for replication
         self._persist: bool = self._popArg(kwargs, "persist", False)
-        # If DROP should be persisted, don't expire (delete) it.
-        if self._persist:
-            self._expireAfterUse = False
+
+        # Non-persistent drops should expire after they are used
+        # If expirationDate is set, the drops will expire so we do not need to update
+        if not self._persist and self._expirationDate == -1:
+            self._expireAfterUse = True
 
         # Useful to have access to all EAGLE parameters without a prior knowledge
         self._parameters = dict(kwargs)

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -352,9 +352,14 @@ class AbstractDROP(EventFirer, EventHandler):
                 "but they are mutually exclusive" % (self,),
             )
 
-        self._expireAfterUse = self._popArg(kwargs, "expireAfterUse", False)
+        # If expireAfterUse is set by the user to be False, we do not want to initiate
+        # a timeout using lifespan, so we set the default for expireAfterUse to None
+        self._expireAfterUse = self._popArg(kwargs, "expireAfterUse", None)
+
+        # We only initiate the lifespan if the expireAfterUse flag has not been specified
+        # as an argument on the Drop.
         self._expirationDate = -1
-        if not self._expireAfterUse:
+        if self._expireAfterUse is None:
             lifespan = float(self._popArg(kwargs, "lifespan", -1))
             if lifespan != -1:
                 self._expirationDate = time.time() + lifespan

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -281,7 +281,17 @@ class DataLifecycleManager:
             if drop.status == DROPStates.EXPIRED:
                 self._deleteDrop(drop)
 
-    def expireCompletedDrops(self):
+    def expireCompletedDrops(self) -> None:
+        """
+        Drops that have 'expireAfterUse' argument specified should be removed
+        when the drop has completed execution.
+
+        Note: This operation occurs independently of the 'persist' argument
+        that will also be used
+
+        Returns:
+            None
+        """
         now = time.time()
         for drop in self._drops.values():
 
@@ -290,7 +300,7 @@ class DataLifecycleManager:
 
             # Expire-after-use: mark as expired if all consumers
             # are finished using this DROP
-            if not drop.persist and drop.expireAfterUse:
+            if drop.expireAfterUse:
                 allDone = all(
                     c.execStatus
                     in [AppDROPStates.FINISHED, AppDROPStates.ERROR]

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -286,8 +286,7 @@ class DataLifecycleManager:
         Drops that have 'expireAfterUse' argument specified should be removed
         when the drop has completed execution.
 
-        Note: This operation occurs independently of the 'persist' argument
-        that will also be used
+        Note: This operation occurs independently of the 'persist' argument.
 
         Returns:
             None

--- a/daliuge-engine/test/lifecycle/test_dlm.py
+++ b/daliuge-engine/test/lifecycle/test_dlm.py
@@ -145,8 +145,8 @@ class TestDataLifecycleManager(unittest.TestCase):
             a = DirectoryContainer(
                 "a",
                 "a",
-                persist=True,  # Persist should have no effect on expireAfterUse
-                expireAfterUse=True,
+                persist=False,
+                expireAfterUse=False, # Marking persist as False should lead to expiry regardless of this flag
                 dirname=tempfile.mkdtemp(),
             )
             b_dirname = tempfile.mkdtemp()

--- a/daliuge-engine/test/lifecycle/test_dlm.py
+++ b/daliuge-engine/test/lifecycle/test_dlm.py
@@ -35,6 +35,7 @@ from dlg.ddap_protocol import DROPStates, DROPPhases
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.data.drops.directorycontainer import DirectoryContainer
 from dlg.data.drops.file import FileDROP
+from dlg.data.drops.memory import InMemoryDROP
 from dlg.droputils import DROPWaiterCtx
 from dlg.lifecycle import dlm
 
@@ -61,7 +62,15 @@ class TestDataLifecycleManager(unittest.TestCase):
 
     def test_dropCompleteTriggersReplication(self):
         with dlm.DataLifecycleManager(enable_drop_replication=True) as manager:
-            drop = FileDROP("oid:A", "uid:A1", expectedSize=1)
+
+            # By default a file is non-persistent
+            drop = FileDROP("oid:B", "uid:B1", expectedSize=1)
+            manager.addDrop(drop)
+            self._writeAndClose(drop)
+            self.assertEqual(DROPPhases.GAS, drop.phase)
+            self.assertEqual(1, len(manager.getDropUids(drop)))
+
+            drop = FileDROP("oid:A", "uid:A1", expectedSize=1, persist=True)
             manager.addDrop(drop)
             self._writeAndClose(drop)
 
@@ -70,12 +79,6 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertEqual(DROPPhases.SOLID, drop.phase)
             self.assertEqual(2, len(manager.getDropUids(drop)))
 
-            # Try the same with a non-persisted data object, it shouldn't be replicated
-            drop = FileDROP("oid:B", "uid:B1", expectedSize=1, persist=False)
-            manager.addDrop(drop)
-            self._writeAndClose(drop)
-            self.assertEqual(DROPPhases.GAS, drop.phase)
-            self.assertEqual(1, len(manager.getDropUids(drop)))
 
     def test_expiringNormalDrop(self):
         with dlm.DataLifecycleManager(check_period=0.5) as manager:
@@ -130,11 +133,15 @@ class TestDataLifecycleManager(unittest.TestCase):
             self.assertEqual(DROPStates.DELETED, drop.status)
             self.assertFalse(drop.exists())
 
-    def test_expireAfterUse(self):
+    def test_expireAfterUseForFile(self):
         """
-        Simple test for the expireAfterUse flag. Two DROPs are created with
-        different values, and after they are used we check whether their data
-        is still there or not
+        Test default and non-default behaviour for the expireAfterUse flag
+        for file drops.
+
+        Default: expireAfterUse=False, so the drop should still exist after it
+        has been consumed.
+        Non-default: expiredAfterUse=True, so the drop will be expired and
+        deleted after it is consumed.
         """
 
         class MyApp(BarrierAppDROP):
@@ -142,43 +149,97 @@ class TestDataLifecycleManager(unittest.TestCase):
                 pass
 
         with dlm.DataLifecycleManager(check_period=0.5, cleanup_period=2) as manager:
-            a = DirectoryContainer(
+
+            # Check default
+            default_fp, default_name = tempfile.mkstemp()
+            default = FileDROP(
                 "a",
                 "a",
-                persist=False,
-                expireAfterUse=False, # Marking persist as False should lead to expiry regardless of this flag
-                dirname=tempfile.mkdtemp(),
+                filepath=default_name
             )
-            b_dirname = tempfile.mkdtemp()
-            b = DirectoryContainer(
+
+            expired_fp, expired_name = tempfile.mkstemp()
+            expired = FileDROP(
                 "b",
                 "b",
-                persist=True,  # Persist should have no effect on expireAfterUse
-                expireAfterUse=False,
-                dirname=b_dirname,
+                filepath=expired_name,
+                expireAfterUse=True  # Remove the file after use
             )
             c = MyApp("c", "c")
             d = MyApp("d", "d")
-            a.addConsumer(c)
-            a.addConsumer(d)
-            b.addConsumer(c)
-            b.addConsumer(d)
+            default.addConsumer(c)
+            default.addConsumer(d)
+            expired.addConsumer(c)
+            expired.addConsumer(d)
 
-            manager.addDrop(a)
-            manager.addDrop(b)
-            manager.addDrop(b)
+            manager.addDrop(default)
+            manager.addDrop(expired)
+            manager.addDrop(expired)
             manager.addDrop(c)
 
             # Make sure all consumers are done
             with DROPWaiterCtx(self, [c, d], 1):
-                a.setCompleted()
-                b.setCompleted()
+                default.setCompleted()
+                expired.setCompleted()
 
-            # Both directories should be there, but after cleanup A's shouldn't
+            # Both directories should be there, but after cleanup B's shouldn't
             # be there anymore
-            self.assertTrue(a.exists())
-            self.assertTrue(b.exists())
+            self.assertTrue(default.exists())
+            self.assertTrue(expired.exists())
             time.sleep(2.5)
-            self.assertFalse(a.exists())
-            self.assertTrue(b.exists())
-            b.delete()
+            self.assertTrue(default.exists())
+            self.assertFalse(expired.exists())
+            default.delete()
+
+    def test_expireAfterUseForMemory(self):
+        """
+        Default: expireAfterUse=True, so the drop should not exist after it
+        has been consumed.
+        Non-default: expiredAfterUse=False, so the drop will be not be expired
+        after it is consumed.
+        """
+
+        class MyApp(BarrierAppDROP):
+            def run(self):
+                pass
+
+        with dlm.DataLifecycleManager(check_period=0.5, cleanup_period=2) as manager:
+
+            # Check default behaviour - deleted for memory drops
+            default = InMemoryDROP(
+                "a",
+                "a",
+            )
+
+            # Non-default behaviour - memory is not deleted
+            non_expired = InMemoryDROP(
+                "b",
+                "b",
+                expireAfterUse=False
+            )
+            c = MyApp("c", "c")
+            d = MyApp("d", "d")
+            default.addConsumer(c)
+            default.addConsumer(d)
+            non_expired.addConsumer(c)
+            non_expired.addConsumer(d)
+
+            manager.addDrop(default)
+            manager.addDrop(non_expired)
+            manager.addDrop(non_expired)
+            manager.addDrop(c)
+
+            # Make sure all consumers are done
+            with DROPWaiterCtx(self, [c, d], 1):
+                default.setCompleted()
+                non_expired.setCompleted()
+
+            # Both directories should be there, but after cleanup B's shouldn't
+            # be there anymore
+            self.assertTrue(default.exists())
+            self.assertTrue(non_expired.exists())
+            time.sleep(2.5)
+            self.assertFalse(default.exists())
+            self.assertTrue(non_expired.exists())
+            non_expired.delete()
+

--- a/daliuge-engine/test/lifecycle/test_dlm.py
+++ b/daliuge-engine/test/lifecycle/test_dlm.py
@@ -145,7 +145,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             a = DirectoryContainer(
                 "a",
                 "a",
-                persist=False,
+                persist=True,  # Persist should have no effect on expireAfterUse
                 expireAfterUse=True,
                 dirname=tempfile.mkdtemp(),
             )
@@ -153,7 +153,7 @@ class TestDataLifecycleManager(unittest.TestCase):
             b = DirectoryContainer(
                 "b",
                 "b",
-                persist=False,
+                persist=True,  # Persist should have no effect on expireAfterUse
                 expireAfterUse=False,
                 dirname=b_dirname,
             )


### PR DESCRIPTION
**Problem**
This PR partially addresses LIU-368, which aims to enable proper persistence of data drops. 

Currently, the `persist` and `expireAfterUse` flag are coupled together. This is orthogonal to the original behaviour, in which the expiry of the drop data should have no bearing on the persistence of the data (which would ensure it is copied elsewhere). 

This PR partially addresses this work by de-coupling the `expireAfterUse` behaviour from the persist behaviour. 

**Solution**
- Remove `persist` check in `dlm.expireCompletedDrops`
- Updated the default values in `dlg.drop` so that if we only use the lifespan if we don't specify `expireAfterUse` in the Drop arguments. Otherwise, we would set `expireAfterUse` to `False` and then the lifespan would be set, which is the opposite of what we want. 

The current default behaviour exists: 

- FileDrop: expireAfterUse=False
- MemoryDrop: ExpireAfterUse=True
- Other Drops: ExpireAfterUse=None
    - _If_ "lifespan" != -1, then the drop will still expire (after the timeout) 
    - _Else_, the drop will not expire after use. 

**Testing** 
- I've confirmed using a simple Hello World graph that setting the `expireAfterUse` to `True` will lead to the `file.out` being removed from the workspace; setting it to `False` leaves it present. 
- I've updated the test cases to be more explicit about the default behaviours for both File and Memory drops. 

**Future work**
The `'persist'` option has not been completely fulfilled. More work needs to be done to: 
- Add a file-store if the 'persist' option is selected
- Establish a warning for `persist` when there is no persistent file-store specified. 
- Pickling/serialization mechansim for a MemoryDrop that is marked as persistent
- Ability to load serialized MemoryDrops
