### PR TITLE
Fixed a few issues with make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .ONESHELL:
-ENV_PREFIX=$(shell python -c "if __import__('pathlib').Path('.venv/bin/pip').exists(): print('.venv/bin/')")
+ENV_PREFIX=$(shell python -c "if __import__('pathlib').Path('.venv/bin/pip').exists(): print('%s/'% __import__('pathlib').Path('.venv/bin').absolute())")
 USING_POETRY=$(shell grep "tool.poetry" pyproject.toml && echo "yes")
 
 .PHONY: help
@@ -51,10 +51,12 @@ lint:             ## Run pylint
 
 .PHONY: test
 test: 		  ## Run tests and generate coverage report.
-	@$(ENV_PREFIX)cd daliuge-translator
-	@$(ENV_PREFXI)py.test --cov --show-capture=no
-	@$(ENV_PREFIX)cd ../daliuge-engine
-	@$(ENV_PREFIX)py.test --cov --show-capture=no
+	@ pip install pytest
+	@ pip install pytest-cov
+	@ cd daliuge-translator
+	@ $(ENV_PREFIX)py.test --cov --show-capture=no
+	@ cd ../daliuge-engine
+	@ $(ENV_PREFIX)py.test --cov --show-capture=no
 
 .PHONY: clean
 clean:            ## Clean unused files.


### PR DESCRIPTION
Just some small fixes to get make test running on a fresh install (no pytest and pytest-cov installed). ENV_PREFIX was actually wrong in many cases, since it was a relative path.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix issues with the 'make test' command by correcting the ENV_PREFIX to use an absolute path and ensuring pytest and pytest-cov are installed before running tests.

Bug Fixes:
- Correct the ENV_PREFIX in the Makefile to use an absolute path instead of a relative path.

Enhancements:
- Ensure pytest and pytest-cov are installed before running tests in the Makefile.

<!-- Generated by sourcery-ai[bot]: end summary -->