### PR TITLE
EAGLE-1243: Modify branch doxygen to name output ports 'yes' and 'no'

### DIFF
--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -16,8 +16,8 @@ from dlg.exceptions import InvalidDropException
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @param dummy_input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/Dummy input port
-# @param yes /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/True condition output port
-# @param no /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/False condition output port
+# @param true /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/True condition output port
+# @param false /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/False condition output port
 # @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
 # @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END

--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -16,8 +16,8 @@ from dlg.exceptions import InvalidDropException
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @param dummy_input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/Dummy input port
-# @param dummy0 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
-# @param dummy1 /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
+# @param yes /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/True condition output port
+# @param no /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/False condition output port
 # @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
 # @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the naming of output ports in the branch component to 'yes' and 'no', improving clarity and readability of the code.

* **Enhancements**:
    - Renamed output ports in the branch component from 'dummy0' and 'dummy1' to 'yes' and 'no' to better reflect their functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->