### PR TITLE
LIU-406: Re-direct the palette generation to EAGLE-graph-repo

### DIFF
--- a/.github/workflows/create-palettes.yml
+++ b/.github/workflows/create-palettes.yml
@@ -47,11 +47,11 @@ jobs:
           EAGLE_UPDATER_TOKEN: ${{ secrets.EAGLE_UPDATER_TOKEN }}
           PALETTE_TOKEN: ${{ secrets.PALETTE_TOKEN }}
         run: |
-          git clone https://$PALETTE_TOKEN@github.com/ICRAR/EAGLE_test_repo
-          mkdir -p EAGLE_test_repo/$PROJECT_NAME
-          mv $OUTPUT_FILENAME.palette EAGLE_test_repo/$PROJECT_NAME/
-          mv $OUTPUT_FILENAME-template.palette EAGLE_test_repo/$PROJECT_NAME/
-          cd EAGLE_test_repo
+          git clone https://$PALETTE_TOKEN@github.com/ICRAR/EAGLE-graph-repo
+          mkdir -p EAGLE-graph-repo/$PROJECT_NAME
+          mv $OUTPUT_FILENAME.palette EAGLE-graph-repo/$PROJECT_NAME/
+          mv $OUTPUT_FILENAME-template.palette EAGLE-raph-repo/$PROJECT_NAME/
+          cd EAGLE-graph-repo
           git add *
           git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $GITHUB_REF_NAME, commit $PROJECT_VERSION)"
           git push

--- a/.github/workflows/create-palettes.yml
+++ b/.github/workflows/create-palettes.yml
@@ -50,7 +50,7 @@ jobs:
           git clone https://$PALETTE_TOKEN@github.com/ICRAR/EAGLE-graph-repo
           mkdir -p EAGLE-graph-repo/$PROJECT_NAME
           mv $OUTPUT_FILENAME.palette EAGLE-graph-repo/$PROJECT_NAME/
-          mv $OUTPUT_FILENAME-template.palette EAGLE-raph-repo/$PROJECT_NAME/
+          mv $OUTPUT_FILENAME-template.palette EAGLE-graph-repo/$PROJECT_NAME/
           cd EAGLE-graph-repo
           git add *
           git diff-index --quiet HEAD || git commit -m "Automatically generated DALiuGE palette (branch $GITHUB_REF_NAME, commit $PROJECT_VERSION)"


### PR DESCRIPTION
# Summary

This PR moves the staging of the operational DALiuGE palettes from the EAGLE_test_repo to the EAGLE-graph-repo. 

This is part of ongoing work to clean up our graph test environments, and means that operational graphs are no longer stored in a 'testing/staging' area.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Redirect the operational DALiuGE palette generation from the EAGLE_test_repo to the EAGLE-graph-repo as part of the effort to clean up graph test environments.

CI:
- Update the CI workflow to redirect the palette generation from the EAGLE_test_repo to the EAGLE-graph-repo.

<!-- Generated by sourcery-ai[bot]: end summary -->