### PR TITLE
LIU-408: Add support for Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -21,7 +21,17 @@ jobs:
             translator: no
           - python-version: "3.10"
             test_number: 2
-            desc: "full package"
+            desc: "full package v3.10"
+            engine: yes
+            translator: yes
+          - python-version:  "3.11"
+            test_number: 3
+            desc: "full package v3.11"
+            engine: yes
+            translator: yes
+          - python-version:  "3.12"
+            test_number: 4
+            desc: "full package v3.12"
             engine: yes
             translator: yes
 

--- a/daliuge-common/dlg/common/tool.py
+++ b/daliuge-common/dlg/common/tool.py
@@ -28,8 +28,7 @@ import subprocess
 import sys
 import time
 
-import pkg_resources
-
+from importlib.metadata import entry_points
 
 logger = logging.getLogger(__name__)
 
@@ -117,9 +116,8 @@ def version(parser, args):
 
 cmdwrap("version", "Reports the DALiuGE version and exits", version)
 
-
 def _load_commands():
-    for entry_point in pkg_resources.iter_entry_points("dlg.tool_commands"):
+    for entry_point in entry_points(group="dlg.tool_commands"):
         entry_point.load().register_commands()
 
 

--- a/daliuge-common/dlg/common/tool.py
+++ b/daliuge-common/dlg/common/tool.py
@@ -19,6 +19,8 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
+# pylint: disable=no-member
+
 """dlg command line utility"""
 import importlib
 import logging

--- a/daliuge-common/dlg/common/tool.py
+++ b/daliuge-common/dlg/common/tool.py
@@ -20,7 +20,6 @@
 #    MA 02111-1307  USA
 #
 """dlg command line utility"""
-
 import importlib
 import logging
 import optparse
@@ -117,8 +116,13 @@ def version(parser, args):
 cmdwrap("version", "Reports the DALiuGE version and exits", version)
 
 def _load_commands():
-    for entry_point in entry_points(group="dlg.tool_commands"):
-        entry_point.load().register_commands()
+    if sys.version_info.minor < 10:
+        all_entry_points = entry_points()
+        for entry_point in all_entry_points["dlg.tool_commands"]:
+            entry_point.load().register_commands()
+    else:
+        for entry_point in entry_points(group="dlg.tool_commands"):
+            entry_point.load().register_commands()
 
 
 def print_usage(prgname):

--- a/daliuge-common/dlg/common/tool.py
+++ b/daliuge-common/dlg/common/tool.py
@@ -19,7 +19,6 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-# pylint: disable=no-member
 
 """dlg command line utility"""
 import importlib
@@ -123,7 +122,7 @@ def _load_commands():
         for entry_point in all_entry_points["dlg.tool_commands"]:
             entry_point.load().register_commands()
     else:
-        for entry_point in entry_points(group="dlg.tool_commands"):
+        for entry_point in entry_points(group="dlg.tool_commands"):  # pylint: disable=unexpected-keyword-arg
             entry_point.load().register_commands()
 
 

--- a/daliuge-common/setup.py
+++ b/daliuge-common/setup.py
@@ -63,8 +63,8 @@ def do_versioning():
 install_requires = [
     "gputil>=1.4.0",
     "merklelib@git+https://github.com/pritchardn/merklelib",
-    "pyzmq==25.1.0",
-    "pydantic==1.10.13",
+    "pyzmq==25.1.1",
+    "pydantic>=2.5",
     "boto3",
     "phonenumbers",
     "mailchecker",

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -145,7 +145,7 @@ install_requires = [
     "paramiko",
     "psutil",
     "python-daemon",
-    "pyzmq == 25.1.0",
+    "pyzmq == 25.1.1",  # Python 25.1.1 is minimal install that supports Python 3.12
     "scp",
     "pyext @ git+https://github.com/itea1001/PyExt",
     "pyyaml",


### PR DESCRIPTION
This PR adds support for newer Python version, Python3.11 and 3.12. 

As Python 3.8 and older version are no longer being maintained, it is useful to make sure we are working with new-er versions that are more likely to be installed on user's machines and shared computing facilities.

## Summary by Sourcery

Add support for Python 3.11 and 3.12 by updating dependencies and CI configurations to ensure compatibility with these versions.

New Features:
- Add support for Python 3.11 and 3.12 in the project.

Enhancements:
- Update dependency versions for pyzmq and pydantic to ensure compatibility with Python 3.12.

CI:
- Update CI configuration to include testing for Python 3.11 and 3.12.