### PR TITLE
Name fix

### DIFF
--- a/daliuge-engine/dlg/deploy/start_dlg_cluster.py
+++ b/daliuge-engine/dlg/deploy/start_dlg_cluster.py
@@ -210,7 +210,7 @@ def start_dim(node_list, log_dir, origin_ip, logv=1):
         "0.0.0.0",
         "-m",
         "2048",
-        "--dump_graphs=true"
+        "--dump_graphs",
     ]
     proc = tool.start_process("dim", args)
     LOGGER.info("Island manager process started with pid %d", proc.pid)
@@ -235,7 +235,7 @@ def start_mm(node_list, log_dir, logv=1):
         "0.0.0.0",
         "-m",
         "2048",
-        "--dump_graphs=true"
+        "--dump_graphs",
     ]
     proc = tool.start_process("mm", args)
     LOGGER.info("Master manager process started with pid %d", proc.pid)


### PR DESCRIPTION
This PR is addressing a bug, which caused the file names of scattered drops to be identical and thus got overwritten at run-time. This only happened when submitting a graph through the CLI or by using the create_dlg_job script. There is also another quite small fix in this PR, which addresses an issue with the CLI flag dump-graphs when using the start_dlg_cluster script.

NOTE: While the fix is quite simple and good for now, it might be worthwhile to look into this again and try to align the generation of the file names between the UI and the CLI submission of graphs.

## Summary by Sourcery

Fix the bug that caused scattered drop file names to be identical and overwritten at runtime when submitting a graph through the CLI or using the create_dlg_job script.  Improve the generation of human-readable UIDs for Drops to prevent duplicates, especially when not submitted through the UI.

Bug Fixes:
- Fix file name overwriting issue for scattered drops submitted via CLI or create_dlg_job script.

Enhancements:
- Improve the heuristic for generating truncated UIDs for Drops to handle cases with multiple underscores and prevent duplicates.