### PR TITLE
LIU-439: Use translator avahi approach for engine.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,17 +33,59 @@ It originated from a prototyping activity as part of the `SDP Consortium
 <https://www.skatelescope.org/sdp/>`_ called Data Flow Management System (DFMS). DFMS aimed to 
 prototype the execution framework of the proposed SDP architecture.
 
-For more information about the installation and usage of the system please refer to the `documentation <https://daliuge.readthedocs.io>`_
-
-
 Development and maintenance of |daliuge| is currently hosted at ICRAR_
 and is performed by the `DIA team <http://www.icrar.org/our-research/data-intensive-astronomy/>`_.
 
+Quickstart
+==========
+
+Most users will need to use DALiuGE locally only when prototyping their workflow as it 
+is designed in EAGLE. This repository provides a `Makefile` that simplifies the setup
+options for running DALiuGE locally, without needing to take into account the distributed 
+and flexible nature of the ecosystem. 
+
+.. note:: It is recommended to have Docker installed when running DALiuGE as a workflow 
+prototyping tool. Please review the installation material for Docker `here <https://docs.docker.com/engine/install/>`.  
+
+The following steps are recommended for quickstarting your DALiuGE install: 
+
+1. Create and enterthe virtual environment
+2. Build the docker images
+3. Run the docker images
+4. Confirm the images are running and accessible from EAGLE using a web browser. 
+
+Creating the virtual environment is as simple as running:: 
+
+    make virtualenv
+    source .venv/bin/activate 
+
+Now, in the ``.venv`` environment, run:: 
+
+    make docker-install 
+
+This will install a development version of the DALiuGE images and is appropriate for local
+installation (*not* a production environment). 
+
+Running both the Engine and the Translator is as a simple as:: 
+
+    make docker-run
+
+It is possible to confirm the running of both by accessing the following links in a browser
+(Opera, Firefox, or Chrome are recommended):: 
+
+    http://dlg-trans.local:8084/ # Translator
+    http://dlg-engine.local:8000/ # Node Manager 
+    http://dlg-engine.local:8001/ # Data Island Manager
+
+
+With this setup running, it is now possible to translate and deploy a prototype EAGLE workflow
+on your local machine. 
+
+For more information about the installation and usage of the system please refer to the `documentation <https://daliuge.readthedocs.io>`_
+
+
 See the ``docs/`` directory for more information, or visit `our online
 documentation <https://daliuge.readthedocs.io/>`_
-
-
-
 
 
 .. |daliuge| replace:: DALiuGE

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Creating the virtual environment is as simple as running::
     make virtualenv
     source .venv/bin/activate 
 
-Now, in the ``.venv`` environment, run:: 
+Now, in the `.venv` environment, run:: 
 
     make docker-install 
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ prototyping tool. Please review the installation material for Docker `here <http
 
 The following steps are recommended for quickstarting your DALiuGE install: 
 
-1. Create and enterthe virtual environment
+1. Create and enter the virtual environment
 2. Build the docker images
 3. Run the docker images
 4. Confirm the images are running and accessible from EAGLE using a web browser. 

--- a/daliuge-common/docker/Dockerfile.dev
+++ b/daliuge-common/docker/Dockerfile.dev
@@ -9,12 +9,12 @@ LABEL stage=builder
 LABEL build=$BUILD_ID
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y avahi-utils gcc python3 python3.8-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl git sudo && \
+    apt-get install -y avahi-daemon avahi-utils gcc python3.9 python3.9-venv python3-pip python3-distutils python3-appdirs libmetis-dev curl git sudo && \
     apt-get clean
 
 COPY / /daliuge
 
-RUN cd / && python3 -m venv dlg && cd /daliuge && \
+RUN cd / && python3.9 -m venv dlg && cd /daliuge && \
     . /dlg/bin/activate && \
     pip install --upgrade pip && \
     pip install wheel numpy && \

--- a/daliuge-engine/docker/Dockerfile.dev
+++ b/daliuge-engine/docker/Dockerfile.dev
@@ -4,7 +4,11 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 
 # RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
-RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
+RUN service avahi-daemon stop && \
+    service dbus start && \
+    service avahi-daemon start && \
+    avahi-set-host-name dlg-engine
+
 COPY / /daliuge
 RUN . /dlg/bin/activate && pip install --upgrade pip && pip install wheel && cd /daliuge && \
     pip install . 

--- a/daliuge-engine/docker/Dockerfile.devall
+++ b/daliuge-engine/docker/Dockerfile.devall
@@ -5,10 +5,16 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 # RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 
+RUN apt install -y git python3.9-dev
+
 RUN apt-get update &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc curl python3-pip python3-numpy
 
-RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
+RUN service avahi-daemon stop && \
+    service dbus start && \
+    service avahi-daemon start && \
+    avahi-set-host-name dlg-engine
+
 # USER ${USER}
 COPY / /daliuge
 RUN . /dlg/bin/activate && pip install wheel && cd /daliuge && \
@@ -26,7 +32,6 @@ ENV VIRTUAL_ENV=/dlg
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV DLG_ROOT="/tmp/dlg"
 
-RUN apt install -y git python3-dev
 
 # Nifty
 #RUN pip install --prefix=$PYTHON_PREFIX git+https://gitlab.com/ska-telescope/sdp/ska-gridder-nifty-cuda.git

--- a/daliuge-engine/docker/Dockerfile.ray
+++ b/daliuge-engine/docker/Dockerfile.ray
@@ -6,7 +6,11 @@ FROM icrar/daliuge-common:${VCS_TAG:-latest}
 #     gcc g++ gdb casacore-dev clang-tidy-10 clang-tidy libboost1.71-all-dev libgsl-dev
 
 RUN sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends gcc python3-pip curl
-RUN service dbus start && service avahi-daemon start && avahi-set-host-name dlg-engine
+
+RUN service avahi-daemon stop && \
+    service dbus start && \
+    service avahi-daemon start && \
+    avahi-set-host-name dlg-engine
 
 COPY / /daliuge
 RUN . /home/ray/dlg/bin/activate && \


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-439](https://icrar.atlassian.net/browse/LIU-439)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- ~[ ] Feature (addition)~
- [x] Bug fix
- ~[ ] Refactor (change)~ 
- [x] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

I have experienced unreliability with the use of dlg-engine as an address when running the docker files on Ubuntu machines. Previously (after spending a day wondering what had broken) this was chalked up to my Ubuntu 22.04 installation being a slightly broken, as @awicenec's and my personal popOS laptops were fine. However, @omaranwar85 also had issues using the host names as well when running on another Ubuntu system, so something was problematic. 


# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

It looks like sending `service avahi start` whilst avahi is already started causes issues. I have never had any issues with the `dlg-trans` address resolving on the daliuge-translator docker container, and it turns out the Dockerfile stops the `avahi-daemon` before starting it, which is not in the engine dockerfile. Copying the translator approach appears to resolve the resolution issues. 

Also added quickstart for README.rst to help people get started ASAP, based on user feedback.

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - Dockerfile scripts installation, not tested/able
- [x] Documentation added
    - I have updated the README with a quickstart guide to help people get something up and running nice and quickly, based on some of the recent user feedback.

## Summary by Sourcery

Update Dockerfiles to resolve engine address resolution issues and add a quickstart guide to the README.

Bug Fixes:
- Fixed engine address resolution issues on Ubuntu by restarting the avahi-daemon service in the Dockerfile.

Documentation:
- Added a quickstart guide to the README to help users get started quickly.

[LIU-439]: https://icrar.atlassian.net/browse/LIU-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ