### PR TITLE
LIU-417: Add GraphConfig to translator

### DIFF
--- a/daliuge-translator/dlg/dropmake/dm_utils.py
+++ b/daliuge-translator/dlg/dropmake/dm_utils.py
@@ -168,8 +168,6 @@ def _check_MKN(m, k, n):
     if ratio1.is_integer() and ratio2.is_integer():
         return int(ratio1), int(ratio2)
     else:
-        from .pg_generator import GraphException
-
         raise GraphException("M-K and k-N must be pairs of multiples")
 
 

--- a/daliuge-translator/dlg/dropmake/graph_config.py
+++ b/daliuge-translator/dlg/dropmake/graph_config.py
@@ -1,0 +1,88 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2015
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+"""
+Module containing utility methods for working with GraphConfigs
+"""
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+ACTIVE_CONFIG_KEY = "activeGraphConfigId"
+CONFIG_KEY = "graphConfigurations"
+GRAPH_NODES = "nodeDataArray"
+
+def apply_active_configuration(logical_graph: dict) -> dict:
+    """
+    Given a JSON representation of the LogicalGraph template, apply the 
+    "Active Configuration" to the relevant constructs/fields.
+
+
+    """
+
+    if not ACTIVE_CONFIG_KEY in logical_graph:
+        LOGGER.warning("No %s available in Logical Graph.", ACTIVE_CONFIG_KEY)
+        return logical_graph
+    
+    if CONFIG_KEY in logical_graph:
+        if not logical_graph[CONFIG_KEY]:
+            LOGGER.warning("No %s provided to the Logical Graph.", CONFIG_KEY)
+            return logical_graph
+
+        activeConfigurationID = logical_graph[ACTIVE_CONFIG_KEY]
+        activeConfig = logical_graph[CONFIG_KEY][activeConfigurationID]
+         
+        nodeDataArray = logical_graph[GRAPH_NODES] 
+
+        for node_id, fields in activeConfig["nodes"].items():
+            idx = get_key_idx_from_list(node_id, nodeDataArray) 
+            if idx is None:
+                LOGGER.warning(
+                    "%s present in activeConfig but no available in Logical Graph."
+                )
+                continue 
+            node_name = nodeDataArray[idx]["name"]
+            for field_id, config_field in activeConfig["nodes"][node_id]["fields"].items():
+                fieldidx = get_key_idx_from_list(field_id, nodeDataArray[idx]["fields"])
+                field = nodeDataArray[idx]["fields"][fieldidx]
+                prev_value = field["value"]
+                field["value"] =  config_field["value"]
+                field_name = field["name"]
+                LOGGER.info("Updating: Node %s, Field %s, from %s to %s",
+                            node_name, field_name, str(prev_value), str(field["value"]))
+                nodeDataArray[idx]["fields"][fieldidx] = field
+        logical_graph[GRAPH_NODES] = nodeDataArray
+    else:
+        LOGGER.error("No graph configuration available in Logical Graph.")
+
+    return logical_graph
+
+
+def get_key_idx_from_list(key: str, dictList: list) -> int: 
+    """
+    Retrieve the index of the node that exists in the nodeDataArray sub-dict in the
+    Logical Graph. 
+
+    Note: This is necessary because we store each node in a list of dictionaries, rather 
+    than a dict of dicts. 
+    """
+    return next((idx for idx, keyDict in enumerate(dictList) if keyDict['id']==key), None)

--- a/daliuge-translator/dlg/dropmake/graph_config.py
+++ b/daliuge-translator/dlg/dropmake/graph_config.py
@@ -57,15 +57,16 @@ def apply_active_configuration(logical_graph: dict) -> dict:
             idx = get_key_idx_from_list(node_id, nodeDataArray) 
             if idx is None:
                 LOGGER.warning(
-                    "%s present in activeConfig but not available in Logical Graph."
+                    "%s present in activeConfig but not available in Logical Graph.",
+                    node_id
                 )
                 continue 
             node_name = nodeDataArray[idx]["name"]
-            for field_id, config_field in activeConfig["nodes"][node_id]["fields"].items():
+            for field_id, cfg_field in activeConfig["nodes"][node_id]["fields"].items():
                 fieldidx = get_key_idx_from_list(field_id, nodeDataArray[idx]["fields"])
                 field = nodeDataArray[idx]["fields"][fieldidx]
                 prev_value = field["value"]
-                field["value"] =  config_field["value"]
+                field["value"] =  cfg_field["value"]
                 field_name = field["name"]
                 LOGGER.info("Updating: Node %s, Field %s, from %s to %s",
                             node_name, field_name, str(prev_value), str(field["value"]))
@@ -96,10 +97,10 @@ def is_config_invalid(logical_graph: dict) -> bool:
     :return: True if the config has correct keys and they are present. 
     """
 
-    checkActiveId = logical_graph.get(ACTIVE_CONFIG_KEY, None)
+    checkActiveId = logical_graph.get(ACTIVE_CONFIG_KEY)
     if not checkActiveId:
         LOGGER.warning("No %s data available in Logical Graph.", ACTIVE_CONFIG_KEY)
-    checkGraphConfig = logical_graph.get(CONFIG_KEY, None)    
+    checkGraphConfig = logical_graph.get(CONFIG_KEY)    
     if not checkGraphConfig:
         LOGGER.warning("No %s data available in Logical Graph.", CONFIG_KEY)
 

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -53,8 +53,9 @@ from dlg.dropmake.dm_utils import (
     GInvalidNode,
     load_lg,
 )
-from .definition_classes import Categories
-from .lg_node import LGNode
+from dlg.dropmake.definition_classes import Categories
+from dlg.dropmake.lg_node import LGNode
+from dlg.dropmake.graph_config import apply_active_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,8 @@ class LG:
         logger.info("Loading graph: %s", lg["modelData"]["filePath"])
         logger.info("Found LG version: %s", lgver)
 
+        lg = apply_active_configuration(lg)
+
         if LG_VER_EAGLE == lgver:
             lg = convert_mkn(lg)
             lg = convert_fields(lg)
@@ -101,6 +104,7 @@ class LG:
             raise GraphException(
                 "Logical graph version '{0}' not supported!".format(lgver)
             )
+
         self._done_dict = {}
         self._group_q = collections.defaultdict(list)
         self._output_q = collections.defaultdict(list)

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -68,7 +68,7 @@ class LG:
     it is doing all the conversion inside __init__
     """
 
-    def __init__(self, f, ssid=None):
+    def __init__(self, f, ssid=None, apply_config=True):
         """
         parse JSON into LG object graph first
         """
@@ -88,7 +88,8 @@ class LG:
         logger.info("Loading graph: %s", lg["modelData"]["filePath"])
         logger.info("Found LG version: %s", lgver)
 
-        lg = apply_active_configuration(lg)
+        if apply_config:
+            lg = apply_active_configuration(lg)
 
         if LG_VER_EAGLE == lgver:
             lg = convert_mkn(lg)

--- a/daliuge-translator/test/dropmake/test_graph_config.py
+++ b/daliuge-translator/test/dropmake/test_graph_config.py
@@ -27,7 +27,7 @@ import daliuge_tests.dropmake as test_graphs
 
 try:
     from importlib.resources import files, as_file
-except (ImportError, ModuleNotFoundError):
+except ModuleNotFoundError:
     from importlib_resources import files
 
 LOG_PRFIX = "WARNING:dlg.dropmake.graph_config:"
@@ -66,7 +66,7 @@ class TestGraphConfig(unittest.TestCase):
             - Keys from the activeGraphConfigId or graphConfigurations are not found in 
             the logical graph. 
         """ 
-        lg = get_lg_from_fname(f"ArrayLoopNoActiveID.graph")
+        lg = get_lg_from_fname("ArrayLoopNoActiveID.graph")
         with self.assertLogs('root', level="WARNING") as cm:
             alt_lg = apply_active_configuration(lg)
         self.assertEqual(

--- a/daliuge-translator/test/dropmake/test_graph_config.py
+++ b/daliuge-translator/test/dropmake/test_graph_config.py
@@ -25,12 +25,20 @@ import unittest
 from dlg.dropmake.graph_config import apply_active_configuration, get_key_idx_from_list
 import daliuge_tests.dropmake as test_graphs
 
+try:
+    from importlib.resources import files, as_file
+except (ImportError, ModuleNotFoundError):
+    from importlib_resources import files
 
-def get_graphconfig_fname(lg_name: str):
+LOG_PRFIX = "WARNING:dlg.dropmake.graph_config:"
+
+def get_lg_from_fname(lg_name: str) -> dict:
     """
-    Return the graph_config from the test repository 
+    Return the logical graph from the graph_config files in the test graph repository 
     """
-    return str(files(test_graphs) / f"graph_config/{lg_name}")
+    fname = str(files(test_graphs) / f"graph_config/{lg_name}")
+    with open(fname, "r") as fp:
+            return json.load(fp)
 
 def get_value_from_lgnode_field(node_id: str, field_id: str, logical_graph: dict) -> str:
     """
@@ -42,21 +50,65 @@ def get_value_from_lgnode_field(node_id: str, field_id: str, logical_graph: dict
     field_idx = get_key_idx_from_list(field_id, logical_graph["nodeDataArray"][idx]["fields"])
     return logical_graph["nodeDataArray"][idx]["fields"][field_idx]["value"]
 
+
 class TestGraphConfig(unittest.TestCase):
     """
     """
 
-    def test_apply_with_no_config(self):
-        pass
+    def test_apply_with_empty_config(self):
+        """
+        Exhaust the following possibilities that may exist when attempting to 
+        apply graph config:
+            - "activeGraphConfigId" is not in graph
+            - "activeGraphConfigId" is empty
+            - "graphConfigurations" is not in graph
+            - "graphConfigurations" is empty
+            - Keys from the activeGraphConfigId or graphConfigurations are not found in 
+            the logical graph. 
+        """ 
+        lg = get_lg_from_fname(f"ArrayLoopNoActiveID.graph")
+        with self.assertLogs('root', level="WARNING") as cm:
+            alt_lg = apply_active_configuration(lg)
+        self.assertEqual(
+            [f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
+            f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
+            cm.output
+        )
 
+        lg['activeGraphConfigId'] = ""
+        with self.assertLogs('root', level="WARNING") as cm:
+            alt_lg = apply_active_configuration(lg)
+        self.assertEqual(
+            [f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
+            f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
+            cm.output
+        )
+ 
+        lg['activeGraphConfigId'] = "temporaryString"
+
+        with self.assertLogs('root', level="WARNING") as cm:
+            alt_lg = apply_active_configuration(lg)
+        self.assertEqual(
+            [f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
+            cm.output
+        )
+
+        lg['graphConfigurations'] = {"key": "value"}
+
+        with self.assertLogs('root', level="WARNING") as cm:
+            alt_lg = apply_active_configuration(lg)
+            self.assertEqual(
+               [f"{LOG_PRFIX}Graph config key does not exist in logical graph. "
+                "Using base field values."],
+               cm.output
+            )
+ 
     def test_apply_with_loop(self):
         """
         ArrayLoopLoop.graph has a GraphConfig with modified "num_of_iter" field in the 
         "Loop" node (construct). 
         """
-        fname = get_graphconfig_fname("ArrayLoopLoop.graph")
-        with open(fname, "r") as fp:
-            lg = json.load(fp)
+        lg = get_lg_from_fname("ArrayLoopLoop.graph")
         node_id = "732df21b-f714-4d25-9773-b4169db270a0"
         field_id = "3d25fcc9-50bb-4bbc-9b19-2eceabc238f2"
         value = get_value_from_lgnode_field(node_id, field_id, lg)
@@ -66,17 +118,15 @@ class TestGraphConfig(unittest.TestCase):
         self.assertEqual(5, int(value))
 
     def test_apply_with_scatter(self):
-        fname = get_graphconfig_fname("ArrayLoopScatter.graph")
-        with open(fname, "r") as fp:
-            lg = json.load(fp)
-        node_id = "732df21b-f714-4d25-9773-b4169db270a0"
-        field_id = "5560c56a-10f3-4d42-a436-404816dddf5f"
+        """
+        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_copies" field in the 
+        "Scatter" node (construct). 
+        """
+        lg = get_lg_from_fname("ArrayLoopScatter.graph")
+        node_id = "5560c56a-10f3-4d42-a436-404816dddf5f"
+        field_id = "0057b318-2405-4b5b-ac59-06c0068f91b7"
         value = get_value_from_lgnode_field(node_id, field_id, lg)
         self.assertEqual(1, int(value))
         lg = apply_active_configuration(lg)
         value = get_value_from_lgnode_field(node_id, field_id, lg)
         self.assertEqual(5, int(value))
-
-class TestGraphUnrollWithconfig(unittest.TestCase):
-    """
-    """

--- a/daliuge-translator/test/dropmake/test_graph_config.py
+++ b/daliuge-translator/test/dropmake/test_graph_config.py
@@ -1,0 +1,82 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2015
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+import json
+import unittest
+from dlg.dropmake.graph_config import apply_active_configuration, get_key_idx_from_list
+import daliuge_tests.dropmake as test_graphs
+
+
+def get_graphconfig_fname(lg_name: str):
+    """
+    Return the graph_config from the test repository 
+    """
+    return str(files(test_graphs) / f"graph_config/{lg_name}")
+
+def get_value_from_lgnode_field(node_id: str, field_id: str, logical_graph: dict) -> str:
+    """
+    Helper function that retrieves the value of a specified field from a given node
+
+    Returns: str representation of the value
+    """
+    idx = get_key_idx_from_list(node_id, logical_graph["nodeDataArray"])
+    field_idx = get_key_idx_from_list(field_id, logical_graph["nodeDataArray"][idx]["fields"])
+    return logical_graph["nodeDataArray"][idx]["fields"][field_idx]["value"]
+
+class TestGraphConfig(unittest.TestCase):
+    """
+    """
+
+    def test_apply_with_no_config(self):
+        pass
+
+    def test_apply_with_loop(self):
+        """
+        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_iter" field in the 
+        "Loop" node (construct). 
+        """
+        fname = get_graphconfig_fname("ArrayLoopLoop.graph")
+        with open(fname, "r") as fp:
+            lg = json.load(fp)
+        node_id = "732df21b-f714-4d25-9773-b4169db270a0"
+        field_id = "3d25fcc9-50bb-4bbc-9b19-2eceabc238f2"
+        value = get_value_from_lgnode_field(node_id, field_id, lg)
+        self.assertEqual(1, int(value))
+        lg = apply_active_configuration(lg)
+        value = get_value_from_lgnode_field(node_id, field_id, lg)
+        self.assertEqual(5, int(value))
+
+    def test_apply_with_scatter(self):
+        fname = get_graphconfig_fname("ArrayLoopScatter.graph")
+        with open(fname, "r") as fp:
+            lg = json.load(fp)
+        node_id = "732df21b-f714-4d25-9773-b4169db270a0"
+        field_id = "5560c56a-10f3-4d42-a436-404816dddf5f"
+        value = get_value_from_lgnode_field(node_id, field_id, lg)
+        self.assertEqual(1, int(value))
+        lg = apply_active_configuration(lg)
+        value = get_value_from_lgnode_field(node_id, field_id, lg)
+        self.assertEqual(5, int(value))
+
+class TestGraphUnrollWithconfig(unittest.TestCase):
+    """
+    """


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

https://icrar.atlassian.net/browse/LIU-417

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [x] Feature (addition)
- ~[ ] Bug fix~
- [x] Refactor (change)
- ~[ ] Documentation~

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

When the translator is sent a LogicalGraphTemplate with an activeGraphConfig, we need a way of applying that config to the graph. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

We apply the GraphConfig prior to updating the logical graph constructs and extracting the input/output apps. This makes sure the value updates occur to the _construct_ nodes in the graph, not the application nodes in the graph. This is because it is from the Construct nodes that we are getting the 'unrolling' parameters. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [x] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- ~[ ] Documentation added~
    - This is not user-facing behaviour.

## Summary by Sourcery

Add support for applying GraphConfig to LogicalGraphTemplate in the translator, enabling configuration of graph constructs. Refactor the LG class to support configuration application during initialization and introduce unit tests to validate the new functionality.

New Features:
- Introduce the ability to apply GraphConfig to LogicalGraphTemplate in the translator, allowing configuration of graph constructs before updating logical graph constructs.

Enhancements:
- Refactor the LG class to include an optional parameter for applying configuration during initialization.

Tests:
- Add unit tests for the new GraphConfig functionality, covering scenarios with empty configurations, loops, and scatter nodes.