### PR TITLE
Avahi trans fix

### DIFF
--- a/daliuge-common/build_common.sh
+++ b/daliuge-common/build_common.sh
@@ -5,7 +5,7 @@
 
 case "$1" in
     "dep")
-        export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+        export VCS_TAG=`git describe --tags --abbrev=0 --always|sed s/v//`
         echo "Building daliuge-common version using tag ${VCS_TAG}"
         docker build --build-arg VCS_TAG=${VCS_TAG} --no-cache -t icrar/daliuge-common:${VCS_TAG} -f docker/Dockerfile .
         echo "Build finished!"

--- a/daliuge-engine/build_engine.sh
+++ b/daliuge-engine/build_engine.sh
@@ -3,7 +3,7 @@
 # branch name or with a release tag depending whether this is a development or deployment
 # version.
 
-export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+export VCS_TAG=`git describe --tags --abbrev=0 --always|sed s/v//`
 export DEV_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
 
 case "$1" in

--- a/daliuge-engine/run_engine.sh
+++ b/daliuge-engine/run_engine.sh
@@ -29,7 +29,7 @@ then
 	export VCS_TAG=$2
 	export C_TAG=$VCS_TAG
 else
-	export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+	export VCS_TAG=`git describe --tags --abbrev=0 --always|sed s/v//`
 	export C_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
 fi
 case "$1" in

--- a/daliuge-translator/build_translator.sh
+++ b/daliuge-translator/build_translator.sh
@@ -3,8 +3,11 @@
 # branch name or with a release tag depending whether this is a development or deployment
 # version.
 
-export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+export VCS_TAG=`git describe --tags --always --abbrev=0|sed s/v//`
 export DEV_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
+if [ $DEV_TAG=="master" ]; then
+	VCS_TAG=$DEV_TAG;
+fi
 
 case "$1" in
     "dep")

--- a/daliuge-translator/run_translator.sh
+++ b/daliuge-translator/run_translator.sh
@@ -4,28 +4,33 @@ then
 	export VCS_TAG=$2
 	export C_TAG=$VCS_TAG
 else
-	export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
+	export VCS_TAG=`git describe --tags --abbrev=0 --always|sed s/v//`
 	export C_TAG=`git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]'`
+	if [ $C_TAG=="master" ]; then VCS_TAG=$C_TAG; fi
 fi
 case "$1" in
     "dep")
         echo "Running Translator deployment version in background..."
         docker run -h dlg-trans --name daliuge-translator --rm -td -p 8084:8084 icrar/daliuge-translator:${VCS_TAG}
-        sleep 3;;
+	sleep 3
+	docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
     "dev")
         echo "Running Translator development version in background..."
         docker run -d -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator:${C_TAG}
-        sleep 3;;
-    "slim")
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
+     "slim")
         echo "Running Translator development version in background..."
         docker run -d -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator.slim:${VCS_TAG}
-        sleep 3;;
-    "casa")
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
+     "casa")
         export VCS_TAG=`git rev-parse --abbrev-ref HEAD| tr '[:upper:]' '[:lower:]'`-casa
         echo "Running Translator development version in foreground..."
         docker run -h dlg-trans --volume $PWD/dlg/dropmake:/dlg/lib/python3.8/site-packages/dlg/dropmake --name daliuge-translator --rm -t -p 8084:8084 icrar/daliuge-translator:${VCS_TAG}
-        sleep 3;;
-    *)
+        sleep 3
+        docker exec -u root daliuge-translator bash -c "service avahi-daemon stop > /dev/null 2>&1 && service dbus restart > /dev/null 2>&1 && service avahi-daemon start > /dev/null 2>&1";;
+     *)
         echo "Usage run_translator.sh <dep|dev|slim|casa>"
         exit 0;;
 esac


### PR DESCRIPTION
This PR covers fixes for a few small issues with the build process:

1) The AVAHI service was not started when running the translator docker container.
2) The docker builds tried to use the commit hash as a name extension for the image when building on master.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the AVAHI service startup issue in the translator Docker container and adjust the Docker build scripts to use the branch name as a tag when building on the master branch.

Bug Fixes:
- Ensure the AVAHI service is started when running the translator Docker container.

Build:
- Modify the Docker build scripts to use the branch name as a tag when on the master branch instead of the commit hash.

<!-- Generated by sourcery-ai[bot]: end summary -->