### PR TITLE
LIU-438: Update CompositeManager and Node handling of DIM default ports.

### DIFF
--- a/daliuge-engine/dlg/deploy/start_dlg_cluster.py
+++ b/daliuge-engine/dlg/deploy/start_dlg_cluster.py
@@ -210,7 +210,7 @@ def start_dim(node_list, log_dir, origin_ip, logv=1):
         "0.0.0.0",
         "-m",
         "2048",
-        "--dump_graphs=true"
+        "--dump_graphs"
     ]
     proc = tool.start_process("dim", args)
     LOGGER.info("Island manager process started with pid %d", proc.pid)
@@ -235,7 +235,7 @@ def start_mm(node_list, log_dir, logv=1):
         "0.0.0.0",
         "-m",
         "2048",
-        "--dump_graphs=true"
+        "--dump_graphs"
     ]
     proc = tool.start_process("mm", args)
     LOGGER.info("Master manager process started with pid %d", proc.pid)

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -148,7 +148,7 @@ class CompositeManager(DROPManager):
             pkeyPath=None,
             dmCheckTimeout=10,
             dump_graphs=False,
-            hosts_are_dim=True
+            hosts_are_dim=False
     ):
         """
         Creates a new CompositeManager. The sub-DMs it manages are to be located

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -147,7 +147,8 @@ class CompositeManager(DROPManager):
             dmHosts: list[str] = None,
             pkeyPath=None,
             dmCheckTimeout=10,
-            dump_graphs=False
+            dump_graphs=False,
+            hosts_are_dim=True
     ):
         """
         Creates a new CompositeManager. The sub-DMs it manages are to be located
@@ -164,7 +165,7 @@ class CompositeManager(DROPManager):
         :param: dmCheckTimeout The timeout used before giving up and declaring
                 a sub-DM as not-yet-present in a given host
         """
-        self._dmHosts = [Node(host) for host in dmHosts]
+        self._dmHosts = [Node(host, dim=hosts_are_dim) for host in dmHosts]
         if self._dmHosts and self._dmHosts[0].rest_port_specified:
             dmPort = -1
         self._dmPort = dmPort
@@ -683,6 +684,7 @@ class MasterManager(CompositeManager):
             dmHosts=dmHosts,
             pkeyPath=pkeyPath,
             dmCheckTimeout=dmCheckTimeout,
-            dump_graphs=dump_graphs
+            dump_graphs=dump_graphs,
+            hosts_are_dim=True
         )
         logger.info("Created MasterManager for DIM hosts: %r", self._dmHosts)

--- a/daliuge-engine/dlg/manager/manager_data.py
+++ b/daliuge-engine/dlg/manager/manager_data.py
@@ -25,7 +25,7 @@ This module contains classes and helper-methods to support the various manager c
 """
 
 import logging
-from dlg import constants
+import dlg.constants as constants
 from enum import IntEnum
 
 logger = logging.getLogger(__name__)
@@ -44,12 +44,15 @@ class Node:
     inter-node communication.
     """
 
-    def __init__(self, host: str):
+    def __init__(self, host: str, dim=False):
         try:
             chunks = host.split(':')
             num_chunks = len(chunks)
             self.host = constants.NODE_DEFAULT_HOSTNAME
-            self.port = constants.NODE_DEFAULT_REST_PORT
+            self.port = (
+                constants.ISLAND_DEFAULT_REST_PORT if dim 
+                else constants.NODE_DEFAULT_REST_PORT
+            )
             self.events_port = constants.NODE_DEFAULT_EVENTS_PORT
             self.rpc_port = constants.NODE_DEFAULT_RPC_PORT
             self._rest_port_specified = False
@@ -113,6 +116,11 @@ class Node:
         """
         Make our serialized Node the string.
         :return: str
+        """
+        return self.serialize()
+
+    def __repr__(self):
+        """
         """
         return self.serialize()
 

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -44,7 +44,8 @@ logger = logging.getLogger(__name__)
 # The RELEASE flag allows us to create development versions properly supported
 # by setuptools/pkg_resources or "final" versions.
 try:
-    VERSION = version("daliuge-common")
+    import dlg
+    VERSION = dlg.__version__
 except PackageNotFoundError:
     logger.warning(
         "WARNING: daliuge-engine requires daliuge-common to be installed first. "

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -42,7 +42,8 @@ logger = logging.getLogger(__name__)
 # The RELEASE flag allows us to create development versions properly supported
 # by setuptools/pkg_resources or "final" versions.
 try:
-    VERSION = version("daliuge-common")
+    import dlg
+    VERSION = dlg.__version__
 except PackageNotFoundError:
     logger.warning(
         "WARNING: daliuge-translator requires daliuge-common to be installed first. "
@@ -118,7 +119,6 @@ install_requires = [
     "psutil",
     "pyswarm",
     "python-multipart",
-    # "ruamel.yaml.clib<=0.2.2",
     "uvicorn==0.18",
     "wheel",
 ]


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-438](https://icrar.atlassian.net/browse/LIU-438)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

When investigating issues with our Docker containers, I realised that when we start the MasterManager, the DIM is initialised using the NodeManager's default port address. 

This PR also address the following bugs that have popped up when helping Gayatri's work: 
- `--dump_graphs` flag was updated to be `store_true` when passed through the command line, but this wasn't updated in the `start_dlg_cluster` script
- There have been issues when installing on `hyades` with the previous version check I implemented in #275. I have updated with a tested and apparently more robust approach. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

See fixes in code.

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - Untested(able) code
- ~[ ] Documentation added~
    - Bug fixes addresses the gap between expected/documented code and what was actually happening. 

## Summary by Sourcery

Update the CompositeManager and Node to handle default ports for DIM.

[LIU-438]: https://icrar.atlassian.net/browse/LIU-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ