### PR TITLE
LIU-427: Add private key support for remote submission.

### DIFF
--- a/daliuge-engine/dlg/deploy/create_dlg_job.py
+++ b/daliuge-engine/dlg/deploy/create_dlg_job.py
@@ -636,6 +636,15 @@ def main():
         default=None,
     )
 
+    parser.add_option(
+        "--ssh_key",
+        dest="ssh_key",
+        type="string", 
+        action="store",
+        help="Path to ssh private key",
+        default=""
+    )
+
     (opts, _) = parser.parse_args(sys.argv)
     if opts.configs:
         print(f"Available facilities: {FACILITIES}")
@@ -734,6 +743,7 @@ def main():
             submit=opts.submit,
             remote=opts.remote,
             username=opts.username,
+            ssh_key=opts.ssh_key
         )
         client._visualise_graph = opts.visualise_graph
         client.submit_job()

--- a/daliuge-engine/dlg/deploy/create_dlg_job.py
+++ b/daliuge-engine/dlg/deploy/create_dlg_job.py
@@ -626,6 +626,7 @@ def main():
         help="Display the available configurations  and exit",
         default=False,
     )
+
     parser.add_option(
         "-U",
         "--username",
@@ -638,11 +639,9 @@ def main():
 
     parser.add_option(
         "--ssh_key",
-        dest="ssh_key",
-        type="string", 
         action="store",
         help="Path to ssh private key",
-        default=""
+        default=None
     )
 
     (opts, _) = parser.parse_args(sys.argv)

--- a/daliuge-engine/dlg/remote.py
+++ b/daliuge-engine/dlg/remote.py
@@ -103,10 +103,7 @@ def createClient(host, username=None, pkeyPath=None):
     client = SSHClient()
     client.set_missing_host_key_policy(AutoAddPolicy())
 
-    pkey = (
-        RSAKey.from_private_key_file(os.path.expanduser(pkeyPath)) if pkeyPath else None
-    )
-    client.connect(host, username=username, pkey=pkey)
+    client.connect(host, username=username, key_filename=pkeyPath)
     return client
 
 

--- a/daliuge-engine/dlg/remote.py
+++ b/daliuge-engine/dlg/remote.py
@@ -25,6 +25,7 @@ A module containing utility code for running remote commands over SSH.
 
 import logging
 import os
+import sys
 import time
 
 from paramiko.client import SSHClient, AutoAddPolicy
@@ -102,8 +103,13 @@ def createClient(host, username=None, pkeyPath=None):
     """
     client = SSHClient()
     client.set_missing_host_key_policy(AutoAddPolicy())
-
-    client.connect(host, username=username, key_filename=pkeyPath)
+    try:
+        client.connect(host, username=username, key_filename=pkeyPath)
+    except FileNotFoundError:
+        logger.warning(
+            "File '%s' was not found, cannot create remote connection", pkeyPath
+        )
+        sys.exit(1)
     return client
 
 


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [x] Feature (addition)

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

When we use Paramiko to make the connection to Slurm in the `SlurmClient` class, we do not pass a private-key to our `remote` utility functions. This means that Paramiko will attempt to find a private key file in the `~/.ssh` directory, and specifically named `id_rsa` (or similar). 

This is fine if using passwordless-SSH on Linux, but can cause issues if using an alternative SSH server/configuration, and on a different OS (e.g. macOS). 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have added an option to pass in an `ssh_key` via the command line and the `SlurmClient` class. This has the added bonus of adding the path of any private key file through a DALiuGE component (e.g. #299). 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - This is command-line functionality that does not have a test harness set up, and also requires setting up something to SSH to as part of the unit tests. That's not impossible, but way outside the scope of this work. 
- ~[ ] Documentation added~
    - I will add documentation to the new Slurm client docs currently being reviewed in #297. 

## Summary by Sourcery

New Features:
- Add support for specifying an SSH private key for remote submissions in the Slurm client.

## Summary by Sourcery

New Features:
- Add support for specifying an SSH private key for remote submissions in the Slurm client.