### PR TITLE
Add manager host to list of nodes when deploy method is Server

### DIFF
--- a/daliuge-translator/dlg/dropmake/web/translator_rest.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_rest.py
@@ -635,7 +635,7 @@ def gen_pg(
             host=mhost, port=mport, url_prefix=mprefix, timeout=30
         )
         # 1. get a list of nodes
-        node_list = mgr_client.nodes()
+        node_list = [f"{mhost}:{mport}"] + mgr_client.nodes()
         logger.debug("Calling mapping to nodes: %s", node_list)
         # 2. mapping PGTP to resources (node list)
         pg_spec = pgtp.to_pg_spec(node_list, ret_str=False)


### PR DESCRIPTION
# Issue

This PR addresses https://github.com/ICRAR/daliuge/issues/255, in which I was not able to generate and deploy physical graphs because only a single node was being returned to the translator when the ManagerClient was queried for current nodes. 

This is only an issue with the Server deploy method; the Browser Direct method is working fine. 

# Cause 
The server and the Browser Direct method use different REST calls: 
- Server: \gen_pg
- Browser Direct: \gen_pg_spec

This is likely due to their requiring different pieces of information at runtime. 

They do get the same list of nodes, albeit in different through different methods. What they do with this list, however, is the difference.

**`\gen_pg`, Server**

https://github.com/ICRAR/daliuge/blob/bf3a8fcda936ed13d8dd41b893ccce560c529275/daliuge-translator/dlg/dropmake/web/translator_rest.py#L637-L641

**`\gen_pg_spec`, Browser Direct** 
https://github.com/ICRAR/daliuge/blob/bf3a8fcda936ed13d8dd41b893ccce560c529275/daliuge-translator/dlg/dropmake/web/translator_rest.py#L721-L726

It is clear that for the Browser Direct case (i.e., the one that works) we are adding the manager to the start of any list of nodes, which is what we need when we split the list of nodes into island and node managers in `to_pg_spec`:

https://github.com/ICRAR/daliuge/blob/bf3a8fcda936ed13d8dd41b893ccce560c529275/daliuge-translator/dlg/dropmake/pgt.py#L279-L280

# Solution

The following is necessary to resolve the issue: 
- Add the manager to the list of nodes for the server (Done) 
- Add some documentation to make explicit what is happening (In-progress) 
- Add more informative error handling when it comes to the node list. 