### PR TITLE
LIU-392: Enable per-port serailisation 

### DIFF
--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -87,7 +87,7 @@ class dropdict(dict):
     def _addSomething(self, other, key, name=None):
         if key not in self:
             self[key] = []
-            # TODO: self[key] = {}
+            # TODO: self[key] = {}; we want to move to dictionaries, not lists
         if other["oid"] not in self[key]:
             # TODO: Returning just the other drop OID instead of the named
             #       port list is not a good solution. Required for the dask

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -87,12 +87,14 @@ class dropdict(dict):
     def _addSomething(self, other, key, name=None):
         if key not in self:
             self[key] = []
+            # TODO: self[key] = {}
         if other["oid"] not in self[key]:
             # TODO: Returning just the other drop OID instead of the named
             #       port list is not a good solution. Required for the dask
             #       tests.
             append = {other["oid"]: name} if name else other["oid"]
             # if name is None:
+            # TODO: self[key][other['oid']: name]
             # raise ValueError
             self[key].append(append)
 
@@ -113,6 +115,32 @@ class dropdict(dict):
 
     def addProducer(self, other, name=None):
         self._addSomething(other, "producers", name=name)
+
+    def _hasSomething(self, key, name):
+        """
+        self[key] => [{oidA: nameA}, {oidB:nameB}]
+
+        Need to translate to ["nameA", "nameB"] to determine if we have that element
+        """
+        if key not in self:
+            return False
+        ports = [] 
+        [ports.extend(pair.values()) for pair in self[key]]
+        return name in ports
+
+    def hasOutput(self, output):
+        """
+        self["outputs"] => [{"oidA": "portnameA"}, {"oidB":"portnameB"}]
+
+        Translate to ["portnameA", "portnameB"]
+        """
+        return self._hasSomething("outputs", output)
+
+    def hasProducer(self, producer):
+        """
+        See hasOutput. 
+        """
+        return self._hasSomething("producers", producer)
 
     def __ge__(self, other):
         return self.get("oid") >= other.get("oid")

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -688,21 +688,6 @@ class PyFuncApp(BarrierAppDROP):
         # and written to its corresponding output
         self.write_results(result)
 
-    def check_outputs_match_results(self, result: tuple):
-        """
-        # TODO This may be removeable
-        """
-        if len(self.outputs) == 1:
-            result = [result]
-        else:
-            from dlg.droputils import listify
-            result = listify(result)
-            if len(result) != len(self.outputs):
-                raise RuntimeError(
-                    f"Number of PyFunc outputs ({len(self.outputs)})"
-                    f"does not match generated results ({len(self.results)})")
-            return result
-
     def _match_parser(self, output_drop):
         """
         Match the output parser to the appropriate drop

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -391,45 +391,41 @@ class PyFuncApp(BarrierAppDROP):
         """
         pargs = [] # positional arguments
         funcargs = {} # Function arguments
-        if "applicationArgs" in self.parameters:
-            appArgs = self.parameters["applicationArgs"]  # we'll pop the default ones
-            _dum = [appArgs.pop(k) for k in self.func_def_keywords if k in appArgs]
-            logger.debug(
-                "Default keyword arguments removed: %s",
-                [i for i in _dum],
-            )
-            # update the positional args
+        if self._applicationArgs:
+           # update the positional args
             pargsDict.update(
                 {k: self.parameters[k] for k in pargsDict if k in self.parameters}
             )
             # if defined in both we use AppArgs values
-            for arg in appArgs:
+            for arg in self._applicationArgs:
                 # check value type and interpret
-                if appArgs[arg]["type"] in ["Json", "Complex"]:
+                if self._applicationArgs[arg]["type"] in ["Json", "Complex"]:
                     try:
-                        value = ast.literal_eval(appArgs[arg]["value"])
-                        encoding = appArgs[arg]["encoding"] 
+                        value = ast.literal_eval(self._applicationArgs[arg]["value"])
+                        # TODO sanity check the encoding? 
+                        encoding = self._applicationArgs[arg]["encoding"] 
                         logger.debug(
                             f"Evaluated %s to %s",
-                            appArgs[arg]["value"],
+                            self._applicationArgs[arg]["value"],
                             type(value),
                         )
-                        appArgs[arg]["value"] = value
+                        self._applicationArgs[arg]["value"] = value
                     except ValueError:
-                        logger.error("Unable to evaluate %s", appArgs[arg]["value"])
+                        logger.error("Unable to evaluate %s", self._applicationArgs[arg]["value"])
                 else:
-                    value = appArgs[arg]["value"]
-                    encoding = appArgs[arg]["encoding"]
+                    value = self._applicationArgs[arg]["value"]
+                    encoding = self._applicationArgs[arg]["encoding"]
                 if arg in pargsDict:
                     pargsDict.update({arg:{"value":value, "encoding":encoding}})
 
-            _ = [appArgs.pop(k) for k in pargsDict if k in appArgs]
+            _ = [self._applicationArgs.pop(k) for k in pargsDict if k in self._applicationArgs]
             logger.debug("Updated posargs dictionary: %s", pargsDict)
 
+            # update the keyword arguments
             keyargsDict.update(
                 {
-                    k: {"value": appArgs[k]["value"], "encoding": appArgs[k]["encoding"]}
-                    for k in keyargsDict if k in appArgs
+                    k: {"value": self._applicationArgs[k]["value"], "encoding": self._applicationArgs[k]["encoding"]}
+                    for k in keyargsDict if k in self._applicationArgs
                 }
             )
             logger.debug("Updated keyargs dictionary: %s", keyargsDict)
@@ -438,13 +434,13 @@ class PyFuncApp(BarrierAppDROP):
             # TODO: This should only be done if the function signature allows it
             vparg = []
             vkarg = {}
-            logger.debug(f"Remaining AppArguments {appArgs}")
-            for arg in appArgs:
-                if appArgs[arg]["type"] in ["Json", "Complex"]:
-                    value = ast.literal_eval(appArgs[arg]["value"])
+            logger.debug(f"Remaining AppArguments {self._applicationArgs}")
+            for arg in self._applicationArgs:
+                if self._applicationArgs[arg]["type"] in ["Json", "Complex"]:
+                    value = ast.literal_eval(self._applicationArgs[arg]["value"])
                 else:
-                    value = appArgs[arg]["value"]
-                if appArgs[arg]["positional"]:
+                    value = self._applicationArgs[arg]["value"]
+                if self._applicationArgs[arg]["positional"]:
                     vparg.append(value)
                 else:
                     vkarg.update({arg: value})
@@ -458,21 +454,23 @@ class PyFuncApp(BarrierAppDROP):
                 logger.debug("Adding remaining **kwargs to funcargs: %s", vkarg)
                 funcargs.update(vkarg)
         else:
+            if self.input_parser:
+                encoding = self.input_parser
+            else:
+                encoding = "dill"
             pargsDict.update(
-                {k: {"value": pargsDict[k], "encoding": "pickle"} for k in pargsDict}
+                {k: {"value": pargsDict[k], "encoding": encoding} for k in pargsDict}
             )
-
-        tmpPargs = {port: subdict["value"] for port, subdict in pargsDict.items()}
+        # Extract arg and values from pargs; we no longer need the encoding 
+        tmpPargs = {arg: subdict["value"] for arg, subdict in pargsDict.items()}
+        logger.debug(f"Updating funcargs with values from pargsDict {pargsDict}")
         funcargs.update(tmpPargs)
+
         # Mixin the values from named ports
         portargs = self._ports2args(posargs, pargsDict, keyargsDict)
 
-        logger.debug(f"Updating funcargs with values from pargsDict {pargsDict}")
-        # Extract port and values from pargs; we no longer need the encoding 
-
         logger.debug(f"Updating funcargs with values from named ports {portargs}")
         tmpPortArgs = {port: subdict["value"] for port, subdict in portargs.items()}
-
         funcargs.update(tmpPortArgs)
 
         return [funcargs, pargs]
@@ -510,44 +508,6 @@ class PyFuncApp(BarrierAppDROP):
                     mode="inputs",
                     addPositionalToKeyword=True,
                     parser=get_port_reader_function(self.input_parser)
-                )
-            )
-        else:
-            check_len = min(
-                len(iitems),
-                self.fn_nargs + self.fn_nkw,
-            )
-
-            iitem_keys = list(iitems.keys())
-            for i in range(min(len(iitems), self.fn_nargs)):
-                key = iitem_keys[i]
-                all_contents = get_port_reader_function(self.input_parser)
-                portargs.update({self.argnames[i]: all_contents(iitems[key])})
-
-        # 4. replace default argument values with named output ports
-        if "outputs" in self.parameters and check_ports_dict(
-            self.parameters["outputs"]
-        ):
-            # TODO remove output processing
-            check_len = min(len(oitems), self.fn_nargs + self.fn_nkw)
-            outputs_dict = collections.OrderedDict()
-            for outport in self.parameters["outputs"]:
-                key = list(outport.keys())[0]
-                outputs_dict[key] = {
-                    "name": oitems[key], 
-                    "path": oitems[key].path if 'path' in oitems else None, 
-                    "drop": oitems[key]
-                }
-
-            portargs.update(
-                identify_named_ports(
-                    outputs_dict,
-                    posargs,
-                    pargsDict,
-                    keyargsDict,
-                    check_len=check_len,
-                    mode="outputs",
-                    addPositionalToKeyword=True,
                 )
             )
         return portargs
@@ -735,28 +695,51 @@ class PyFuncApp(BarrierAppDROP):
                     f"does not match generated results ({len(self.results)})")
             return result
 
-    def _match_parser(output_drop):
+    def _match_parser(self, output_drop):
         """
         Match the output parser to the appropriate drop
         """
+        
+        encoding = None
+        component_params = self.parameters.get("componentParams")
+        if not component_params:
+            return self.output_parser
+        if "outputs" in self.parameters and check_ports_dict(self.parameters["outputs"]):
+            for outport in self.parameters["outputs"]:
+                drop_uid, drop_port  = list(outport.items())[0]
+                if drop_uid == output_drop.uid:
+                    encoding = component_params[drop_port]["encoding"]
+        if encoding:
+            return DropParser(encoding)
+        else:
+            return self.output_parser
 
     def write_results(self, result):
 
         if not self.outputs:
             return
-
         for o in self.outputs:
-            if self.output_parser is DropParser.PICKLE:
+            parser = self._match_parser(o)
+            if parser is DropParser.PICKLE:
                 logger.debug(f"Writing pickeled result {type(result)} to {o}")
                 o.write(pickle.dumps(result))
-            elif self.output_parser is DropParser.EVAL:
-                o.write(repr(result).encode("utf-8"))
-            elif self.output_parser is DropParser.NPY:
+            elif parser is DropParser.EVAL or parser is DropParser.UTF8:
+                encoded_result = repr(result).encode("utf-8")
+                o.write(encoded_result)
+            elif parser is DropParser.NPY:
+                import numpy as np
+                if not isinstance(result, np.ndarray):
+                    try: 
+                        result = np.array(result)
+                    except Exception as e:
+                        raise(e)
                 drop_loaders.save_npy(o, result)
-            elif self.output_parser is DropParser.RAW:
+            elif parser is DropParser.RAW:
                 o.write(result)
-            elif self.output_parser is DropParser.DILL:
-                o.write(pickle.dumps(result))
+            elif parser is DropParser.DILL:
+                o.write(dill.dumps(result))
+            elif parser is DropParser.BINARY:
+                drop_loaders.save_binary(o, result)
             else:
                 ValueError(self.output_parser.__repr__())
 

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -416,7 +416,7 @@ class PyFuncApp(BarrierAppDROP):
                     value = self._applicationArgs[arg]["value"]
                     encoding = self._applicationArgs[arg].get("encoding", "pickle")
                 if arg in pargsDict:
-                    pargsDict.update({arg:{"value":value, "encoding":encoding}})
+                    pargsDict[arg] = {"value":value, "encoding":encoding}
             
             _ = [self._applicationArgs.pop(k) for k in pargsDict if k in self._applicationArgs]
             logger.debug("Updated posargs dictionary: %s", pargsDict)
@@ -443,7 +443,7 @@ class PyFuncApp(BarrierAppDROP):
                 if self._applicationArgs[arg]["positional"]:
                     vparg.append(value)
                 else:
-                    vkarg.update({arg: value})
+                    vkarg[arg] = value
 
             # TODO: check where this is defined in signature
             self.arguments = inspect.getfullargspec(self.func)
@@ -693,19 +693,16 @@ class PyFuncApp(BarrierAppDROP):
         Match the output parser to the appropriate drop
         """
         
-        encoding = None
+        encoding = None # TODO: When we remove the output_parser, transition this to dill
         component_params = self.parameters.get("componentParams")
         if not component_params:
             return self.output_parser
         if "outputs" in self.parameters and check_ports_dict(self.parameters["outputs"]):
             for outport in self.parameters["outputs"]:
                 drop_uid, drop_port  = list(outport.items())[0]
-                if drop_uid == output_drop.uid:
+                if drop_uid == output_drop.uid and drop_port in component_params:
                     encoding = component_params[drop_port]["encoding"]
-        if encoding:
-            return DropParser(encoding)
-        else:
-            return self.output_parser
+        return DropParser(encoding) if encoding else self.output_parser
 
     def write_results(self, result):
         from dlg.droputils import listify

--- a/daliuge-engine/dlg/apps/simple_functions.py
+++ b/daliuge-engine/dlg/apps/simple_functions.py
@@ -64,6 +64,19 @@ def createMultiOut(v1: Any = 1, v2: Any = 7) -> tuple:
     out2 = v2
     return out1, out2
 
+def getMax(v1: float=1.0, v2: float=7.0) -> float:
+    """
+    Return the largest float of two different values. 
+
+    Inputs: 
+        v1: value 1
+        v2: value 2 
+
+    Returns:
+        max(v1, v2)
+    """    
+    return max(v1, v2)
+
 
 def string2json(string: str, pickle_flag: bool = False) -> list:
     """

--- a/daliuge-engine/dlg/drop_loaders.py
+++ b/daliuge-engine/dlg/drop_loaders.py
@@ -122,13 +122,15 @@ def load_binary(drop: "DataDROP"):
    """
    buf = io.BytesIO()
    desc = drop.open()
-   while True:
+   read = True
+   while read:
        data = drop.read(desc)
-       if not data: 
-           break
-       buf.write(data)
-       drop.close(desc)
-       return buf.getvalue().decode()
+       if data: 
+           buf.write(data)
+           drop.close(desc)
+           return buf.getvalue().decode()
+        
+       return 0
 
 def save_binary(drop: "DataDROP", data: bytes):
     """

--- a/daliuge-engine/dlg/drop_loaders.py
+++ b/daliuge-engine/dlg/drop_loaders.py
@@ -128,11 +128,11 @@ def load_binary(drop: "DataDROP"):
            break
        buf.write(data)
        drop.close(desc)
-       return buf.getvalue()
+       return buf.getvalue().decode()
 
 def save_binary(drop: "DataDROP", data: bytes):
     """
-    Load binary 
+    Save binary 
     """
     bytes_data = io.BytesIO(data)
     dropio = drop.getIO()

--- a/daliuge-engine/dlg/drop_loaders.py
+++ b/daliuge-engine/dlg/drop_loaders.py
@@ -99,3 +99,20 @@ def load_npy(drop: "DataDROP", allow_pickle=False) -> np.ndarray:
 
 def load_numpy(drop: "DataDROP", allow_pickle=True):
     return load_npy(drop, allow_pickle=allow_pickle)
+
+
+import dill
+def load_dill(drop: "DataDROP"):
+    """
+    Load dill
+    """
+    buf = io.BytesIO()
+    desc = drop.open()
+    while True:
+        data = drop.read(desc)
+        if not data:
+            break
+        buf.write(data)
+    drop.close(desc)
+    return dill.loads(buf.getbuffer())
+

--- a/daliuge-engine/dlg/drop_loaders.py
+++ b/daliuge-engine/dlg/drop_loaders.py
@@ -116,3 +116,26 @@ def load_dill(drop: "DataDROP"):
     drop.close(desc)
     return dill.loads(buf.getbuffer())
 
+def load_binary(drop: "DataDROP"): 
+   """
+   Load binary 
+   """
+   buf = io.BytesIO()
+   desc = drop.open()
+   while True:
+       data = drop.read(desc)
+       if not data: 
+           break
+       buf.write(data)
+       drop.close(desc)
+       return buf.getvalue()
+
+def save_binary(drop: "DataDROP", data: bytes):
+    """
+    Load binary 
+    """
+    bytes_data = io.BytesIO(data)
+    dropio = drop.getIO()
+    dropio.open(OpenMode.OPEN_WRITE)
+    dropio.write(bytes_data)
+    dropio.close()

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -27,8 +27,8 @@ full JSON representation.
 import collections
 import importlib
 import logging
+from typing import List, Optional
 
-from typing import List
 from dlg.common.reproducibility.constants import ReproducibilityFlags
 
 from . import droputils
@@ -39,6 +39,7 @@ from .drop import (
     LINKTYPE_NTO1_PROPERTY,
     LINKTYPE_1TON_APPEND_METHOD,
 )
+
 from .data.drops.data_base import NullDROP
 from .data.drops.container import ContainerDROP
 
@@ -245,7 +246,9 @@ def loadDropSpecs(dropSpecList):
     return dropSpecs, reprodata
 
 
-def createGraphFromDropSpecList(dropSpecList, session=None, ret_drops=False):
+def createGraphFromDropSpecList(dropSpecList: List[dict],
+                                session: Optional["Session"]=None
+                                ) -> List[AbstractDROP]:
     logger.debug("Found %d DROP definitions", len(dropSpecList))
 
     # Step #1: create the actual DROPs
@@ -317,8 +320,6 @@ def createGraphFromDropSpecList(dropSpecList, session=None, ret_drops=False):
         drop for drop in drops.values() if not droputils.getUpstreamObjects(drop)
     ]
     logger.info("%d graph roots found, bye-bye!", len(roots))
-    if ret_drops:
-        return roots, drops
     return roots
 
 

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -245,7 +245,7 @@ def loadDropSpecs(dropSpecList):
     return dropSpecs, reprodata
 
 
-def createGraphFromDropSpecList(dropSpecList, session=None):
+def createGraphFromDropSpecList(dropSpecList, session=None, ret_drops=False):
     logger.debug("Found %d DROP definitions", len(dropSpecList))
 
     # Step #1: create the actual DROPs
@@ -317,7 +317,8 @@ def createGraphFromDropSpecList(dropSpecList, session=None):
         drop for drop in drops.values() if not droputils.getUpstreamObjects(drop)
     ]
     logger.info("%d graph roots found, bye-bye!", len(roots))
-
+    if ret_drops:
+        return roots, drops
     return roots
 
 

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -255,8 +255,6 @@ def replace_named_ports(
     # we will need an ordered dict for all positional arguments
     # thus we create it here and fill it with values
     positionalPortArgs = collections.OrderedDict(positionalArgs)
-    #       zip(positionalArgs, [None] * len(positionalArgs))
-    # )
 
     logger.debug(
         "posargs: %s; keyargs: %s, %s",

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -163,6 +163,7 @@ def identify_named_ports(
                 value = parser(port_dict[keys[i]]["drop"])
             # if not found in appArgs we don't put them into portargs either
             # pargsDict.update({key: value})
+            keywordArgs[key]["value"] = value
             keywordPortArgs.update({key: keywordArgs[key]})
             logger.debug("Using %s of type %s for kwarg %s", mode, type(value), key)
             _ = keywordArgs.pop(key)  # remove from original arg list
@@ -301,7 +302,8 @@ def replace_named_ports(
     appArgs = {arg: subdict['value'] for arg, subdict in appArgs.items()}
     positionalArgs = {arg: subdict['value'] for arg, subdict in positionalArgs.items()}
     keywordArgs = {arg: subdict['value'] for arg, subdict in keywordArgs.items()}
-
+    keywordPortArgs = {arg: subdict['value'] for arg, subdict in keywordPortArgs.items()}
+ 
      # Construct the final keywordArguments and positionalPortArguments
     for k, v in keywordPortArgs.items():
         if v not in [None, ""]:
@@ -375,7 +377,7 @@ def _get_args(appArgs, positional=False):
     """
     args = {
         arg: {"value": appArgs[arg]["value"], 
-              "encoding": appArgs.get("encoding", "dill")}
+              "encoding": appArgs[arg].get("encoding", "dill")}
         for arg in appArgs
         if (appArgs[arg]["positional"] == positional)
     }

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -12,13 +12,14 @@ logger = logging.getLogger(__name__)
 class DropParser(Enum):
     RAW = "raw"
     PICKLE = "pickle"
-    EVAL = "eval"
+    EVAL = "eval" 
     NPY = "npy"
     DILL = "dill"
     # JSON = "json"
     PATH = "path"  # input only
     DATAURL = "dataurl"  # input only
     BINARY = "binary"
+    UTF8 = "utf-8"
 
 
 def serialize_kwargs(keyargs, prefix="--", separator=" "):
@@ -378,7 +379,6 @@ def _get_args(appArgs, positional=False):
     logger.debug("%s arguments: %s", argType, args)
     return args
 
-
 def get_port_reader_function(input_parser: DropParser):
     """
     Return the function used to read input from a named port
@@ -388,7 +388,7 @@ def get_port_reader_function(input_parser: DropParser):
     if input_parser is DropParser.PICKLE:
         # all_contents = lambda x: pickle.loads(droputils.allDropContents(x))
         reader = drop_loaders.load_pickle
-    elif input_parser is DropParser.EVAL:
+    elif input_parser is DropParser.EVAL or input_parser is DropParser.UTF8:
 
         def optionalEval(x):
             # Null and Empty Drops will return an empty byte string
@@ -406,7 +406,7 @@ def get_port_reader_function(input_parser: DropParser):
     elif input_parser is DropParser.DILL:
         reader = drop_loaders.load_dill
     elif input_parser is DropParser.BINARY:
-         reader = drop_loaders.load_dill
+         reader = drop_loaders.load_binary
     else:
         raise ValueError(input_parser.__repr__())
     return reader

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -133,14 +133,14 @@ def identify_named_ports(
     keywordPortArgs = {}
     positionalArgs = list(positionalArgs)
     keys = list(port_dict.keys())
-    logger.debug("Checking ports: %sagainst %s %s", keys, positionalArgs, keywordArgs)
+    logger.debug("Checking ports: %s against %s %s", keys, positionalArgs, keywordArgs)
     for i in range(check_len):
         try:
             key = port_dict[keys[i]]["name"]
             value = port_dict[keys[i]]["path"]
-        except KeyError:
-            logger.debug("portDict: %s", port_dict)
-            raise KeyError
+        except KeyError as e:
+            logger.debug("portDict: %s does not have key: %s", port_dict, keys[i])
+            raise KeyError("")
         if value is None:
             value = ""  # make sure we are passing NULL drop events
         if key in positionalArgs:

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -299,7 +299,12 @@ def replace_named_ports(
     positionalArgs = _get_args(appArgs, positional=True)
     keywordArgs = _get_args(appArgs, positional=False)
 
-    # Construct the final keywordArguments and positionalPortArguments
+    # Extract values from dictionaries - "encoding" etc. are irrelevant
+    appArgs = {arg: subdict['value'] for arg, subdict in appArgs.items()}
+    positionalArgs = {arg: subdict['value'] for arg, subdict in positionalArgs.items()}
+    keywordArgs = {arg: subdict['value'] for arg, subdict in keywordArgs.items()}
+
+     # Construct the final keywordArguments and positionalPortArguments
     for k, v in keywordPortArgs.items():
         if v not in [None, ""]:
             keywordArgs.update({k: v})

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -254,9 +254,9 @@ def replace_named_ports(
     keywordArgs = _get_args(appArgs, positional=False)
     # we will need an ordered dict for all positional arguments
     # thus we create it here and fill it with values
-    positionalPortArgs = collections.OrderedDict(
-        zip(positionalArgs, [None] * len(positionalArgs))
-    )
+    positionalPortArgs = collections.OrderedDict(positionalArgs)
+    #       zip(positionalArgs, [None] * len(positionalArgs))
+    # )
 
     logger.debug(
         "posargs: %s; keyargs: %s, %s",
@@ -371,7 +371,8 @@ def _get_args(appArgs, positional=False):
     Separate out the arguments dependening on if we want positional or keyword style
     """
     args = {
-        arg: appArgs[arg]["value"]
+        arg: {"value": appArgs[arg]["value"], 
+              "encoding": appArgs.get("encoding", "dill")}
         for arg in appArgs
         if (appArgs[arg]["positional"] == positional)
     }

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -191,6 +191,7 @@ def check_ports_dict(ports: list) -> bool:
         bool: True if all ports are dict, else False
     """
     # all returns true if list is empty!
+    logger.debug("Ports list is: %s", ports)
     if len(ports) > 0:
         return all(isinstance(p, dict) for p in ports)
     else:

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -169,7 +169,7 @@ extra_requires = {
     "aws": ["boto3"],
     "test": [
         "pytest",
-        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo",
+        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-392",
     ],
 }
 

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -169,7 +169,7 @@ extra_requires = {
     "aws": ["boto3"],
     "test": [
         "pytest",
-        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-392",
+        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo",
     ],
 }
 

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -135,7 +135,8 @@ class TestPyFuncApp(unittest.TestCase):
 
     def test_pickle_func(self, f=lambda x: x, input_data="hello", output_data="hello"):
         a = InMemoryDROP("a", "a")
-        b = _PyFuncApp("b", "b", f)
+        kwargs = {a.uid: 'x'}
+        b = _PyFuncApp("b", "b", f, **kwargs)
         c = InMemoryDROP("c", "c")
 
         b.addInput(a)
@@ -151,14 +152,15 @@ class TestPyFuncApp(unittest.TestCase):
     def test_eval_func(self, f=lambda x: x, input_data=None, output_data=None):
         input_data = [2, 2] if input_data is None else input_data
         output_data = [2, 2] if output_data is None else output_data
-
         a = InMemoryDROP("a", "a")
+        kwargs = {a.uid: 'x'}
         b = _PyFuncApp(
             "b",
             "b",
             f,
             input_parser=DropParser.EVAL,
             output_parser=DropParser.EVAL,
+            **kwargs
         )
         c = InMemoryDROP("c", "c")
 
@@ -178,19 +180,21 @@ class TestPyFuncApp(unittest.TestCase):
     def test_string2json_func(self, f=string2json, input_data=None, output_data=None):
         input_data = '["a", "b", "c"]' if input_data is None else input_data
         output_data = ["a", "b", "c"] if output_data is None else output_data
-
+ 
         a = InMemoryDROP("a", "a")
+        kwargs = {a.uid: 'string'}
         b = _PyFuncApp(
             "b",
             "b",
             f,
+            **kwargs
         )
         c = InMemoryDROP("c", "c")
 
         b.addInput(a)
         b.addOutput(c)
 
-        with DROPWaiterCtx(self, c, 5):
+        with DROPWaiterCtx(self, c, 120):
             drop_loaders.save_pickle(a, input_data)
             a.setCompleted()
         for drop in a, b, c:
@@ -202,12 +206,14 @@ class TestPyFuncApp(unittest.TestCase):
         output_data = numpy.ones([2, 2]) if output_data is None else output_data
 
         a = InMemoryDROP("a", "a")
+        kwargs = {a.uid: 'x'}
         b = _PyFuncApp(
             "b",
             "b",
             f,
             input_parser=DropParser.NPY,
             output_parser=DropParser.NPY,
+            **kwargs
         )
         c = InMemoryDROP("c", "c")
 
@@ -221,9 +227,10 @@ class TestPyFuncApp(unittest.TestCase):
             self.assertEqual(DROPStates.COMPLETED, drop.status)
         numpy.testing.assert_equal(output_data, drop_loaders.load_npy(c))
 
-    def _test_simple_functions(self, f, input_data, output_data):
+    def _test_simple_functions(self, f, input_data, output_data, argname):
         a, c = [InMemoryDROP(x, x) for x in ("a", "c")]
-        b = _PyFuncApp("b", "b", f)
+        kwargs = {a.uid:argname}
+        b = _PyFuncApp("b", "b", f, **kwargs)
         b.addInput(a)
         b.addOutput(c)
 
@@ -238,12 +245,12 @@ class TestPyFuncApp(unittest.TestCase):
     def test_func1(self):
         """Checks that func1 in this module works when wrapped"""
         data = os.urandom(64)
-        self._test_simple_functions("func1", data, data)
+        self._test_simple_functions("func1", data, data, argname="arg1")
 
     def test_func2(self):
         """Checks that func2 in this module works when wrapped"""
         n = random.randint(0, 1_000_000)
-        self._test_simple_functions("func2", n, 2 * n)
+        self._test_simple_functions("func2", n, 2 * n, argname="arg1")
 
     def test_inner_func(self):
         n = random.randint(0, 1_000_000)
@@ -251,11 +258,11 @@ class TestPyFuncApp(unittest.TestCase):
         def f(x):
             return x + 2
 
-        self._test_simple_functions(f, n, n + 2)
+        self._test_simple_functions(f, n, n + 2, argname="x")
 
     def test_lambda(self):
         n = random.randint(0, 1_000_000)
-        self._test_simple_functions(lambda x: x / 2, n, n / 2)
+        self._test_simple_functions(lambda x: x / 2, n, n / 2, argname="x")
 
     def test_inner_func_with_closure(self):
         n = random.randint(0, 1_000_000)
@@ -263,11 +270,11 @@ class TestPyFuncApp(unittest.TestCase):
         def f(x):
             return x + n
 
-        self._test_simple_functions(f, n, n + n)
+        self._test_simple_functions(f, n, n + n, argname="x")
 
     def test_lambda_with_closure(self):
         n = random.randint(0, 1_000_000)
-        self._test_simple_functions(lambda x: (x + n) / 2, n, (n + n) / 2)
+        self._test_simple_functions(lambda x: (x + n) / 2, n, (n + n) / 2, argname="x")
 
     def _test_func3(self, output_drops, expected_outputs):
         a = _PyFuncApp("a", "a", "func3")
@@ -298,7 +305,7 @@ class TestPyFuncApp(unittest.TestCase):
         with multiple outputs.
         """
         output_drops = [InMemoryDROP(x, x) for x in ("b", "c", "d")]
-        self._test_func3(output_drops, ("b", "c", "d"))
+        self._test_func3(output_drops, [["b", "c", "d"]])
 
     def _test_defaults(self, expected_out, *args, **kwargs):
         def _do_test(func, expected_out, *args, **kwargs):
@@ -465,6 +472,11 @@ class PyFuncAppIntraNMTest(NMTestsMixIn, unittest.TestCase):
                 "categoryType": "Application",
                 "dropclass": "dlg.apps.pyfunc.PyFuncApp",
                 "func_name": __name__ + ".func1",
+                "inputs": [
+                    {
+                        "A": "arg1"
+                    },
+                ]
             },
             {
                 "oid": "C",
@@ -500,7 +512,12 @@ class PyFuncAppIntraNMTest(NMTestsMixIn, unittest.TestCase):
                 "categoryType": "Application",
                 "dropclass": "dlg.apps.pyfunc.PyFuncApp",
                 "func_name": __name__ + ".func1",
-            },
+                "inputs": [
+                    {
+                        "A": "arg1"
+                    },
+                ]
+            }
         ]
         g2 = [
             {

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -78,6 +78,7 @@ def _PyFuncApp(oid, uid, f, **kwargs):
     input_kws = [
         {k: v} for k, v in kwargs.items() if k not in ["input_parser", "output_parser"]
     ]
+
     fcode, fdefaults = pyfunc.serialize_func(f)
     return pyfunc.PyFuncApp(
         oid,
@@ -234,7 +235,7 @@ class TestPyFuncApp(unittest.TestCase):
         b.addInput(a)
         b.addOutput(c)
 
-        with DROPWaiterCtx(self, c, 5):
+        with DROPWaiterCtx(self, c, 50):
             a.write(pickle.dumps(input_data))
             a.setCompleted()
 
@@ -305,7 +306,7 @@ class TestPyFuncApp(unittest.TestCase):
         with multiple outputs.
         """
         output_drops = [InMemoryDROP(x, x) for x in ("b", "c", "d")]
-        self._test_func3(output_drops, [["b", "c", "d"]])
+        self._test_func3(output_drops, ["b", "c", "d"])
 
     def _test_defaults(self, expected_out, *args, **kwargs):
         def _do_test(func, expected_out, *args, **kwargs):

--- a/daliuge-engine/test/manager/test_daemon.py
+++ b/daliuge-engine/test/manager/test_daemon.py
@@ -143,7 +143,7 @@ class TestDaemon(unittest.TestCase):
         # if we query the MM it should know about its nodes, which should have
         # one element
         mc = MasterManagerClient()
-        nodes = _get_nodes_from_client(mc)
+        nodes = _get_nodes_from_client(mc)["nodes"]
         self.assertIsNotNone(nodes)
         self.assertEqual(
             1,

--- a/daliuge-engine/test/test_dask_emulation.py
+++ b/daliuge-engine/test/test_dask_emulation.py
@@ -145,17 +145,8 @@ class _TestDelayed(object):
         delayed = self.delayed
         compute = self.compute
 
-        one, two, three, four = (
-            delayed(1.0),
-            delayed(2.0),
-            delayed(3.0),
-            delayed(4.0),
-        )
-        # TODO make sure that we accept lists as specific input
-        # I Think the *args expander is not working appropriately here when we use it in 
-        # The appDrop method. 
-        the_sum = delayed(add_list)([one, two])
-        the_sub = delayed(subtract_list)([four, three])
+        the_sum = delayed(add_list)([1.0, 2.0])
+        the_sub = delayed(subtract_list)([4.0, 3.0])
         division = delayed(divide)(the_sum, the_sub)
         parts = delayed(partition, nout=2)(division)
         x, y = parts
@@ -167,13 +158,10 @@ class _TestDelayed(object):
         delayed = self.delayed
         compute = self.compute
 
-        one, two, three, four = (
-            delayed(1.0),
-            delayed(2.0),
-            delayed(3.0),
-            delayed(4.0),
-        )
-        doubles = [delayed(lambda i: i * 2)(x) for x in (one, two, three, four)]
+        def double(x):
+            return x*2
+    
+        doubles = [delayed(double)(x) for x in (1.0, 2.0, 3.0, 4.0)]
         result = compute(doubles)
         self.assertEqual([2.0, 4.0, 6.0, 8.0], result)
 

--- a/daliuge-engine/test/test_dask_emulation.py
+++ b/daliuge-engine/test/test_dask_emulation.py
@@ -44,6 +44,7 @@ except ImportError:
 
 
 def add(x, y):
+    logger.debug(f"{repr(x)}")
     return x + y
 
 
@@ -51,11 +52,12 @@ def add_list(numbers):
     return functools.reduce(add, numbers)
 
 
-def subtract(x, y):
+def subtract(x: float, y: float):
+    logger.debug(f"{repr(x)}")
     return x - y
 
 
-def subtract_list(numbers):
+def subtract_list(numbers: list):
     return functools.reduce(subtract, numbers)
 
 
@@ -129,7 +131,7 @@ class _TestDelayed(object):
         """
         delayed = self.delayed
         compute = self.compute
-
+        
         the_sum = delayed(add)(1.0, 2.0)
         the_sub = delayed(subtract)(4.0, 3.0)
         division = delayed(divide)(the_sum, the_sub)
@@ -149,11 +151,15 @@ class _TestDelayed(object):
             delayed(3.0),
             delayed(4.0),
         )
+        # TODO make sure that we accept lists as specific input
+        # I Think the *args expander is not working appropriately here when we use it in 
+        # The appDrop method. 
         the_sum = delayed(add_list)([one, two])
         the_sub = delayed(subtract_list)([four, three])
         division = delayed(divide)(the_sum, the_sub)
         parts = delayed(partition, nout=2)(division)
-        result = compute(delayed(add)(*parts))
+        x, y = parts
+        result = compute(delayed(add)(x,y))
         self.assertEqual(3.0, result)
 
     def test_compute_with_lists(self):

--- a/daliuge-engine/test/test_dask_emulation.py
+++ b/daliuge-engine/test/test_dask_emulation.py
@@ -44,7 +44,6 @@ except ImportError:
 
 
 def add(x, y):
-    logger.debug(f"{repr(x)}")
     return x + y
 
 
@@ -53,7 +52,6 @@ def add_list(numbers):
 
 
 def subtract(x: float, y: float):
-    logger.debug(f"{repr(x)}")
     return x - y
 
 

--- a/daliuge-engine/test/test_drop_ports.py
+++ b/daliuge-engine/test/test_drop_ports.py
@@ -1,0 +1,78 @@
+#a
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2014
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+"""
+Unit/regression testing for the application of named_port_utils.py
+
+Use examples derived from the following DROP classes: 
+- pyfunc
+- s3_drop
+- bash_shell_app
+- dockerapp 
+- mpi
+"""
+import logging
+import unittest
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+import json
+import dlg.droputils as droputils
+
+import dlg.graph_loader as graph_loader
+
+from pathlib import Path
+from dlg.dropmake import path_utils
+
+from dlg.ddap_protocol import DROPStates
+
+from test.apps.test_pyfunc import func_with_defaults
+
+class TestPortsLoaded(unittest.TestCase):
+    """
+    Given a dropspec, make sure the ports are loaded correctly. 
+    """ 
+
+    def test_extract_attributes(self):
+        """
+        Given a drop, make sure the attributes are accurately loaded.
+
+        Rules for applicationArgs: 
+            - If it is an applicationArgument and it has a port value, we don't
+              set this as a param
+
+        """
+        spec = Path(path_utils.get_lg_fpath("drop_spec", "test_ports.graph"))
+        with Path(spec).open('r') as f: 
+            appDropSpec = json.load(f)
+        
+        roots, drops = graph_loader.createGraphFromDropSpecList(appDropSpec, ret_drops=True)
+        # drops = [v for d,v in drops.items()]
+        leafs = droputils.getLeafNodes(roots)  
+        with  droputils.DROPWaiterCtx(self, leafs, timeout=3000):
+            for drop in roots: 
+                fut = drop.async_execute()
+                fut.result()
+                
+        for l in leafs:
+            self.assertEqual(DROPStates.COMPLETED, l.status) 

--- a/daliuge-engine/test/test_drop_ports.py
+++ b/daliuge-engine/test/test_drop_ports.py
@@ -28,7 +28,7 @@ Use examples derived from the following DROP classes:
 - s3_drop
 - bash_shell_app
 - dockerapp 
-- mpi
+    - mpi
 """
 import logging
 import unittest
@@ -66,7 +66,7 @@ class TestPortsLoaded(unittest.TestCase):
         with Path(spec).open('r') as f: 
             appDropSpec = json.load(f)
         
-        roots, drops = graph_loader.createGraphFromDropSpecList(appDropSpec, ret_drops=True)
+        roots = graph_loader.createGraphFromDropSpecList(appDropSpec)
         # drops = [v for d,v in drops.items()]
         leafs = droputils.getLeafNodes(roots)  
         with  droputils.DROPWaiterCtx(self, leafs, timeout=3000):

--- a/daliuge-engine/test/test_drop_ports.py
+++ b/daliuge-engine/test/test_drop_ports.py
@@ -105,12 +105,12 @@ class TestPortsEncoding(unittest.TestCase):
             self.assertEqual(DROPStates.COMPLETED, l.status) 
 
         # Leaf Node 1 has been encoded first as numpy, second as UTF-8. 
-        leaf = leafs.pop(0)
-        desc = leaf.open()
-        self.assertEqual("array(2)", leaf.read(desc).decode())
-        leaf = leafs.pop(0)
+        leaf = leafs.pop()
         desc = leaf.open()
         self.assertEqual(8, dill.loads(leaf.read(desc)))
+        leaf = leafs.pop()
+        desc = leaf.open()
+        self.assertEqual("array(2)", leaf.read(desc).decode())
         
 
     def test_bash_shell_ports(self): 
@@ -118,4 +118,7 @@ class TestPortsEncoding(unittest.TestCase):
         "drop_spec", "pyfunc_glob_shell_test.graph"
         """
         leafs = self._create_and_run_graph_spec_from_lgt("pyfunc_glob_shell_test.graph")
-
+        
+        for l in leafs:
+            self.assertEqual(DROPStates.COMPLETED, l.status) 
+        self.assertEqual(0, leafs.pop().proc.returncode)

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -36,8 +36,8 @@ import time
 from itertools import product
 import numpy as np
 
-from dlg.common import CategoryType
-from dlg.common import dropdict
+from dlg.common import CategoryType, dropdict
+
 from dlg.dropmake.dm_utils import (
     LG_APPREF,
     getNodesKeyDict,
@@ -431,7 +431,12 @@ class LG:
             Categories.PYTHON_APP,
         ]
 
-    def _link_drops(self, slgn, tlgn, src_drop, tgt_drop, llink):
+    def _link_drops(self, 
+                    slgn: LGNode, 
+                    tlgn: LGNode, 
+                    src_drop: dropdict, 
+                    tgt_drop: dropdict, 
+                    llink: dict):
         """ """
         sdrop = None
         if slgn.is_gather:
@@ -482,10 +487,26 @@ class LG:
             tdrop.addStreamingInput(dropSpec_null, name="stream")
             self._drop_dict["new_added"].append(dropSpec_null)
         elif s_type in ["Application", "Control"]:
-            sname = slgn._getPortName("outputPorts")
+            sname = slgn._getPortName("outputPorts", index=-1)
             tname = tlgn._getPortName("inputPorts")
-            # logger.debug("Found port names: IN: %s, OUT: %s", sname, tname)
-            sdrop.addOutput(tdrop, name=sname)
+
+            # sname is dictionary of all output ports on the sDROP. 
+            # Therefore there's an expected number of output edges that we need to add
+            # We keep track of this by querying the sDROP's current outputs and seeing 
+            # what is currently 'lowest' in number. Eventual, all output port names will 
+            # be added. 
+            expected = [p for p in sname.keys()]
+            output_port = expected[0]
+            if "outputs" in sdrop:
+                actual = []
+                [actual.extend(pair.values()) for pair in sdrop["outputs"]]
+                actual_counts = {port: actual.count(port) for port in set(expected)}
+                expected_counts = {port: expected.count(port) for port in (expected)}
+                differences = {port: (expected_counts[port] - actual_counts.get(port,0)) for port in expected_counts}
+                candidates = {port: deficit for port, deficit in differences.items() if deficit>0}
+                if candidates: 
+                    output_port = max(candidates, key=candidates.get)
+            sdrop.addOutput(tdrop, name=output_port)
             tdrop.addProducer(sdrop, name=tname)
             if Categories.BASH_SHELL_APP == s_type:
                 bc = src_drop["command"]

--- a/daliuge-translator/dlg/dropmake/lg_node.py
+++ b/daliuge-translator/dlg/dropmake/lg_node.py
@@ -761,9 +761,7 @@ class LGNode:
                 if "usage" not in field:  # fixes manual graphs
                     continue
                 if field["usage"] in port_selector[ports]:
-                    if portId is None:
-                        name = field["name"]
-                    elif field["id"] == portId:
+                    if portId is None or field["id"] == portId:
                         name = field["name"]
                     # can't be sure that name is unique
                     if name not in ports_dict:

--- a/daliuge-translator/dlg/dropmake/path_utils.py
+++ b/daliuge-translator/dlg/dropmake/path_utils.py
@@ -40,8 +40,11 @@ def get_lg_fpath(test_type, f_name):
     if test_type == "pickle":
         f_name = f_name.split(".")[0] + ".pkl"
         f_dir += test_type
-    elif test_type == "pg_spec":
+    elif test_type == "go_js_json":
         f_name = f_name.split(".")[0] + ".json"
+        f_dir += test_type
+    elif test_type == "drop_spec":
+        f_name = f_name.split(".")[0] + ".spec"
         f_dir += test_type
     else:
         f_dir += "logical_graphs"

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -125,7 +125,7 @@ install_requires = [
 extra_requires = {
     "test": [
         "pytest",
-        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-392",
+        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo",
     ]
 }
 

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -125,7 +125,7 @@ install_requires = [
 extra_requires = {
     "test": [
         "pytest",
-        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo",
+        "eagle_test_graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-392",
     ]
 }
 

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -382,7 +382,8 @@ if __name__ == '__main__':
         "chiles_simple.graph",
         "Plasma_test.graph",
         "SharedMemoryTest_update.graph",
-        "test_ports.graph"
+        "test_ports.graph",
+        "pyfunc_glob_shell_test.graph"
         # "simpleMKN_update.graph", # Currently broken
     ]
 

--- a/daliuge-translator/test/dropmake/test_pg_gen.py
+++ b/daliuge-translator/test/dropmake/test_pg_gen.py
@@ -382,6 +382,7 @@ if __name__ == '__main__':
         "chiles_simple.graph",
         "Plasma_test.graph",
         "SharedMemoryTest_update.graph",
+        "test_ports.graph"
         # "simpleMKN_update.graph", # Currently broken
     ]
 
@@ -391,15 +392,29 @@ if __name__ == '__main__':
         lg = LG(fp, ssid=TEST_SSID)
 
         lg_unroll = lg.unroll_to_tpl()
-        fn_pkl = lg_name.split('.')[0] + '.pkl'
         pkl_path = path_utils.get_lg_fpath("pickle", lg_name)
         with open(pkl_path, 'wb') as fp:
             pickle.dump(lg_unroll, fp)
 
         pgt = PGT(lg_unroll)
         pg_json = pgt.to_gojs_json(visual=True, string_rep=False)
-        fn_json = lg_name.split('.')[0] + '.json'
-        pg_path = path_utils.get_lg_fpath("pg_spec", lg_name)
+        pg_path = path_utils.get_lg_fpath("go_js_json", lg_name)
 
         with open(pg_path, 'w') as fp:
             json.dump(pg_json, fp, indent=2)
+
+        node_list = [
+            "10.128.0.11",
+            "10.128.0.12",
+            "10.128.0.13",
+            "10.128.0.14",
+            "10.128.0.15",
+            "10.128.0.16",
+        ]
+        pgtp = MetisPGTP(lg_unroll,merge_parts=True)
+        pgtp.to_gojs_json(visual=True, string_rep=False)
+        pg_spec = pgtp.to_pg_spec(node_list=node_list, num_islands=1, ret_str=False)
+        fn_spec = lg_name.split('.')[0] + '.spec'
+        drop_spec_path = path_utils.get_lg_fpath("drop_spec", lg_name)
+        with open(drop_spec_path, 'w') as fp:
+            json.dump(pg_spec, fp, indent=2)

--- a/docs/development/app_development/app_index.rst
+++ b/docs/development/app_development/app_index.rst
@@ -25,9 +25,14 @@ integration and testing during component development. As mentioned already, for 
  pyfunc_components
  datadrop_io
  eagle_app_integration
-..  docker_components
-..  deployment_testing
-..  dynlib_components
+
+.. toctree:: 
+    :hidden:
+
+    bash_advanced
+    docker_components
+    deployment_testing
+    dynlib_components
     service_components
     test_and_debug
     wrap_existing

--- a/docs/development/app_development/app_index.rst
+++ b/docs/development/app_development/app_index.rst
@@ -22,12 +22,13 @@ integration and testing during component development. As mentioned already, for 
  bash_components
  python_components
  special_components
- dynlib_components
- docker_components
- service_components
  pyfunc_components
  datadrop_io
- wrap_existing
- test_and_debug
  eagle_app_integration
- deployment_testing
+..  docker_components
+..  deployment_testing
+..  dynlib_components
+    service_components
+    test_and_debug
+    wrap_existing
+ 

--- a/docs/development/app_development/bash_advanced.rst
+++ b/docs/development/app_development/bash_advanced.rst
@@ -1,6 +1,6 @@
-.. .. _advanced_bash:
-.. 
-.. Advanced Bash Components
-.. ------------------------
+.. _advanced_bash:
+
+Advanced Bash Components
+------------------------
 
 TODO

--- a/docs/development/app_development/bash_components.rst
+++ b/docs/development/app_development/bash_components.rst
@@ -22,7 +22,9 @@ Steps
 
 Please note that the *Hello World* example is also described (with videos) as part of the `EAGLE documentation <https://eagle-dlg.readthedocs.io/en/master/helloWorld.html>`_.
 
-That should give you the idea how to use bash commands as |daliuge| components. Seems not a lot? Well, actually this is allowing you to execute whatever can be executed on the command line where the engine is running as part of a |daliuge| graph. That includes all bash commands, but also every other executable available on the PATH of the engine. Now that is a bit more exciting, but the excitement stops as soon as you think about real world (not Hello World) examples: Really useful commands will require inputs and outputs in the form of command line parameters and files or pipes. This is discussed in the :ref:`advanced_bash` chapter. 
+That should give you the idea how to use bash commands as |daliuge| components. Seems not a lot? Well, actually this is allowing you to execute whatever can be executed on the command line where the engine is running as part of a |daliuge| graph. That includes all bash commands, but also every other executable available on the PATH of the engine. Now that is a bit more exciting, but the excitement stops as soon as you think about real world (not Hello World) examples: Really useful commands will require inputs and outputs in the form of command line parameters and files or pipes. These will be expanded up on in future work. 
+
+.. This is discussed in the :ref:`advanced_bash` chapter. 
 
 Verification
 ------------
@@ -80,8 +82,8 @@ The applicationArgs are treated in the order of appearance. After the constructi
 
 Eventually we will also drop support for the command_line_arguments parameters. However, currently the applicationArgs can't be used to specify positional arguments (just a value) and thus, as a fallback users can still use one the command_line_arguments to achieve that. It should also be noted that for really simple commands, like the one used in the helloWorld example, users can simply specify that in the command parameter directly and ommit all of the others. 
 
-.. _advanced_bash:
+.. .. _advanced_bash:
 
-Advanced Bash Components
-------------------------
-.. include:: bash_advanced.rst
+.. Advanced Bash Components
+.. ------------------------
+.. .. include:: bash_advanced.rst

--- a/docs/development/app_development/pyfunc_components.rst
+++ b/docs/development/app_development/pyfunc_components.rst
@@ -9,16 +9,13 @@ maps directly to an existing python function or a lambda expression, named appli
 Port Parsers
 ------------
 
-Pyfunc components when interfacing with data drops may utilize one of several builtin port parsing formats.
+Pyfunc components when interfacing with data drops may use one of several builtin port parsing formats.
 
-* Pickle - Reads and writes data to pickle format
-* Eval - Reads data using eval() function and writes using repr() function
-* Npy - Reads and writes to .npy format
-* Path - Reads the drop path rather than data
-* Url - Reads the drop url rather than data
+- Binary
+- Pickle
+- Dill 
+- Numpy 
+- Base64
+- UTF-8
 
-
-Note
-""""
-
-Only a single port parser can currently be used for all input ports of a Pyfunc. This is subject to change in future.
+Port parsing is now possible on a per-port basis, which means that a PyFunc application may take into account input parameters from various data sources of different origins and encodings.  

--- a/docs/development/app_development/special_components.rst
+++ b/docs/development/app_development/special_components.rst
@@ -9,7 +9,7 @@ In addition users can develop a number of specialized components, which are base
 #. MPI Components
 #. Archiving/store Components
 
-Descriptions TODO
+.. Descriptions TODO
 
 Built-in Application Components
 ===============================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,11 @@ and is performed by the `DIA team <http://www.icrar.org/our-research/data-intens
  graph_development
  cli
  api-index
-..  development/dev_index
+
+.. toctree:: 
+    :hidden:
+
+    development/dev_index
     usage/index
 
 Citations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,10 +28,10 @@ and is performed by the `DIA team <http://www.icrar.org/our-research/data-intens
  architecture/index
  deployment
  graph_development
- development/dev_index
- usage/index
  cli
  api-index
+..  development/dev_index
+    usage/index
 
 Citations
 ---------

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -7,5 +7,5 @@
  :maxdepth: 3
 
  intro
- reduction
- graph_developer
+..  reduction
+..  graph_developer

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -7,5 +7,9 @@
  :maxdepth: 3
 
  intro
-..  reduction
-..  graph_developer
+ 
+.. toctree:: 
+    :hidden:
+    
+    reduction
+    graph_developer


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->
[LIU-392](https://icrar.atlassian.net/browse/LIU-392)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [x] Feature (addition)
- [ ] Bug fix
- [x] Refactor (change)
- [X] Documentation 

# Problem/Issue 

Previously, we have only supported a single serialisation method for all inputs, and all outputs going into a component. This limited the combinations of ports into/out of a component in the graph. 

EAGLE now supports per-port encoding, which is not supported by DALiuGE. The aim of this PR is to enable that support. 

![Screenshot from 2024-11-06 17-51-11](https://github.com/user-attachments/assets/daff9c0d-6eba-4906-9598-cbf5263632a2)

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have updated the `named_port_utils.py` and `PyFunc` code to support the new "encoding" parameter that is passed through the graph JSON. 

Key updates include: 
- Reorganising PyFunc's input port deserialisation and corresponding test code.
    -  This was necessary because there were two paths of code that evaluated input ports for functions, one of which was _only_ used in the tests. The reason for this is the tests were not passing in the `"inputs"` to the test PyFuncApp drops, so there was nothing triggering the standard code pathway. 
    - The tests have been updated so they now follow the single path of code, and we only use that pathway. 
    - This also affected the `dask_emulation` and subsequent tests which required some work to fix, as the graph is built programmatically, which means the inputs/outputs functionality had to be added too. 
- Updating the translator: we previously only stored a single output port (the last output port seen by the translator). This has been rectified so all output ports are tracked. 
- `named_port_utils.py`. This utility file is used by all the other components that use named-ports for inputs; some small adjustments were made to account for the encoding and values. 
- `test_drop_ports.py`: These are integration tests that confirm graphs that uses different encodings on ports work as expected, and correctly read/write using those encodings. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [x] Unittests added
- [x] Documentation added

## Summary by Sourcery

Enable per-port serialization and refactor input/output port handling for improved clarity.

New Features:
- Enable per-port serialization for input and output ports in the application.

Enhancements:
- Refactor the handling of input and output ports to improve code clarity and maintainability.

[LIU-392]: https://icrar.atlassian.net/browse/LIU-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for per-port serialization, enabling flexible encoding and decoding of data passed between application ports.

New Features:
- Support per-port serialization for inputs and outputs.

Tests:
- Added integration tests to validate the functionality of per-port serialization with different encodings.