### PR TITLE
Added 'encoding' attribute to fields in LG schema

### DIFF
--- a/daliuge-translator/dlg/dropmake/lg.graph.schema
+++ b/daliuge-translator/dlg/dropmake/lg.graph.schema
@@ -318,6 +318,11 @@
                                 "keyAttribute": {
                                     "type": "boolean"
                                 },
+                                "encoding": {
+                                    "type": "string",
+                                    "enum": ["binary", "pickle", "dill", "npy", "base64", "utf-8"],
+                                    "default": "dill"
+                                },
                                 "id": {
                                     "type": "string"
                                 },


### PR DESCRIPTION
Deleted old branch (eagle-1231), reproduced this work in new branch (eagle-1231-2).

Adds the 'encoding' attribute to fields in the JSON schema for logical graphs. Possible values of the attribute are:

- "binary"
- "pickle"
- "dill" (default)
- "npy"
- "base64"
- "utf-8"