### PR TITLE
LIU-385: Add support for SubGraphs in translator

### DIFF
--- a/daliuge-translator/dlg/dropmake/definition_classes.py
+++ b/daliuge-translator/dlg/dropmake/definition_classes.py
@@ -53,6 +53,7 @@ class Categories:
     GROUP_BY = "GroupBy"
     LOOP = "Loop"
     VARIABLES = "Variables"
+    SUBGRAPH = "SubGraph"
 
     BRANCH = "Branch"
     DATA = "Data"
@@ -106,6 +107,7 @@ CONSTRUCT_TYPES = [
     Categories.LOOP,
     Categories.MKN,
     Categories.SERVICE,
+    Categories.SUBGRAPH
 ]
 
 
@@ -117,3 +119,4 @@ class ConstructTypes:
     LOOP = Categories.LOOP
     MKN = Categories.MKN
     SERVICE = Categories.SERVICE
+    SUBGRAPH = Categories.SUBGRAPH

--- a/daliuge-translator/dlg/dropmake/dm_utils.py
+++ b/daliuge-translator/dlg/dropmake/dm_utils.py
@@ -467,6 +467,7 @@ def convert_construct(lgo):
             ConstructTypes.SCATTER,
             ConstructTypes.GATHER,
             ConstructTypes.SERVICE,
+            ConstructTypes.SUBGRAPH
         ]:
             continue
         has_app = None
@@ -482,6 +483,8 @@ def convert_construct(lgo):
                 has_app = ak
                 break
         if has_app is None:
+            if node["category"] == ConstructTypes.SUBGRAPH:
+                node["hasInputApp"] = False
             continue
         # step 1
         app_node = dict()
@@ -513,6 +516,9 @@ def convert_construct(lgo):
 
         if node["category"] == ConstructTypes.SERVICE:
             app_node["isService"] = True
+
+        if node["category"] == ConstructTypes.SUBGRAPH:
+            app_node["hasInputApp"] = True
 
         new_nodes.append(app_node)
 

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -371,6 +371,8 @@ class LG:
         elif lgn.is_service:
             # no action required, inputapp node aleady created and marked with "isService"
             pass
+        elif lgn.is_subgraph:
+            pass
         else:
             src_drop = lgn.make_single_drop(iid, loop_ctx=lpcxt)
             self._drop_dict[lgn.id].append(src_drop)
@@ -772,6 +774,9 @@ class LG:
                     # per compute instance
                     tlgn["categoryType"] = "Application"
                     tlgn["category"] = "PythonApp"
+                elif tlgn.is_subgraph:
+                    # TODO LIU-385: Add behaviour for when we have an SubGraphInputApp
+                    pass
                 else:
                     raise GraphException(
                         "Unsupported target group {0}".format(tlgn.jd.category)
@@ -827,6 +832,10 @@ class LG:
                 # for sl_drop in self._drop_dict[lid]:
                 #     if 'gather-data_drop' in sl_drop:
                 #         del sl_drop['gather-data_drop']
+            elif lgn.is_subgraph:
+                if not lgn.jd['hasInputApp']:
+                    del self._drop_dict[lid]
+                # TODO LIU-385: Add support for SubGraphs with InputApps
 
         logger.info(
             "Unroll progress - extra drops done for session %s",

--- a/daliuge-translator/dlg/dropmake/lg_node.py
+++ b/daliuge-translator/dlg/dropmake/lg_node.py
@@ -514,6 +514,10 @@ class LGNode:
         return self._jd["category"] == Categories.MPI
 
     @property
+    def is_subgraph(self):
+        return self._jd["category"] == Categories.SUBGRAPH
+
+    @property
     def group_keys(self):
         """
         Return:
@@ -702,6 +706,8 @@ class LGNode:
                             break
                 elif self.is_service:
                     self._dop = 1  # TODO: number of compute nodes
+                elif self.is_subgraph:
+                    self._dop = 1
                 else:
                     raise GInvalidNode(
                         "Unrecognised (Group) Logical Graph Node: '{0}'".format(


### PR DESCRIPTION
This supports SubGraphs with no InputApps, which functionally ignores the entire SubGraph construct.

|Logical Graph| Translated Graph|
| ---- | ---- | 
| ![image](https://github.com/ICRAR/daliuge/assets/5227425/29364ab3-569f-4b80-898b-feeb96fe6c78) | ![image](https://github.com/ICRAR/daliuge/assets/5227425/015907e8-46b8-45ca-a355-0565381a0525) | 

This does **not** address the functionality of sub-graphs with input apps, nor does it make any attempt to address the translation of those graphs; this may lead to undefined behaviour if a sub-graph with input apps is submitted for translation.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds support for SubGraphs in the translator, specifically handling SubGraphs with no InputApps. It introduces a new property to identify SubGraph nodes and updates relevant functions to process these constructs.

* **New Features**:
    - Added support for SubGraphs in the translator, allowing SubGraphs with no InputApps to be processed.
* **Enhancements**:
    - Introduced a new property `is_subgraph` in `lg_node.py` to identify SubGraph nodes.
    - Updated `convert_construct` function in `dm_utils.py` to handle SubGraph constructs.

<!-- Generated by sourcery-ai[bot]: end summary -->