### PR TITLE
Fix missing rtd_sphinx_them install directive

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+
+  python:
+    install:
+      - requirements: docs/requirements.txt
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"


### PR DESCRIPTION
My previous commit missed the install requirements.txt from the new RTD config: https://blog.readthedocs.com/defaulting-latest-build-tools/. 

This is (still) leading to build failures for our documentation (albeit different build failures). 

https://readthedocs.org/projects/daliuge/builds/24361205/