### PR TITLE
LIU-395: Resolve missing AppDrop tracebacks from log files.

### DIFF
--- a/daliuge-engine/conftest.py
+++ b/daliuge-engine/conftest.py
@@ -1,0 +1,8 @@
+"""
+This file ensures dlg.runtime is loaded up when running pytest on a suite of tests.
+
+This sets up the correct logging runtime and drop-tracking.
+"""
+
+import dlg.runtime
+import pytest

--- a/daliuge-engine/dlg/apps/app_base.py
+++ b/daliuge-engine/dlg/apps/app_base.py
@@ -7,6 +7,7 @@ import math
 import threading
 
 from dlg.drop_loaders import load_pickle
+from dlg.drop import track_current_drop
 from dlg.data.drops.container import ContainerDROP
 from dlg.data.drops.data_base import DataDROP
 from dlg.ddap_protocol import (
@@ -15,7 +16,6 @@ from dlg.ddap_protocol import (
     DROPStates,
     DROPRel,
 )
-from dlg.utils import object_tracking
 from dlg.exceptions import InvalidDropException, InvalidRelationshipException
 
 from dlg.meta import (
@@ -23,8 +23,6 @@ from dlg.meta import (
 )
 
 logger = logging.getLogger(__name__)
-
-track_current_drop = object_tracking("drop")
 
 
 class DropRunner(ABC):

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -289,7 +289,6 @@ class Session(object):
 
         # This will check the consistency of each dropSpec
         logger.debug("Trying to add graphSpec:")
-        logger.exception("Trying to test exception")
         for x in graphSpec:
             logger.debug("%s: %s", x, x.keys())
         try:

--- a/daliuge-engine/test/test_logs.py
+++ b/daliuge-engine/test/test_logs.py
@@ -1,0 +1,104 @@
+import logging
+import time
+import pytest
+
+from pathlib import Path
+
+
+from dlg.runtime import version  # Imported to setup DlgLogger
+from dlg.apps.app_base import BarrierAppDROP
+from dlg.droputils import DROPWaiterCtx
+from dlg.manager.session import Session, generateLogFileName
+
+default_repro = {
+    "rmode": "1",
+    "RERUN": {
+        "lg_blockhash": "x",
+        "pgt_blockhash": "y",
+        "pg_blockhash": "z",
+    },
+}
+default_graph_repro = {
+    "rmode": "1",
+    "meta_data": {"repro_protocol": 0.1, "hashing_alg": "_sha3.sha3_256"},
+    "merkleroot": "a",
+    "RERUN": {
+        "signature": "b",
+    },
+}
+
+class MockThrowingDrop(BarrierAppDROP):
+    def run(self):
+        raise RuntimeError("App drop thrown")
+
+def add_test_reprodata(graph: list):
+    for drop in graph:
+        drop["reprodata"] = default_repro.copy()
+    graph.append(default_graph_repro.copy())
+    return graph
+
+def test_logs(caplog):
+    """
+    Confirm that when we run a session in which the AppDrop experiences a runtime error,
+    we produce the trackback for that application in the file.
+
+    This acts as a regression test to make sure changes in the future don't lead to
+    app/data drop tracking no longer adding appropriate attributes to the LogRecords such
+    that they pass the filter setup in the Session constructor. For further information,
+    review the runtime/__init__.py file.
+
+    The test uses the pytest.caplog fixture to first confirm that:
+    1. An exception is logged in the DlgLogger, and
+    2. That the exception passes through the filters setup in the Session constructor, and
+        properly described in the session log file.
+
+    This aims to detect regressions when re-organising class structures or logging in the
+    future.
+    """
+
+    with caplog.at_level(logging.INFO):
+        with Session("log-session") as s:
+            s.addGraphSpec(
+                add_test_reprodata(
+                    [
+                        {
+                            "oid": "A",
+                            "categoryType": "Data",
+                            "dropclass": "dlg.data.drops.memory.InMemoryDROP",
+                            "consumers": ["B"],
+                        },
+                        {
+                            "oid": "B",
+                            "categoryType": "Application",
+                            "dropclass": "test.test_session.MockThrowingDrop",
+                            "sleep_time": 2,
+                        },
+                        {
+                            "oid": "C",
+                            "categoryType": "Data",
+                            "dropclass": "dlg.data.drops.memory.InMemoryDROP",
+                            "producers": ["B"],
+                        },
+                    ]
+                )
+            )
+
+            s.deploy()
+            with DROPWaiterCtx(None, s.drops["C"], 300):
+                s.drops["A"].write(b"x")
+                s.drops["A"].setCompleted()
+
+            # Logger needs time to get messages.
+            time.sleep(5)
+            logfile = Path(generateLogFileName(s._sessionDir, s.sessionId))
+            exception_logged = False
+            for record in caplog.records:
+                if record.name == 'dlg.apps.app_base' and record.levelname == 'ERROR':
+                    exception_logged = True
+                    with logfile.open('r') as f:
+                        buffer = f.read()
+                        assert record.name in buffer
+                        assert 'Traceback' in buffer
+                        assert 'App drop thrown' in buffer
+            assert exception_logged
+            logfile.unlink(missing_ok=True)

--- a/daliuge-engine/test/test_session.py
+++ b/daliuge-engine/test/test_session.py
@@ -29,12 +29,13 @@ import pytest
 from pathlib import Path
 
 
+from dlg.runtime import version  # Imported to setup DlgLogger
+
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.ddap_protocol import DROPLinkType, DROPStates, AppDROPStates
 from dlg.droputils import DROPWaiterCtx
 from dlg.exceptions import InvalidGraphException
 from dlg.manager.session import SessionStates, Session, generateLogFileName
-from dlg.runtime import version  # Imported to setup DlgLogger
 
 default_repro = {
     "rmode": "1",
@@ -150,8 +151,6 @@ def test_logs(caplog):
                         assert 'Traceback' in buffer
                         assert 'App drop thrown' in buffer
             assert exception_logged
-            logfile.unlink()
-
 
 class TestSession(unittest.TestCase):
     def test_sessionStates(self):
@@ -166,10 +165,12 @@ class TestSession(unittest.TestCase):
             s.deploy()
             self.assertEqual(SessionStates.RUNNING, s.status)
 
+
             # Now we can't do any of these
             self.assertRaises(Exception, s.deploy)
             self.assertRaises(Exception, s.addGraphSpec, "")
             self.assertRaises(Exception, s.linkGraphParts, "", "", 0)
+
 
     def test_sessionStates_noDrops(self):
         # No drops created, we can deploy right away


### PR DESCRIPTION
# Issue

This addresses [LIU-395](https://icrar.atlassian.net/browse/LIU-395): we would like to make the debugging of errors that occur at runtime easier and more clearer. However, if an app experiences an exception (for example), or the session is unable to instantiate drops for some reason (e.g. logical graph references non-existent dropclasses), the session-log currently does not show any information about the errors. 

# Solution 
It turns out that we have previously been able to do this before but some movement in the class structure caused issues. This took _a long time_ to actually narrow time, in part because of my unfamiliarity with the logging code, and in part because our logging has is doing lots of cool - but hidden - things.  

We only log to the session FileHandler if we have the `session_id` attribute associated with the LogRecord; this is to ensure we don't end up with every session's logs in our per-session log file.  The issue occurred because we use a custom logger, DlgLogger, defined in `runtime/__init__.py`. This appends `session_id `and `drop_uid` attributes to the `LogRecord` object every time a `logger` call is made in a thread associated with a drop. The way we identify those threads is through: 

```python
            from .. import drop
            from ..manager import session
                ...
                drop = drop.track_current_drop.tlocal.drop
                ... 
                if drop and hasattr(drop, "_dlg_session_id"):                   
                    session_id = drop._dlg_session_id                           

```

This is using the `track_current_drop` associated with the base `drop.py` file. The problem was that when the app_base.py file was created, a different `track_current_drop` was created, which meant all methods in that file that were using the `@track_current_drop` decorator were not visible to the `track_current_drop` used in the `DlgLogger` class. 

Updating `app_base.py` to import the more global `drop.track_current_drop` method (as done in `data_base.py`, which was logging fine) resolves the issue. 

I have added a unittest in `test_session` to make sure this sort of regression doesn't happen in the future, and I've improved some of the exception logging in the `Session` class whilst I have been working here. 

[LIU-395]: https://icrar.atlassian.net/browse/LIU-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix missing tracebacks in session logs by correcting the import of `track_current_drop` in `app_base.py`. Enhance exception logging in the `Session` class and add a regression test to ensure runtime errors are properly logged.

Bug Fixes:
- Resolve missing tracebacks in session logs by ensuring the correct `track_current_drop` method is imported in `app_base.py`.

Enhancements:
- Improve exception logging in the `Session` class to provide clearer error messages and better debugging information.

Tests:
- Add a unittest in `test_session.py` to verify that runtime errors in AppDrop are logged correctly, preventing future regressions.

<!-- Generated by sourcery-ai[bot]: end summary -->