### PR TITLE
Liu 456

### DIFF
--- a/daliuge-common/dlg/clients.py
+++ b/daliuge-common/dlg/clients.py
@@ -28,7 +28,7 @@ import urllib.parse
 from dlg import constants
 from .restutils import RestClient
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 compress = os.environ.get("DALIUGE_COMPRESSED_JSON", True)
 
 quote = urllib.parse.quote

--- a/daliuge-common/dlg/common/__init__.py
+++ b/daliuge-common/dlg/common/__init__.py
@@ -28,7 +28,7 @@ from .osutils import terminate_or_kill, wait_or_kill
 from .network import check_port, connect_to, portIsClosed, portIsOpen, write_to
 from .streams import ZlibCompressedStream, JSONStream
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class CategoryType(str, Enum):
@@ -124,7 +124,7 @@ class dropdict(dict):
         """
         if key not in self:
             return False
-        ports = [] 
+        ports = []
         [ports.extend(pair.values()) for pair in self[key]]
         return name in ports
 
@@ -138,7 +138,7 @@ class dropdict(dict):
 
     def hasProducer(self, producer):
         """
-        See hasOutput. 
+        See hasOutput.
         """
         return self._hasSomething("producers", producer)
 
@@ -147,6 +147,7 @@ class dropdict(dict):
 
     def __lt__(self, other):
         return self.get("oid") < other.get("oid")
+
 
 def _sanitize_links(links):
     """
@@ -190,18 +191,14 @@ def get_roots(pg_spec):
         oid = dropspec["oid"]
         all_oids.add(oid)
         ctype = (
-            dropspec["categoryType"]
-            if "categoryType" in dropspec
-            else dropspec["type"]
+            dropspec["categoryType"] if "categoryType" in dropspec else dropspec["type"]
         )
         if ctype in (
             CategoryType.APPLICATION,
             CategoryType.SOCKET,
             "app",
         ):
-            if dropspec.get("inputs", None) or dropspec.get(
-                "streamingInputs", None
-            ):
+            if dropspec.get("inputs", None) or dropspec.get("streamingInputs", None):
                 nonroots.add(oid)
             if dropspec.get("outputs", None):
                 do = _sanitize_links(dropspec["outputs"])
@@ -233,9 +230,7 @@ def get_leaves(pg_spec):
         oid = dropspec["oid"]
         all_oids.add(oid)
         ctype = (
-            dropspec["categoryType"]
-            if "categoryType" in dropspec
-            else dropspec["type"]
+            dropspec["categoryType"] if "categoryType" in dropspec else dropspec["type"]
         )
 
         if ctype in [CategoryType.APPLICATION, "app"]:

--- a/daliuge-common/dlg/common/network.py
+++ b/daliuge-common/dlg/common/network.py
@@ -25,7 +25,7 @@ import logging
 import socket
 import time
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def check_port(host, port, timeout=0, checking_open=True, return_socket=False):
@@ -46,9 +46,7 @@ def check_port(host, port, timeout=0, checking_open=True, return_socket=False):
     """
 
     if return_socket and not checking_open:
-        raise ValueError(
-            "If return_socket is True then checking_open must be True"
-        )
+        raise ValueError("If return_socket is True then checking_open must be True")
 
     start = time.time()
     while True:

--- a/daliuge-common/dlg/common/osutils.py
+++ b/daliuge-common/dlg/common/osutils.py
@@ -24,7 +24,7 @@ import logging
 import math
 import time
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def terminate_or_kill(proc, timeout):

--- a/daliuge-common/dlg/common/reproducibility/reprodata_compare.py
+++ b/daliuge-common/dlg/common/reproducibility/reprodata_compare.py
@@ -39,7 +39,7 @@ from dlg.common.reproducibility.constants import (
     ReproducibilityFlags,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def _unique_filemid():

--- a/daliuge-common/dlg/common/reproducibility/reproducibility.py
+++ b/daliuge-common/dlg/common/reproducibility/reproducibility.py
@@ -51,7 +51,7 @@ from dlg.common.reproducibility.reproducibility_fields import (
     extract_fields,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def common_hash(value: bytes):
@@ -96,12 +96,9 @@ def accumulate_lg_drop_data(drop: dict, level: ReproducibilityFlags):
     # category = drop.get("categoryType", "")
 
     # Cheeky way to get field list into dicts. map(dict, drop...) makes a copy
-    fields = {
-        e.pop("name"): e["value"] for e in map(dict, drop.get("fields", {}))
-    }
+    fields = {e.pop("name"): e["value"] for e in map(dict, drop.get("fields", {}))}
     app_fields = {
-        e.pop("name"): e["value"]
-        for e in map(dict, drop.get("applicationArgs", {}))
+        e.pop("name"): e["value"] for e in map(dict, drop.get("applicationArgs", {}))
     }
     fields.update(app_fields)
     lg_fields = lg_block_fields(category, level, app_fields.keys())
@@ -376,9 +373,7 @@ def build_lg_block_data(drop: dict, rmode):
     if "merkleroot" in drop["reprodata"][rmode.name]["lg_data"]:
         lg_hash = drop["reprodata"][rmode.name]["lg_data"]["merkleroot"]
         block_data.append(lg_hash)
-    for parenthash in sorted(
-        drop["reprodata"][rmode.name]["lg_parenthashes"].values()
-    ):
+    for parenthash in sorted(drop["reprodata"][rmode.name]["lg_parenthashes"].values()):
         block_data.append(parenthash)
     mtree = MerkleTree(block_data, common_hash)
     drop["reprodata"][rmode.name]["lg_blockhash"] = mtree.merkle_root
@@ -393,9 +388,7 @@ def build_pgt_block_data(drop: dict, rmode):
     block_data = []
     if "pgt_data" in drop["reprodata"][rmode.name]:
         if "merkleroot" in drop["reprodata"][rmode.name]["pgt_data"]:
-            block_data.append(
-                drop["reprodata"][rmode.name]["pgt_data"]["merkleroot"]
-            )
+            block_data.append(drop["reprodata"][rmode.name]["pgt_data"]["merkleroot"])
     if "lg_blockhash" in drop["reprodata"][rmode.name]:
         block_data.append(drop["reprodata"][rmode.name]["lg_blockhash"])
     for parenthash in sorted(
@@ -417,9 +410,7 @@ def build_pg_block_data(drop: dict, rmode):
         drop["reprodata"][rmode.name]["pgt_blockhash"],
         drop["reprodata"][rmode.name]["lg_blockhash"],
     ]
-    for parenthash in sorted(
-        drop["reprodata"][rmode.name]["pg_parenthashes"].values()
-    ):
+    for parenthash in sorted(drop["reprodata"][rmode.name]["pg_parenthashes"].values()):
         block_data.append(parenthash)
     mtree = MerkleTree(block_data, common_hash)
     drop["reprodata"][rmode.name]["pg_blockhash"] = mtree.merkle_root
@@ -432,16 +423,12 @@ def build_rg_block_data(drop: dict, rmode):
     :return:
     """
     block_data = [
-        drop["reprodata"][rmode.name].get("rg_data", {"merkleroot": b""})[
-            "merkleroot"
-        ],
+        drop["reprodata"][rmode.name].get("rg_data", {"merkleroot": b""})["merkleroot"],
         drop["reprodata"][rmode.name]["pg_blockhash"],
         drop["reprodata"][rmode.name]["pgt_blockhash"],
         drop["reprodata"][rmode.name]["lg_blockhash"],
     ]
-    for parenthash in sorted(
-        drop["reprodata"][rmode.name]["rg_parenthashes"].values()
-    ):
+    for parenthash in sorted(drop["reprodata"][rmode.name]["rg_parenthashes"].values()):
         block_data.append(parenthash)
     mtree = MerkleTree(block_data, common_hash)
     drop["reprodata"][rmode.name]["rg_blockhash"] = mtree.merkle_root
@@ -464,13 +451,13 @@ def lg_build_blockdag(logical_graph: dict, level):
     queue = collections.deque()
     # TODO: Deal with MKN/Scatter Input drops
     for drop in logical_graph.get("nodeDataArray", []):
-        did = (drop["id"])
+        did = drop["id"]
         dropset[did] = [drop, 0, 0]
         neighbourset[did] = []
 
     for edge in logical_graph.get("linkDataArray", []):
-        src = (edge["from"])
-        dest = (edge["to"])
+        src = edge["from"]
+        dest = edge["to"]
         dropset[dest][1] += 1
         dropset[src][2] += 1
         neighbourset[src].append(dest)
@@ -510,21 +497,17 @@ def lg_build_blockdag(logical_graph: dict, level):
                     ):
                         # Add my new hash to the parent-hash list
                         if did not in parenthash:
-                            parenthash[did] = dropset[did][0]["reprodata"][
-                                level.name
-                            ]["lg_blockhash"]
+                            parenthash[did] = dropset[did][0]["reprodata"][level.name][
+                                "lg_blockhash"
+                            ]
                         # parenthash.append(dropset[did][0]['reprodata']['lg_blockhash'])
                     else:
                         # Add my parenthashes to the parent-hash list
                         parenthash.update(
-                            dropset[did][0]["reprodata"][level.name][
-                                "lg_parenthashes"
-                            ]
+                            dropset[did][0]["reprodata"][level.name]["lg_parenthashes"]
                         )
                         # parenthash.extend(dropset[did][0]['reprodata']['lg_parenthashes'])
-                if (
-                    rmode != ReproducibilityFlags.REPRODUCE
-                ):  # Non-compressing behaviour
+                if rmode != ReproducibilityFlags.REPRODUCE:  # Non-compressing behaviour
                     parenthash[did] = dropset[did][0]["reprodata"][level.name][
                         "lg_blockhash"
                     ]
@@ -627,13 +610,13 @@ def build_blockdag(drops: list, abstraction: str, level: ReproducibilityFlags):
                         "categoryType"
                         in dropset[did][0]["reprodata"][rmode.name]["pgt_data"]
                     ):
-                        ctype = dropset[did][0]["reprodata"][rmode.name][
-                            "pgt_data"
-                        ]["categoryType"]
+                        ctype = dropset[did][0]["reprodata"][rmode.name]["pgt_data"][
+                            "categoryType"
+                        ]
                     else:
-                        ctype = dropset[did][0]["reprodata"][rmode.name][
-                            "lgt_data"
-                        ]["categoryType"]
+                        ctype = dropset[did][0]["reprodata"][rmode.name]["lgt_data"][
+                            "categoryType"
+                        ]
 
                     if (
                         ctype.lower() == "data"
@@ -642,9 +625,9 @@ def build_blockdag(drops: list, abstraction: str, level: ReproducibilityFlags):
                     ):
                         # Add my new hash to the parent-hash list
                         if did not in parenthash:
-                            parenthash[did] = dropset[did][0]["reprodata"][
-                                level.name
-                            ][blockstr + "_blockhash"]
+                            parenthash[did] = dropset[did][0]["reprodata"][level.name][
+                                blockstr + "_blockhash"
+                            ]
                         # parenthash.append(dropset[did][0]['reprodata'] \
                         # [blockstr + "_blockhash"])
                     else:
@@ -670,9 +653,9 @@ def build_blockdag(drops: list, abstraction: str, level: ReproducibilityFlags):
                             parentstr
                         ].update(parenthash)
                 elif rmode != ReproducibilityFlags.RERUN:
-                    dropset[neighbour][0]["reprodata"][level.name][
-                        parentstr
-                    ].update(parenthash)
+                    dropset[neighbour][0]["reprodata"][level.name][parentstr].update(
+                        parenthash
+                    )
             if dropset[neighbour][1] == 0:
                 queue.append(neighbour)
 
@@ -680,9 +663,7 @@ def build_blockdag(drops: list, abstraction: str, level: ReproducibilityFlags):
         logger.warning("Not a DAG")
 
     for i, leaf in enumerate(leaves):
-        leaves[i] = dropset[leaf][0]["reprodata"][level.name][
-            blockstr + "_blockhash"
-        ]
+        leaves[i] = dropset[leaf][0]["reprodata"][level.name][blockstr + "_blockhash"]
     return leaves, visited
 
     # logger.info("BlockDAG Generated at" + abstraction + " level")
@@ -751,9 +732,7 @@ def init_lg_repro_data(logical_graph: dict):
         if rmode.name not in logical_graph["reprodata"]:
             logical_graph["reprodata"][rmode.name] = {}
         leaves, _ = lg_build_blockdag(logical_graph, rmode)
-        logical_graph["reprodata"][rmode.name][
-            "signature"
-        ] = agglomerate_leaves(leaves)
+        logical_graph["reprodata"][rmode.name]["signature"] = agglomerate_leaves(leaves)
     logger.info("Reproducibility data finished at LG level")
     return logical_graph
 

--- a/daliuge-common/dlg/common/tool.py
+++ b/daliuge-common/dlg/common/tool.py
@@ -30,7 +30,8 @@ import time
 
 from importlib.metadata import entry_points
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger("dlg." + __name__)
+logger = logging.getLogger("dlg")
 
 
 def add_logging_options(parser):
@@ -116,13 +117,16 @@ def version(parser, args):
 
 cmdwrap("version", "Reports the DALiuGE version and exits", version)
 
+
 def _load_commands():
     if sys.version_info.minor < 10:
         all_entry_points = entry_points()
         for entry_point in all_entry_points["dlg.tool_commands"]:
             entry_point.load().register_commands()
     else:
-        for entry_point in entry_points(group="dlg.tool_commands"):  # pylint: disable=unexpected-keyword-arg
+        for entry_point in entry_points(
+            group="dlg.tool_commands"
+        ):  # pylint: disable=unexpected-keyword-arg
             entry_point.load().register_commands()
 
 

--- a/daliuge-common/dlg/restutils.py
+++ b/daliuge-common/dlg/restutils.py
@@ -33,7 +33,7 @@ from . import exceptions
 from .exceptions import DaliugeException, SubManagerException
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ThreadingWSGIServer(
@@ -144,8 +144,7 @@ class RestClient(object):
     def _post_form(self, url, content=None):
         if content is not None:
             content = urllib.parse.urlencode(content)
-        ret = self._POST(
-            url, content, content_type="application/x-www-form-urlencoded")
+        ret = self._POST(url, content, content_type="application/x-www-form-urlencoded")
         return json.load(ret) if ret else None
 
     def _post_json(self, url, content, compress=False):
@@ -178,13 +177,12 @@ class RestClient(object):
         stream, _ = self._request(url, "DELETE")
         return stream
 
-    def _request(self, url, method, content=None, headers: dict=None, timeout=10):
+    def _request(self, url, method, content=None, headers: dict = None, timeout=10):
         if not headers:
             headers = {}
         # Do the HTTP stuff...
         url = self.url_prefix + url
-        logger.debug("Sending %s request to %s:%d%s",
-                     method, self.host, self.port, url)
+        logger.debug("Sending %s request to %s:%d%s", method, self.host, self.port, url)
 
         if not common.portIsOpen(self.host, self.port, timeout):
             raise RestClientException(

--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -23,6 +23,7 @@
 Module containing miscellaneous utility classes and functions.
 """
 import base64
+import dill
 import errno
 import functools
 import importlib
@@ -38,7 +39,6 @@ import zlib
 import re
 import grp
 import pwd
-import pickle
 
 from pathlib import Path
 
@@ -529,12 +529,12 @@ def prepareUser(DLG_ROOT=getDlgDir()):
 
 def serialize_data(d):
     # return pickle.dumps(d)
-    return b2s(base64.b64encode(pickle.dumps(d)))
+    return b2s(base64.b64encode(dill.dumps(d)))
 
 
 def deserialize_data(d):
     # return pickle.loads()
-    return pickle.loads(base64.b64decode(d.encode("utf8")))
+    return dill.loads(base64.b64decode(d.encode("utf8")))
 
 
 def truncateUidToKey(uid: str) -> str:

--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -46,7 +46,7 @@ import netifaces
 
 from . import common
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def timed_import(module_name):

--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -352,6 +352,8 @@ def object_tracking(name):
 
             setattr(current_object, name, args[0])
             try:
+                if "self" in kwargs:
+                    kwargs.pop("self")
                 return f(*args, **kwargs)
             finally:
                 setattr(current_object, name, previous)

--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -351,9 +351,23 @@ def object_tracking(name):
                 previous = None
 
             setattr(current_object, name, args[0])
+            logger.debug(
+                ">>>> Inside track_current_drop: %s humanKey: %s",
+                current_object,
+                (
+                    args[0]._humanKey
+                    if hasattr(getattr(current_object, name), "_humanKey")
+                    else "unknown"
+                ),
+            )
             try:
                 if "self" in kwargs:
                     kwargs.pop("self")
+                logger.debug(
+                    ">>>> Inside track_current_drop: %s, %s",
+                    f,
+                    hasattr(current_object, name),
+                )
                 return f(*args, **kwargs)
             finally:
                 setattr(current_object, name, previous)
@@ -361,6 +375,16 @@ def object_tracking(name):
         return _wrapper
 
     track_current_drop.tlocal = current_object
+    logger.debug(
+        ">>>> Inside track_current_drop: %s humanKey: %s",
+        current_object,
+        (
+            current_object._humanKey
+            if hasattr(current_object, name)
+            and hasattr(getattr(current_object, name), "_humanKey")
+            else "unknown"
+        ),
+    )
     return track_current_drop
 
 

--- a/daliuge-common/dlg/utils.py
+++ b/daliuge-common/dlg/utils.py
@@ -351,23 +351,7 @@ def object_tracking(name):
                 previous = None
 
             setattr(current_object, name, args[0])
-            logger.debug(
-                ">>>> Inside track_current_drop: %s humanKey: %s",
-                current_object,
-                (
-                    args[0]._humanKey
-                    if hasattr(getattr(current_object, name), "_humanKey")
-                    else "unknown"
-                ),
-            )
             try:
-                if "self" in kwargs:
-                    kwargs.pop("self")
-                logger.debug(
-                    ">>>> Inside track_current_drop: %s, %s",
-                    f,
-                    hasattr(current_object, name),
-                )
                 return f(*args, **kwargs)
             finally:
                 setattr(current_object, name, previous)
@@ -375,16 +359,6 @@ def object_tracking(name):
         return _wrapper
 
     track_current_drop.tlocal = current_object
-    logger.debug(
-        ">>>> Inside track_current_drop: %s humanKey: %s",
-        current_object,
-        (
-            current_object._humanKey
-            if hasattr(current_object, name)
-            and hasattr(getattr(current_object, name), "_humanKey")
-            else "unknown"
-        ),
-    )
     return track_current_drop
 
 

--- a/daliuge-engine/dlg/apps/app_base.py
+++ b/daliuge-engine/dlg/apps/app_base.py
@@ -285,8 +285,8 @@ class AppDROP(ContainerDROP):
             self.name,
             "FINISHED" if not is_error else "ERROR",
         )
-        self.completedrop()
         self._fire("producerFinished", status=self.status, execStatus=self.execStatus)
+        self.completedrop()
 
     def cancel(self):
         """Moves this application drop to its CANCELLED state"""

--- a/daliuge-engine/dlg/apps/app_base.py
+++ b/daliuge-engine/dlg/apps/app_base.py
@@ -22,7 +22,7 @@ from dlg.meta import (
     dlg_int_param,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class DropRunner(ABC):
@@ -483,14 +483,13 @@ class InputFiredAppDROP(AppDROP):
                 if logger.getEffectiveLevel() != logging.getLevelName(
                     self._global_log_level
                 ):
+                    logging.getLogger("dlg").setLevel(self._global_log_level)
                     logger.warning(
                         "Setting log-level after execution %s.%s back to %s",
                         self.name,
                         self._humanKey,
                         self._global_log_level,
                     )
-                    # logging.getLogger("dlg").setLevel(self._global_log_level)
-                    logger.setLevel(self._global_log_level)
                 break
             except:
                 if self.execStatus == AppDROPStates.CANCELLED:

--- a/daliuge-engine/dlg/apps/archiving.py
+++ b/daliuge-engine/dlg/apps/archiving.py
@@ -33,7 +33,7 @@ from ..meta import (
     dlg_streaming_input,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ExternalStoreApp(BarrierAppDROP):

--- a/daliuge-engine/dlg/apps/archiving.py
+++ b/daliuge-engine/dlg/apps/archiving.py
@@ -81,6 +81,13 @@ class ExternalStoreApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param ngasSrv localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/URL of the NGAS Server
+# @param ngasPort 7777/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/"TCP/IP Port on the NGAS Server"
+# @param ngasMime "application/octet-stream"/String/ApplicationArgument/NoPort/ReadWrite//False/False/Mime-type of the NGAS payload
+# @param ngasTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/Archiving request timeout
+# @param ngasConnectTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/NGAS Server connection timeout
+# @param fileObject /Object.File/ApplicationArgument/InputPort/ReadWrite//False/False/Input File Object
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.archiving.NgasArchivingApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name archiving/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -88,14 +95,6 @@ class ExternalStoreApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param ngasSrv localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/URL of the NGAS Server
-# @param ngasPort 7777/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/"TCP/IP Port on the NGAS Server"
-# @param ngasMime "application/octet-stream"/String/ApplicationArgument/NoPort/ReadWrite//False/False/Mime-type of the NGAS payload
-# @param ngasTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/Archiving request timeout
-# @param ngasConnectTimeout 2/Integer/ApplicationArgument/NoPort/ReadOnly//False/False/NGAS Server connection timeout
-# @param fileObject /Object.File/ApplicationArgument/InputPort/ReadWrite//False/False/Input File Object
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class NgasArchivingApp(ExternalStoreApp):
     """

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -377,6 +377,7 @@ class StreamingInputBashAppBase(BashShellBase, AppDROP):
 # @param command_line_arguments /String/ComponentParameter/NoPort/ReadWrite//False/False/Additional command line arguments to be added to the command line to be executed
 # @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters on the command line
 # @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.bash_shell_app.BashShellApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name bash_shell_app/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -384,8 +385,6 @@ class StreamingInputBashAppBase(BashShellBase, AppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class BashShellApp(BashShellBase, BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/bash_shell_app.py
+++ b/daliuge-engine/dlg/apps/bash_shell_app.py
@@ -59,7 +59,7 @@ from ..meta import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def message_stdouts(prefix, stdout, stderr, enc="utf8"):

--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -9,6 +9,10 @@ from dlg.exceptions import InvalidDropException
 # @par EAGLE_START
 # @param category Branch
 # @param tag template
+# @param dummy_input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/Dummy input port
+# @param true /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/True condition output port
+# @param false /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/False condition output port
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.branch.BranchAppDrop/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -16,11 +20,6 @@ from dlg.exceptions import InvalidDropException
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dummy_input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/Dummy input port
-# @param true /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/True condition output port
-# @param false /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/False condition output port
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class BranchAppDrop(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/branch.py
+++ b/daliuge-engine/dlg/apps/branch.py
@@ -9,7 +9,7 @@ from dlg.exceptions import InvalidDropException
 # @par EAGLE_START
 # @param category Branch
 # @param tag template
-# @param dropclass dlg.apps.simple.SimpleBranch/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
+# @param dropclass dlg.apps.branch.BranchAppDrop/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used

--- a/daliuge-engine/dlg/apps/crc.py
+++ b/daliuge-engine/dlg/apps/crc.py
@@ -85,17 +85,15 @@ class CRCApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param data /String/ApplicationArgument/OutputPort/ReadWrite//False/False/Input data stream
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.crc.CRCStreamApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name crc/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
-# @param output_parser pickle/Select/ApplicationArgument/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param data /String/ApplicationArgument/OutputPort/ReadWrite//False/False/Input data stream
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class CRCStreamApp(AppDROP):
     """

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -45,7 +45,7 @@ from dlg.apps.app_base import BarrierAppDROP
 from dlg.exceptions import DaliugeException, InvalidDropException
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 DLG_ROOT = utils.getDlgDir()
 

--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -89,6 +89,7 @@ class ContainerIpWaiter(object):
 # @param entrypoint /String/ComponentParameter/NoPort/ReadWrite//False/False/Alternate entrypoint
 # @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters and their respective values on the command line
 # @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.dockerapp.DockerApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name dockerapp/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -101,8 +102,6 @@ class ContainerIpWaiter(object):
 # @param removeContainer True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Instruct Docker engine to delete the container after execution is complete
 # @param additionalBindings /String/ComponentParameter/NoPort/ReadWrite//False/False/Directories which will be visible inside the container during run-time. Format is srcdir_on_host:trgtdir_on_container. Multiple entries can be separated by commas.
 # @param portMappings /String/ComponentParameter/NoPort/ReadWrite//False/False/Port mappings on the host machine
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class DockerApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -32,7 +32,7 @@ from ..ddap_protocol import AppDROPStates
 from ..apps.app_base import AppDROP, BarrierAppDROP
 from ..exceptions import InvalidDropException
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 _read_cb_type = ctypes.CFUNCTYPE(
     ctypes.c_size_t, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t

--- a/daliuge-engine/dlg/apps/dynlib.py
+++ b/daliuge-engine/dlg/apps/dynlib.py
@@ -370,6 +370,7 @@ class DynlibStreamApp(DynlibAppBase, AppDROP):
 # @param category DynlibApp
 # @param tag template
 # @param libpath /String/ComponentParameter/NoPort/ReadWrite//False/False/"The location of the shared object/DLL that implements this application"
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.dynlib.DynlibApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name dynlib/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -377,8 +378,6 @@ class DynlibStreamApp(DynlibAppBase, AppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class DynlibApp(DynlibAppBase, BarrierAppDROP):
     """Loads a dynamic library into the current process and runs it"""
@@ -466,15 +465,14 @@ def get_from_subprocess(proc, q):
 # @param category DynlibProcApp
 # @param tag template
 # @param libpath /String/ComponentParameter/NoPort/ReadWrite//False/False/"The location of the shared object/DLL that implements this application"
+# @param dropclass dlg.apps.dynlib.DynlibProcApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dropclass dlg.apps.dynlib.DynlibProcApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name dynlib/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class DynlibProcApp(BarrierAppDROP):
     """Loads a dynamic library in a different process and runs it"""

--- a/daliuge-engine/dlg/apps/mpi.py
+++ b/daliuge-engine/dlg/apps/mpi.py
@@ -56,14 +56,13 @@ logger = logging.getLogger(__name__)
 # @param output_redirection /String/ComponentParameter/NoPort/ReadWrite//False/False/The command line argument that specifies the output from this application
 # @param paramValueSeparator " "/String/ComponentParameter/NoPort/ReadWrite//False/False/Separator character(s) between parameters on the command line
 # @param argumentPrefix "--"/String/ComponentParameter/NoPort/ReadWrite//False/False/Prefix to each keyed argument on the command line
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.mpi.MPIApp/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class MPIApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/mpi.py
+++ b/daliuge-engine/dlg/apps/mpi.py
@@ -39,7 +39,7 @@ from ..meta import (
     dlg_enum_param,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 ##

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -630,7 +630,8 @@ class PyFuncApp(BarrierAppDROP):
             raise InvalidDropException(
                 self, "No function specified (either via name or code)"
             )
-
+        self.name = f"{self.name}:{self.func_name}"  # PyFuncApp is parent
+        logger.debug("AppDROP name: %s", self.name)
         # Lookup function or import bytecode as a function
         if not self.func_code:
             self.func = import_using_name(self, self.func_name)

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -741,7 +741,7 @@ class PyFuncApp(BarrierAppDROP):
                 drop_uid, drop_port = list(outport.items())[0]
                 if drop_uid == output_drop.uid and drop_port in component_params:
                     param_enc = component_params[drop_port]["encoding"]
-                    encoding = param_enc if param_enc else encoding
+                    encoding = param_enc or encoding
         return DropParser(encoding) if encoding else self.output_parser
 
     def write_results(self, result):

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -178,6 +178,7 @@ def import_using_code(func_code: str, func_name: str, serialized: bool = True):
 # @param tag daliuge
 # @param func_name object.__init__/String/ComponentParameter/NoPort/ReadWrite//False/False/Python function name
 # @param func_code /String/ComponentParameter/NoPort/ReadWrite//False/False/Python function code, e.g. 'def f(args): return args'. Function name has to be 'f'!
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.pyfunc.PyFuncApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name Object/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param self /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Port exposing the object
@@ -186,8 +187,6 @@ def import_using_code(func_code: str, func_name: str, serialized: bool = True):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/The allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 #     \~English Mapping from argname to default value. Should match only the last part of the argnames list.
 #               Values are interpreted as Python code literals and that means string values need to be quoted.
 # @par EAGLE_END
@@ -210,6 +209,7 @@ class PyMemberApp(BarrierAppDROP):
 # @param tag template
 # @param func_name /String/ComponentParameter/NoPort/ReadWrite//False/False/Python function name
 # @param func_code /String/ComponentParameter/NoPort/ReadWrite//False/False/Python function code, e.g. 'def func_name(args): return args'. Note that func_name above needs to match the defined name here.
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.pyfunc.PyFuncApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name pyfunc/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -217,8 +217,6 @@ class PyMemberApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/The allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 #     \~English Mapping from argname to default value. Should match only the last part of the argnames list.
 #               Values are interpreted as Python code literals and that means string values need to be quoted.
 # @par EAGLE_END

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -60,7 +60,8 @@ from dlg.meta import (
 )
 from dlg.pyext import pyext
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger("dlg." + __name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def serialize_func(f):

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -39,7 +39,7 @@ from io import StringIO
 from contextlib import redirect_stdout
 
 from dlg import drop_loaders
-from dlg.utils import serialize_data, deserialize_data, object_tracking
+from dlg.utils import serialize_data, deserialize_data
 from dlg.named_port_utils import (
     DropParser,
     check_ports_dict,
@@ -61,7 +61,6 @@ from dlg.meta import (
 from dlg.pyext import pyext
 
 logger = logging.getLogger(__name__)
-track_current_drop = object_tracking("drop")
 
 
 def serialize_func(f):
@@ -266,7 +265,6 @@ class PyFuncApp(BarrierAppDROP):
     input_parser = dlg_enum_param(DropParser, "input_parser", DropParser.DILL)
     output_parser = dlg_enum_param(DropParser, "output_parser", DropParser.DILL)
 
-    @track_current_drop
     def _mixin_func_defaults(self):
         """
         func_defaults can be passed in through an argument, but this is only used for
@@ -310,7 +308,6 @@ class PyFuncApp(BarrierAppDROP):
         logger.debug("func_defaults %s", self.func_defaults)
         self.fn_defaults.update(self.func_defaults)
 
-    @track_current_drop
     def _init_fn_defaults(self):
         """
         Inititalize self.fn_defaults dictionary from values provided.
@@ -361,7 +358,6 @@ class PyFuncApp(BarrierAppDROP):
         logger.debug("Got default values for arguments %s", self.arguments_defaults)
         logger.debug(f"initialized fn_defaults with {self.fn_defaults}")
 
-    @track_current_drop
     def _clean_applicationArgs(self):
         """
         remove function definition arguments in applicationArgs
@@ -387,7 +383,6 @@ class PyFuncApp(BarrierAppDROP):
                     # only transfer if there is a value or precious is True
                     self._applicationArgs.pop(kw)
 
-    @track_current_drop
     def _initialise_positional_args(self, argsDict: dict):
         """
         Ensure default arguments are properly setup.
@@ -406,7 +401,6 @@ class PyFuncApp(BarrierAppDROP):
 
         return argsDict
 
-    @track_current_drop
     def _get_arg_info(self, arg):
 
         value = self._applicationArgs[arg]["value"]
@@ -414,7 +408,6 @@ class PyFuncApp(BarrierAppDROP):
 
         return value, encoding
 
-    @track_current_drop
     def _init_appArgs(self, pargsDict: dict, keyargsDict: dict, posargs: list) -> list:
         """
         Identify and fill application arguments.
@@ -505,7 +498,6 @@ class PyFuncApp(BarrierAppDROP):
 
         return [funcargs, pargs]
 
-    @track_current_drop
     def _ports2args(self, posargs, pargsDict, keyargsDict) -> dict:
         """
         Replace arguments with values from ports.
@@ -565,7 +557,6 @@ class PyFuncApp(BarrierAppDROP):
         )
         return portargs
 
-    @track_current_drop
     def initialize_with_func_code(self):
         """
         This function takes over if code is passed in through an argument.
@@ -596,7 +587,6 @@ class PyFuncApp(BarrierAppDROP):
         if isinstance(self.func_arg_mapping, str):
             self.func_arg_mapping = ast.literal_eval(self.func_arg_mapping)
 
-    @track_current_drop
     def initialize(self, **kwargs):
         """
         The initialization of a function component is mainly dealing with mapping
@@ -659,7 +649,6 @@ class PyFuncApp(BarrierAppDROP):
         logger.debug(f"Input mapping provided: {self.func_arg_mapping}")
         self._recompute_data = {}
 
-    @track_current_drop
     def run(self):
         """
         Function positional and keyword argument treatment:
@@ -766,7 +755,6 @@ class PyFuncApp(BarrierAppDROP):
                     encoding = param_enc or encoding
         return DropParser(encoding) if encoding else self.output_parser
 
-    @track_current_drop
     def write_results(self, result):
         from dlg.droputils import listify
 

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -42,6 +42,11 @@ from dlg.meta import (
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param remoteUser /String/ApplicationArgument/NoPort/ReadWrite//False/False/Remote user address
+# @param pkeyPath /String/ApplicationArgument/NoPort/ReadWrite//False/False/Private key path
+# @param timeout 60/Float/ApplicationArgument/NoPort/ReadWrite//False/False/Connection timeout in seconds
+# @param file /Object.PathBasedDrop/ApplicationArgument/InputOutput/ReadWrite//False/False/File path
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.scp.ScpApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name scp/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -49,12 +54,6 @@ from dlg.meta import (
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param remoteUser /String/ApplicationArgument/NoPort/ReadWrite//False/False/Remote user address
-# @param pkeyPath /String/ApplicationArgument/NoPort/ReadWrite//False/False/Private key path
-# @param timeout 60/Float/ApplicationArgument/NoPort/ReadWrite//False/False/Connection timeout in seconds
-# @param file /Object.PathBasedDrop/ApplicationArgument/InputOutput/ReadWrite//False/False/File path
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class ScpApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -31,7 +31,7 @@ import logging
 import time
 import numpy as np
 
-from dlg import drop, droputils, drop_loaders
+from dlg import droputils, drop_loaders
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.apps.pyfunc import PyFuncApp
 from dlg.data.drops.container import ContainerDROP
@@ -51,10 +51,8 @@ from dlg.meta import (
 )
 from dlg.exceptions import DaliugeException
 from dlg.rpc import DropProxy
-from dlg.utils import object_tracking
 
-track_current_drop = object_tracking("drop")
-logger = logging.getLogger("dlg")
+logger = logging.getLogger("__name__")
 
 
 class NullBarrierApp(BarrierAppDROP):
@@ -687,16 +685,7 @@ class HelloWorldApp(BarrierAppDROP):
 
     greet = dlg_string_param("greet", "World")
 
-    @track_current_drop
     def run(self):
-        logger.info("Internal logger: %s", logger.name)
-        logger.info(
-            "log-level for %s.%s: %s",
-            self.name,
-            self._humanKey,
-            # track_current_drop.tlocal.drop._humanKey,
-            self._log_level,
-        )
         ins = self.inputs
         # if no inputs use the parameter else use the input
         if len(ins) == 0:

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -31,7 +31,7 @@ import logging
 import time
 import numpy as np
 
-from dlg import droputils, drop_loaders
+from dlg import drop, droputils, drop_loaders
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.apps.pyfunc import PyFuncApp
 from dlg.data.drops.container import ContainerDROP
@@ -51,9 +51,10 @@ from dlg.meta import (
 )
 from dlg.exceptions import DaliugeException
 from dlg.rpc import DropProxy
+from dlg.utils import object_tracking
 
-
-logger = logging.getLogger(__name__)
+track_current_drop = object_tracking("drop")
+logger = logging.getLogger("dlg")
 
 
 class NullBarrierApp(BarrierAppDROP):
@@ -655,7 +656,6 @@ class GenericNpyGatherApp(BarrierAppDROP):
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
-# @param hello "world"/Object/ApplicationArgument/OutputPort/ReadWrite//False/False/message
 # @par EAGLE_END
 class HelloWorldApp(BarrierAppDROP):
     """
@@ -675,14 +675,15 @@ class HelloWorldApp(BarrierAppDROP):
     )
 
     greet = dlg_string_param("greet", "World")
-    _log_level = dlg_string_param("log_level", "DEBUG")
 
+    @track_current_drop
     def run(self):
         logger.info("Internal logger: %s", logger.name)
         logger.info(
             "log-level for %s.%s: %s",
             self.name,
             self._humanKey,
+            # track_current_drop.tlocal.drop._humanKey,
             self._log_level,
         )
         ins = self.inputs

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -103,8 +103,6 @@ class PythonApp(BarrierAppDROP):
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 
 
@@ -159,8 +157,6 @@ class SleepApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class CopyApp(BarrierAppDROP):
     """
@@ -217,8 +213,6 @@ class CopyApp(BarrierAppDROP):
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class SleepAndCopyApp(SleepApp, CopyApp):
     """A combination of the SleepApp and the CopyApp. It sleeps, then copies"""
@@ -247,8 +241,6 @@ class SleepAndCopyApp(SleepApp, CopyApp):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param array /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/random array
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class RandomArrayApp(BarrierAppDROP):
     """
@@ -327,8 +319,6 @@ class RandomArrayApp(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param array /Object.Array/ApplicationArgument/InputOutput/ReadWrite//False/False/Port for the array(s)
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class AverageArraysApp(BarrierAppDROP):
     """
@@ -423,8 +413,6 @@ class AverageArraysApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/0-base placeholder port for inputs
 # @param output /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Placeholder port for outputs
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class GenericGatherApp(BarrierAppDROP):
     component_meta = dlg_component(
@@ -469,8 +457,6 @@ class GenericGatherApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input /Object/ApplicationArgument/InputPort/ReadWrite//False/False/0-base placeholder port for inputs
 # @param output /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Placeholder port for outputs
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class DictGatherApp(BarrierAppDROP):
     component_meta = dlg_component(
@@ -523,8 +509,6 @@ class DictGatherApp(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input /Object/ComponentParameter/InputPort/ReadWrite//False/False/0-base placeholder port for inputs
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class ArrayGatherApp(BarrierAppDROP):
     component_meta = dlg_component(
@@ -572,8 +556,6 @@ class ArrayGatherApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/Port for the input array(s)
 # @param array_out /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/reduced array
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class GenericNpyGatherApp(BarrierAppDROP):
     """
@@ -673,8 +655,6 @@ class GenericNpyGatherApp(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param hello "world"/Object/ApplicationArgument/OutputPort/ReadWrite//False/False/message
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class HelloWorldApp(BarrierAppDROP):
     """
@@ -731,8 +711,6 @@ class HelloWorldApp(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param content /String/ApplicationArgument/OutputPort/ReadWrite//False/False/content read from URL
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class UrlRetrieveApp(BarrierAppDROP):
     """
@@ -789,8 +767,6 @@ class UrlRetrieveApp(BarrierAppDROP):
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class GenericScatterApp(BarrierAppDROP):
     """
@@ -860,8 +836,6 @@ class GenericScatterApp(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/A numpy array of arrays
 # @param array_out /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/reduced array
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class GenericNpyScatterApp(BarrierAppDROP):
     """
@@ -929,8 +903,6 @@ class GenericNpyScatterApp(BarrierAppDROP):
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
-# @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/The allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
-# @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
 # @par EAGLE_END
 class Branch(PyFuncApp):
 
@@ -972,8 +944,6 @@ class Branch(PyFuncApp):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param rest_array /Object.array/ApplicationArgument/InputOutput/ReadWrite//False/False/List of elements
 # @param element /Object.element/ApplicationArgument/OutputPort/ReadWrite//False/False/first element
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class PickOne(BarrierAppDROP):
     """
@@ -1034,8 +1004,6 @@ class PickOne(BarrierAppDROP):
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param array /Object.Array/ApplicationArgument/OutputPort/ReadWrite//False/False/random array
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class ListAppendThrashingApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -884,6 +884,23 @@ class GenericNpyScatterApp(BarrierAppDROP):
                 drop_loaders.save_numpy(self.outputs[out_index], result[split_index])
 
 
+class SimpleBranch(BranchAppDrop, NullBarrierApp):
+    """
+    Simple branch app that is told the result of its condition.
+    We are keeping this not to break existing graphs.
+    """
+
+    def initialize(self, **kwargs):
+        self.result = self._popArg(kwargs, "result", True)
+        BranchAppDrop.initialize(self, **kwargs)
+
+    def run(self):
+        pass
+
+    def condition(self):
+        return self.result
+
+
 ##
 # @brief Branch
 # @details A branch application that copies the input to either the 'true' or the 'false' output depending on the result of

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -884,6 +884,7 @@ class GenericNpyScatterApp(BarrierAppDROP):
                 drop_loaders.save_numpy(self.outputs[out_index], result[split_index])
 
 
+##
 # @brief Branch
 # @details A branch application that copies the input to either the 'true' or the 'false' output depending on the result of
 # the provided conditional function. The conditional function can be specified either in-line or as an external function and has
@@ -895,7 +896,7 @@ class GenericNpyScatterApp(BarrierAppDROP):
 # @param category Branch
 # @param tag daliuge
 # @param func_name condition/String/ComponentParameter/NoPort/ReadWrite//False/False/Python conditional function name. This can also be a valid import path to an importable function.
-# @param func_code /String/ComponentParameter/NoPort/ReadWrite//False/False/Python function code for the branch condition, e.g. 'def condition(x): return (x > 0)'. Note that func_name above needs to match the defined name here.
+# @param func_code condition(x): return (x > 0)/String/ComponentParameter/NoPort/ReadWrite//False/False/Python function code for the branch condition. Modify as required. Note that func_name above needs to match the defined name here.
 # @param x /Object/ComponentParameter/InputPort/ReadWrite//False/False/Port carrying the input which is also used in the condition function. Note that the name of the parameter has to match the argument of the condition function.
 # @param true  /Object/ComponentParameter/OutputPort/ReadWrite//False/False/If condition is true the input will be copied to this port
 # @param false /Object/ComponentParameter/OutputPort/ReadWrite//False/False/If condition is false the input will be copied to this port
@@ -906,6 +907,14 @@ class GenericNpyScatterApp(BarrierAppDROP):
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @par EAGLE_END
 class Branch(PyFuncApp):
+    """
+    A branch application that copies the input to either the 'true' or the 'false' output depending on the result of
+    the provided conditional function. The conditional function can be specified either in-line or as an external function and has
+    to return a boolean value.
+    The inputs of the application are passed on as arguments to the conditional function. The conditional function needs to return
+    a boolean value, but the application will copy the input data to the true or false output, depending on the result of the
+    conditional function.
+    """
 
     bufsize = dlg_int_param("bufsize", 65536)
 

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -79,6 +79,7 @@ class NullBarrierApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag template
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.PythonApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
@@ -100,6 +101,7 @@ class PythonApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param sleep_time 5/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/The number of seconds to sleep
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.SleepApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -152,6 +154,7 @@ class SleepApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param bufsize 65536/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Buffer size
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.CopyApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -210,6 +213,7 @@ class CopyApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param sleep_time 5/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/The number of seconds to sleep
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.SleepAndCopyApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -237,6 +241,7 @@ class SleepAndCopyApp(SleepApp, CopyApp):
 # @param low 0/Float/ApplicationArgument/NoPort/ReadWrite//False/False/Low value of range in array [inclusive]
 # @param high 1/Float/ApplicationArgument/NoPort/ReadWrite//False/False/High value of range of array [exclusive]
 # @param integer True/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/Generate integer array?
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.RandomArrayApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -315,6 +320,7 @@ class RandomArrayApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param method mean/Select/ApplicationArgument/NoPort/ReadWrite/mean,median/False/False/The method used for averaging
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.AverageArraysApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -408,6 +414,7 @@ class AverageArraysApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param num_of_inputs 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/The Gather width, stating how many inputs each Gather instance will handle
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.GenericGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -451,7 +458,8 @@ class GenericGatherApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param value_dict value_dict/Jasom/ApplicationArgument/NoPort/ReadWrite//False/False/The value dictionary can be initialized here
+# @param value_dict value_dict/Jason/ApplicationArgument/NoPort/ReadWrite//False/False/The value dictionary can be initialized here
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.DictGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -505,6 +513,7 @@ class DictGatherApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param value_array value_array/array/ApplicationArgument/OutputPort/ReadWrite//False/False/The value array can be initialized here
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.ArrayGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -551,6 +560,7 @@ class ArrayGatherApp(BarrierAppDROP):
 # @param num_of_inputs 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/The Gather width, stating how many inputs each Gather instance will handle
 # @param function sum/Select/ApplicationArgument/NoPort/ReadWrite/sum,prod,min,max,add,multiply,maximum,minimum/False/False/The function used for gathering
 # @param reduce_axes None/String/ApplicationArgument/NoPort/ReadOnly//False/False/The array axes to reduce, None reduces all axes for sum, prod, max, min functions
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.GenericNpyGatherApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -651,6 +661,7 @@ class GenericNpyGatherApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param greet World/String/ApplicationArgument/NoPort/ReadWrite//False/False/What appears after 'Hello '
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.HelloWorldApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -716,6 +727,7 @@ class HelloWorldApp(BarrierAppDROP):
 # @param category PythonApp
 # @param tag daliuge
 # @param url None/String/ApplicationArgument/NoPort/ReadWrite//False/False/The URL to retrieve
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.UrlRetrieveApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -772,9 +784,10 @@ class UrlRetrieveApp(BarrierAppDROP):
 # @param array_in /Object.Array/ApplicationArgument/InputPort/ReadWrite//False/False/A numpy array of arrays, where the first axis is of length <numSplit>
 # @param object_out /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/reduced array or single element, depending on element flag.
 # @param element False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/if True the outputs of each of the splits will be the first element of the split array, rather than the split array.
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
@@ -841,6 +854,8 @@ class GenericScatterApp(BarrierAppDROP):
 # @param num_of_copies 4/Integer/ConstructParameter/NoPort/ReadWrite//False/False/Specifies the number of replications of the content of the scatter construct
 # @param scatter_axes /String/ApplicationArgument/NoPort/ReadWrite//False/False/The axes to split input ndarrays on, e.g. [0,0,0], length must match the number of input ports
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param dropclass dlg.apps.simple.GenericNpyScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -927,6 +942,8 @@ class SimpleBranch(BranchAppDrop, NullBarrierApp):
 # @param x /Object/ComponentParameter/InputPort/ReadWrite//False/False/Port carrying the input which is also used in the condition function. Note that the name of the parameter has to match the argument of the condition function.
 # @param true  /Object/ComponentParameter/OutputPort/ReadWrite//False/False/If condition is true the input will be copied to this port
 # @param false /Object/ComponentParameter/OutputPort/ReadWrite//False/False/If condition is false the input will be copied to this port
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param dropclass dlg.apps.simple.Branch/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -980,6 +997,8 @@ class Branch(PyFuncApp):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param dropclass dlg.apps.simple.PickOne/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -1041,6 +1060,8 @@ class PickOne(BarrierAppDROP):
 # @param category PythonApp
 # @param tag test
 # @param size 100/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/the size of the array
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param dropclass dlg.apps.simple.ListAppendThrashingApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -20,6 +20,7 @@
 #    MA 02111-1307  USA
 #
 """Applications used as examples, for testing, or in simple situations"""
+import dill
 import _pickle
 from numbers import Number
 import pickle
@@ -925,7 +926,10 @@ class Branch(PyFuncApp):
         self.outputs[1 if result else 0].skip()  # send skip to correct branch
 
         output = self.outputs[0 if result else 1]
-        droputils.copyDropContents(self.inputs[0], output, bufsize=self.bufsize)
+        if self.inputs:
+            droputils.copyDropContents(self.inputs[0], output, bufsize=self.bufsize)
+        else:
+            output.write(dill.dumps(result))
 
 
 ##

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -675,8 +675,16 @@ class HelloWorldApp(BarrierAppDROP):
     )
 
     greet = dlg_string_param("greet", "World")
+    _log_level = dlg_string_param("log_level", "DEBUG")
 
     def run(self):
+        logger.info("Internal logger: %s", logger.name)
+        logger.info(
+            "log-level for %s.%s: %s",
+            self.name,
+            self._humanKey,
+            self._log_level,
+        )
         ins = self.inputs
         # if no inputs use the parameter else use the input
         if len(ins) == 0:
@@ -689,6 +697,7 @@ class HelloWorldApp(BarrierAppDROP):
             except _pickle.UnpicklingError:
                 phrase = str(droputils.allDropContents(ins[0]), encoding="utf-8")
             self.greeting = f"Hello {phrase}"
+        logger.debug("Greeting is %s", self.greeting)
 
         outs = self.outputs
         if len(outs) < 1:

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -52,7 +52,8 @@ from dlg.meta import (
 from dlg.exceptions import DaliugeException
 from dlg.rpc import DropProxy
 
-logger = logging.getLogger("__name__")
+# logger = logging.getLogger("__name__")
+logger = logging.getLogger("dlg." + __name__)
 
 
 class NullBarrierApp(BarrierAppDROP):

--- a/daliuge-engine/dlg/apps/simple_functions.py
+++ b/daliuge-engine/dlg/apps/simple_functions.py
@@ -64,17 +64,18 @@ def createMultiOut(v1: Any = 1, v2: Any = 7) -> tuple:
     out2 = v2
     return out1, out2
 
-def getMax(v1: float=1.0, v2: float=7.0) -> float:
-    """
-    Return the largest float of two different values. 
 
-    Inputs: 
+def getMax(v1: float = 1.0, v2: float = 7.0) -> float:
+    """
+    Return the largest float of two different values.
+
+    Inputs:
         v1: value 1
-        v2: value 2 
+        v2: value 2
 
     Returns:
         max(v1, v2)
-    """    
+    """
     return max(v1, v2)
 
 

--- a/daliuge-engine/dlg/apps/socket_listener.py
+++ b/daliuge-engine/dlg/apps/socket_listener.py
@@ -56,6 +56,12 @@ logger = logging.getLogger(__name__)
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param host localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/Host address
+# @param port 1111/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Host port
+# @param bufsize 4096/String/ApplicationArgument/NoPort/ReadWrite//False/False/Receive buffer size
+# @param reuseAddr False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/
+# @param data /String/ComponentParameter/OutputPort/ReadWrite//False/False/
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.socket_listener.SocketListener/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name socket_listener/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
@@ -63,13 +69,6 @@ logger = logging.getLogger(__name__)
 # @param group_start False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the start of a group?
 # @param input_error_threshold 0/Integer/ComponentParameter/NoPort/ReadWrite//False/False/the allowed failure rate of the inputs (in percent), before this component goes to ERROR state and is not executed
 # @param n_tries 1/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Specifies the number of times the 'run' method will be executed before finally giving up
-# @param host localhost/String/ApplicationArgument/NoPort/ReadWrite//False/False/Host address
-# @param port 1111/Integer/ApplicationArgument/NoPort/ReadWrite//False/False/Host port
-# @param bufsize 4096/String/ApplicationArgument/NoPort/ReadWrite//False/False/Receive buffer size
-# @param reuseAddr False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/
-# @param data /String/ApplicationArgument/OutputPort/ReadWrite//False/False/
-# @param input_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Input port parsing technique
-# @param output_parser pickle/Select/ComponentParameter/NoPort/ReadWrite/raw,pickle,eval,npy,path,dataurl/False/False/Output port parsing technique
 # @par EAGLE_END
 class SocketListenerApp(BarrierAppDROP):
     """

--- a/daliuge-engine/dlg/apps/socket_listener.py
+++ b/daliuge-engine/dlg/apps/socket_listener.py
@@ -41,7 +41,7 @@ from ..meta import (
     dlg_streaming_input,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 ##

--- a/daliuge-engine/dlg/apps/subgraph.py
+++ b/daliuge-engine/dlg/apps/subgraph.py
@@ -44,8 +44,8 @@ def shutdownManager(managers: dict) -> None:
     :return:
     """
     for manager in managers.values():
-        manager['manager'].shutdown()
-        manager['server'].stop()
+        manager["manager"].shutdown()
+        manager["server"].stop()
 
 
 def startupManagersInThread(managers: dict) -> None:
@@ -57,8 +57,7 @@ def startupManagersInThread(managers: dict) -> None:
     """
     for manager in managers.values():
         thread = threading.Thread(
-            target=manager['server'].start,
-            args=(manager['host'], manager['port'])
+            target=manager["server"].start, args=(manager["host"], manager["port"])
         )
         thread.start()
 
@@ -68,6 +67,8 @@ def startupManagersInThread(managers: dict) -> None:
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
+# @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
+# @param dropclass dlg.apps.simple.GenericScatterApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param dropclass dlg.apps.subgraph.SubGraphLocal/String/ComponentParameter/NoPort/ReadOnly//False/False/
 # @param execution_time 5/Float/ConstraintParameter/NoPort/ReadOnly//False/False/Estimated execution time
 # @param num_cpus 1/Integer/ConstraintParameter/NoPort/ReadOnly//False/False/Number of cores used
@@ -106,7 +107,7 @@ class SubGraphLocal(BarrierAppDROP):
         self._session_prefix = self._popArg(kwargs, "session_prefix", "subgraph")
 
     def _pollRESTInterface(
-            self, manager: DROPManager, session: str, pollFrequencyInSeconds: int = 30
+        self, manager: DROPManager, session: str, pollFrequencyInSeconds: int = 30
     ):
         """
         Check the completion status of each drop in the SubGraph.
@@ -156,30 +157,32 @@ class SubGraphLocal(BarrierAppDROP):
         either successfully completed or failed.
         """
         managers = {
-            'node': {
-                'manager': NodeManager(
+            "node": {
+                "manager": NodeManager(
                     self._nodeManagerHost, rpc_port=6667, events_port=5556
                 ),
-                'port': self._nm_port,
-                'host': self._nodeManagerHost
+                "port": self._nm_port,
+                "host": self._nodeManagerHost,
             },
-            'dim': {
-                'manager': DataIslandManager([self._nodeManagerHost]),
-                'port': self._dim_port,
-                'host': self._islandManagerHost,
-            }
+            "dim": {
+                "manager": DataIslandManager([self._nodeManagerHost]),
+                "port": self._dim_port,
+                "host": self._islandManagerHost,
+            },
         }
-        managers['node']['server'] = NMRestServer(managers['node'])
-        managers['dim']['server'] = CompositeManagerRestServer(managers['dim'])
+        managers["node"]["server"] = NMRestServer(managers["node"])
+        managers["dim"]["server"] = CompositeManagerRestServer(managers["dim"])
         startupManagersInThread(managers)
 
         nodes = [self._islandManagerHost, self._nodeManagerHost]
         try:
-            session = self._translateAndDeploySubGraph(managers['dim']['manager'], nodes)
+            session = self._translateAndDeploySubGraph(
+                managers["dim"]["manager"], nodes
+            )
             while not self._pollRESTInterface(
-                    manager=managers['dim']['manager'],
-                    session=session,
-                    pollFrequencyInSeconds=10
+                manager=managers["dim"]["manager"],
+                session=session,
+                pollFrequencyInSeconds=10,
             ):
                 logger.info("Running SubGraph externally")
 
@@ -219,5 +222,6 @@ class SubGraphLocal(BarrierAppDROP):
         :return: A string prefix
         """
         ts = time.time()
-        return (f"{self._session_prefix}_"
-                + datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d_%H-%M-%S'))
+        return f"{self._session_prefix}_" + datetime.datetime.fromtimestamp(
+            ts
+        ).strftime("%Y-%m-%d_%H-%M-%S")

--- a/daliuge-engine/dlg/dask_emulation.py
+++ b/daliuge-engine/dlg/dask_emulation.py
@@ -40,7 +40,7 @@ from .ddap_protocol import DROPStates
 from .apps.app_base import BarrierAppDROP
 from .exceptions import InvalidDropException
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ResultTransmitter(BarrierAppDROP):
@@ -63,7 +63,7 @@ class ResultTransmitter(BarrierAppDROP):
             except EOFError:
                 content = None
             return content
-        
+
         results = map(read_result, self.inputs)  # @UndefinedVariable
         results = list(results)
         if len(self.inputs) == 1:
@@ -72,7 +72,9 @@ class ResultTransmitter(BarrierAppDROP):
 
         s = socket.socket()
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
-        logger.debug("Attempting to bind ResultTransmitter to %s:%i", self.host, self.port)
+        logger.debug(
+            "Attempting to bind ResultTransmitter to %s:%i", self.host, self.port
+        )
         s.bind((self.host, self.port))
         s.listen(1)
         client, _ = s.accept()
@@ -285,7 +287,6 @@ class _DelayedDrops(_DelayedDrop):
     def _add_upstream(self, upstream: _DelayedDrop):
         _DelayedDrop._add_upstream(self, upstream)
         self.dropdict["inputs"].append(upstream.oid)
-        
 
     def make_dropdict(self):
         return dropdict(
@@ -293,7 +294,7 @@ class _DelayedDrops(_DelayedDrop):
                 "categoryType": "Application",
                 "dropclass": "dlg.dask_emulation._Listifier",
                 "name": "listifier",
-                "inputs": self.inputs
+                "inputs": self.inputs,
             }
         )
 
@@ -327,7 +328,7 @@ class _AppDrop(_DelayedDrop):
                 "categoryType": "Application",
                 "dropclass": "dlg.apps.pyfunc.PyFuncApp",
                 "func_arg_mapping": {},
-                "inputs" : self.inputs
+                "inputs": self.inputs,
             }
         )
         if self.fname is not None:
@@ -390,12 +391,15 @@ class _AppDrop(_DelayedDrop):
             self.inputs.append(self._to_delayed_arg(arg))
             self.original_kwarg_names.append(name)
 
-        leftover_args = [x for x in list(signature(self.f).parameters.keys()) 
-                        if x not in list(kwargs.keys())]
+        leftover_args = [
+            x
+            for x in list(signature(self.f).parameters.keys())
+            if x not in list(kwargs.keys())
+        ]
 
         iter_range = min(len(args), len(leftover_args))
         for i in range(iter_range):
-            self.inputs.append(self._to_delayed_arg(args[i])) #, leftover_args[i]))
+            self.inputs.append(self._to_delayed_arg(args[i]))  # , leftover_args[i]))
             self.original_arg_names.append(leftover_args[i])
 
         if self.nout is None:
@@ -442,12 +446,14 @@ class _DataDrop(_DelayedDrop):
 def getitem(x, i):
     """
     Helper function to ensure the delayed() __getitem__ gets the appropriate arguments
-    in the correct order. 
+    in the correct order.
     """
-    try: 
+    try:
         return x[i]
     except TypeError:
         return x
+
+
 class _DataDropSequence(_DataDrop):
     """One or more _DataDrops that can be subscribed"""
 
@@ -473,6 +479,7 @@ class _DataDropSequence(_DataDrop):
             self.producer,
         )
 
+
 def delayed(x, *args, **kwargs):
     """Like dask.delayed, but quietly swallowing anything other than `nout`"""
     if "nout" in kwargs:
@@ -481,7 +488,7 @@ def delayed(x, *args, **kwargs):
         nout = args[0]
     else:
         nout = None
-    
+
     if callable(x):
         return _AppDrop(x, nout=nout)
         # return x(*args, **kwargs)

--- a/daliuge-engine/dlg/data/drops/container.py
+++ b/daliuge-engine/dlg/data/drops/container.py
@@ -11,7 +11,7 @@ from dlg.ddap_protocol import (
     DROPRel,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ContainerDROP(DataDROP):
@@ -65,9 +65,7 @@ class ContainerDROP(DataDROP):
     @property
     def expirationDate(self):
         if self._children:
-            return heapq.nlargest(
-                1, [c.expirationDate for c in self._children]
-            )[0]
+            return heapq.nlargest(1, [c.expirationDate for c in self._children])[0]
         return self._expirationDate
 
     @property

--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -50,7 +50,7 @@ except:
 
     _checksumType = ChecksumTypes.CRC_32
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 ##
@@ -353,7 +353,7 @@ class DataDROP(AbstractDROP):
         """
 
         try:
-            dropInputPorts = self.parameters['producers']
+            dropInputPorts = self.parameters["producers"]
         except KeyError:
             logging.debug("No producers available for drop: %s", self.uid)
             return
@@ -362,7 +362,7 @@ class DataDROP(AbstractDROP):
         finalDropPortMap = {}  # Final mapping of named port to value stored in producer
 
         for p in self.producers:
-            params = p.parameters['outputs']
+            params = p.parameters["outputs"]
             for param in params:
                 try:
                     key = list(param.keys())[0]
@@ -376,8 +376,10 @@ class DataDROP(AbstractDROP):
                     portValue = p.parameters[param[key]]
                 # TODO This currently only allows 1 UID -> Portname/Value
                 # Investigate UID -> [Portname1:Value1, Portnam2:value2,..,]
-                producerPortValueMap[producerUid] = {"portname": portName,
-                                                     "value": portValue}
+                producerPortValueMap[producerUid] = {
+                    "portname": portName,
+                    "value": portValue,
+                }
 
         for port in dropInputPorts:
             try:
@@ -387,19 +389,18 @@ class DataDROP(AbstractDROP):
                 continue
             for uid, portname in port.items():
                 try:
-                    print(uid, portname)
+                    logger.debug("Trying to map UID: %s to port %s", uid, portname)
                     tmp = producerPortValueMap[uid]
-                    if tmp['portname'] == portname:
-                        finalDropPortMap[portname] = tmp['value']
+                    if tmp["portname"] == portname:
+                        finalDropPortMap[portname] = tmp["value"]
                 except KeyError:
-                    print("Not available")
+                    logger.debug("UID %s Not available!", uid)
 
         for portname in finalDropPortMap:
             if portname in self.parameters:
                 self.parameters[portname] = finalDropPortMap[portname]
 
         self._updatedPorts = True
-
 
     @abstractmethod
     def getIO(self) -> DataIO:

--- a/daliuge-engine/dlg/data/drops/directorycontainer.py
+++ b/daliuge-engine/dlg/data/drops/directorycontainer.py
@@ -30,7 +30,7 @@ from dlg.data.drops.container import ContainerDROP
 from dlg.exceptions import InvalidDropException, InvalidRelationshipException
 from dlg.meta import dlg_bool_param
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 # TODO: This needs some more work

--- a/daliuge-engine/dlg/data/drops/directorycontainer.py
+++ b/daliuge-engine/dlg/data/drops/directorycontainer.py
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param check_exists True/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
 # @param dirname /String/ApplicationArgument/NoPort/ReadWrite//False/False/"Directory name/path"
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param dummy /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Dummy output port
 # @par EAGLE_END
 class DirectoryContainer(PathBasedDrop, ContainerDROP):

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -46,6 +46,7 @@ from typing import Union
 # @param base_name file/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
 # @param persist True/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port

--- a/daliuge-engine/dlg/data/drops/json_drop.py
+++ b/daliuge-engine/dlg/data/drops/json_drop.py
@@ -27,7 +27,7 @@ import logging
 
 from dlg.data.drops.file import FileDROP
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("__main__" + __name__)
 
 
 class JsonDROP(FileDROP):

--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -86,6 +86,7 @@ def parse_pydata(pd_dict: dict) -> bytes:
 # @param tag daliuge
 # @param pydata None/String/ApplicationArgument/NoPort/ReadWrite//False/False/Data to be loaded into memory
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
@@ -193,6 +194,7 @@ class PythonObjectDROP(InMemoryDROP):
 # @param pydata None/String/ApplicationArgument/NoPort/ReadWrite//False/False/Data to be loaded into memory
 # @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data

--- a/daliuge-engine/dlg/data/drops/ngas.py
+++ b/daliuge-engine/dlg/data/drops/ngas.py
@@ -37,13 +37,13 @@ from dlg.meta import dlg_string_param, dlg_int_param
 # @param ngasConnectTimeout 2/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Timeout for connecting to the NGAS server
 # @param ngasMime "text/ascii"/String/ComponentParameter/NoPort/ReadWrite//False/False/Mime-type to be used for archiving
 # @param ngasTimeout 2/Integer/ComponentParameter/NoPort/ReadWrite//False/False/Timeout for receiving responses for NGAS
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
+# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @param dropclass dlg.data.drops.ngas.NgasDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name ngas/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
-# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class NgasDROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/drops/parset_drop.py
+++ b/daliuge-engine/dlg/data/drops/parset_drop.py
@@ -31,7 +31,7 @@ from dlg.drop import DEFAULT_INTERNAL_PARAMETERS
 from dlg.data.io import MemoryIO
 from dlg.meta import dlg_string_param
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 ##

--- a/daliuge-engine/dlg/data/drops/parset_drop.py
+++ b/daliuge-engine/dlg/data/drops/parset_drop.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 # @param base_name parset_drop/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
 # @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param Config /Object.File/ApplicationArgument/OutputPort/ReadWrite//False/False/The output configuration file
 # @par EAGLE_END
 class ParameterSetDROP(DataDROP):

--- a/daliuge-engine/dlg/data/drops/s3_drop.py
+++ b/daliuge-engine/dlg/data/drops/s3_drop.py
@@ -61,11 +61,10 @@ from dlg.meta import (
 # @param Key /String/ComponentParameter/NoPort/ReadWrite//False/False/The S3 object key
 # @param profile_name /String/ComponentParameter/NoPort/ReadWrite//False/False/The S3 profile name
 # @param endpoint_url /String/ComponentParameter/NoPort/ReadWrite//False/False/The URL exposing the S3 REST API
+# @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param dropclass dlg.data.drops.s3_drop.S3DROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name s3_drop/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param streaming False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component streams input and output data
-# @param persist False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Specifies whether this data component contains data that should not be deleted after execution
-# @param dummy /Object/ApplicationArgument/InputOutput/ReadWrite//False/False/Dummy port
 # @par EAGLE_END
 class S3DROP(DataDROP):
     """

--- a/daliuge-engine/dlg/data/io.py
+++ b/daliuge-engine/dlg/data/io.py
@@ -37,7 +37,7 @@ if sys.version_info >= (3, 8):
     from dlg.shared_memory import DlgSharedMemory
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class OpenMode:
@@ -318,10 +318,10 @@ class SharedMemoryIO(DataIO):
         total_size = len(data) + self._written
         if total_size > self._buf.size:
             self._buf.resize(total_size)
-            self._buf.buf[self._written: total_size] = data
+            self._buf.buf[self._written : total_size] = data
             self._written = total_size
         else:
-            self._buf.buf[self._written: total_size] = data
+            self._buf.buf[self._written : total_size] = data
             self._written = total_size
             self._buf.resize(total_size)
             # It may be inefficient to resize many times, but assuming data is written 'once' this is
@@ -358,7 +358,9 @@ class SharedMemoryIO(DataIO):
     def delete(self):
         self._close()
 
+
 # pylint: enable=possibly-used-before-assignment
+
 
 class FileIO(DataIO):
     """
@@ -675,5 +677,3 @@ def IOForURL(url):
     logger.debug("I/O chosen for dataURL %s: %r", url, io)
 
     return io
-
-

--- a/daliuge-engine/dlg/deploy/common.py
+++ b/daliuge-engine/dlg/deploy/common.py
@@ -31,7 +31,7 @@ from ..manager.session import SessionStates
 import itertools
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class _StatusDumper(BaseDROPManagerClient):

--- a/daliuge-engine/dlg/deploy/deployment_utils.py
+++ b/daliuge-engine/dlg/deploy/deployment_utils.py
@@ -25,7 +25,7 @@ import re
 import subprocess
 import time
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ListTokens(object):

--- a/daliuge-engine/dlg/deploy/dlg_monitor.py
+++ b/daliuge-engine/dlg/deploy/dlg_monitor.py
@@ -60,7 +60,7 @@ FORMAT = (
     "%(asctime)-15s [%(levelname)5.5s] %(name)s#%(funcName)s:%(lineno)s %(message)s"
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 delimit = b"@#%!$"
 dl = len(delimit)
 

--- a/daliuge-engine/dlg/deploy/dlg_proxy.py
+++ b/daliuge-engine/dlg/deploy/dlg_proxy.py
@@ -53,7 +53,7 @@ default_dlg_monitor_port = 8081
 default_dlg_port = 8001
 FORMAT = "%(asctime)-15s [%(levelname)5.5s] [%(threadName)15.15s] %(name)s#%(funcName)s:%(lineno)s %(message)s"
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 delimit = b"@#%!$"
 dl = len(delimit)
 
@@ -200,9 +200,7 @@ class ProxyServer:
                     tag = self._dlg_sock_tag_dict.get(the_socket, None)
                     logger.debug("Received %s from DALiuGE manager", b2s(tag))
                     if tag is None:
-                        logger.error(
-                            "Tag for DALiuGE socket %r is gone", the_socket
-                        )
+                        logger.error("Tag for DALiuGE socket %r is gone", the_socket)
                     else:
                         send_to_monitor(self.monitor_socket, delimit.join([tag, data]))
                         logger.debug("Sent %s to Monitor", b2s(tag))

--- a/daliuge-engine/dlg/deploy/helm_client.py
+++ b/daliuge-engine/dlg/deploy/helm_client.py
@@ -47,7 +47,7 @@ from dlg.dropmake import pg_generator
 from dlg.restutils import RestClient
 from dlg.common.k8s_utils import check_k8s_env
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def _num_deployments_required(islands, nodes):
@@ -82,9 +82,7 @@ def _write_chart(
         "kubeVersion": kubeVersion,
     }
     # TODO: Fix app_version quotations.
-    with open(
-        f"{chart_dir}{os.sep}{name}", "w", encoding="utf-8"
-    ) as chart_file:
+    with open(f"{chart_dir}{os.sep}{name}", "w", encoding="utf-8") as chart_file:
         yaml.dump(chart_info, chart_file)
 
 
@@ -97,13 +95,9 @@ def _write_values(chart_dir, config):
 
 
 def _read_values(chart_dir):
-    with open(
-        f"{chart_dir}{os.sep}values.yaml", "r", encoding="utf-8"
-    ) as old_file:
+    with open(f"{chart_dir}{os.sep}values.yaml", "r", encoding="utf-8") as old_file:
         data = yaml.safe_load(old_file)
-    with open(
-        f"{chart_dir}{os.sep}values.yaml", "r", encoding="utf-8"
-    ) as custom_file:
+    with open(f"{chart_dir}{os.sep}values.yaml", "r", encoding="utf-8") as custom_file:
         new_data = yaml.safe_load(custom_file)
     data.update(new_data)
     logger.info("Read yaml values file")
@@ -164,9 +158,7 @@ class HelmClient:
             self._set_physical_graph(physical_graph_file)
 
         # Copy in template files.
-        library_root = pathlib.Path(
-            os.path.dirname(dlg.__file__)
-        ).parent.parent
+        library_root = pathlib.Path(os.path.dirname(dlg.__file__)).parent.parent
         logger.debug(f"Helm chart copied to: {library_root}")
         if sys.version_info >= (3, 8):
             shutil.copytree(
@@ -183,9 +175,9 @@ class HelmClient:
     def _set_physical_graph(self, physical_graph_content, co_host=True):
         self._physical_graph_file = physical_graph_content
         self._islands, self._nodes = _find_resources(self._physical_graph_file)
-        self._num_machines = _num_deployments_required(
-            self._islands, self._nodes
-        ) - (1 if co_host else 0)
+        self._num_machines = _num_deployments_required(self._islands, self._nodes) - (
+            1 if co_host else 0
+        )
 
     def _find_pod_details(self):
         # NOTE: +1 for the master.
@@ -317,24 +309,16 @@ class HelmClient:
             else:
                 logger.error("K8s pods did not start in timeframe allocated")
                 self.teardown()
-                raise RuntimeWarning(
-                    "K8s pods did not start in timeframe allocated"
-                )
+                raise RuntimeWarning("K8s pods did not start in timeframe allocated")
         else:
-            logger.info(
-                f"Created helm chart {self._chart_name} in {self._deploy_dir}"
-            )
+            logger.info(f"Created helm chart {self._chart_name} in {self._deploy_dir}")
 
     def teardown(self):
         if not self._k8s_access:
             raise RuntimeError("Cannot access k8s")
         for i in range(self._num_machines - 1, -1, -1):
-            subprocess.check_output(
-                [f"helm uninstall daliuge-daemon-{i}"], shell=True
-            )
-        subprocess.check_output(
-            [f"helm uninstall daliuge-daemon-master"], shell=True
-        )
+            subprocess.check_output([f"helm uninstall daliuge-daemon-{i}"], shell=True)
+        subprocess.check_output([f"helm uninstall daliuge-daemon-master"], shell=True)
 
     def _monitor(self, session_id=None):
         def _task():
@@ -347,9 +331,7 @@ class HelmClient:
                     )
                     break
                 except:
-                    logger.exception(
-                        "Monitoring failed, attempting to restart"
-                    )
+                    logger.exception("Monitoring failed, attempting to restart")
 
         threads = threading.Thread(target=_task)
         threads.start()
@@ -368,9 +350,7 @@ class HelmClient:
         node_ips.remove(self._pod_details["master"]["ip"])
         node_ips = [self._pod_details["master"]["ip"]] + node_ips
         # node_ips = ['localhost']
-        physical_graph = pg_generator.resource_map(
-            pgt_data, node_ips, co_host_dim=True
-        )
+        physical_graph = pg_generator.resource_map(pgt_data, node_ips, co_host_dim=True)
         # TODO: Add dumping to log-dir
         submit(
             physical_graph,

--- a/daliuge-engine/dlg/deploy/remotes.py
+++ b/daliuge-engine/dlg/deploy/remotes.py
@@ -29,7 +29,7 @@ import socket
 
 from . import deployment_utils
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class Remote(object):

--- a/daliuge-engine/dlg/deploy/utils/monitor_replayer.py
+++ b/daliuge-engine/dlg/deploy/utils/monitor_replayer.py
@@ -48,7 +48,7 @@ import networkx as nx
 import numpy as np
 import pygraphviz as pgv
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 ORIGINAL_COLOR = (87, 87, 87)
 YELLOW_COLOR = (255, 255, 0)
@@ -150,9 +150,7 @@ class GraphPlayer(object):
         with open(self.status_path) as f:
             for i, line in enumerate(f):
                 colour_dict = dict()
-                colour_dict[
-                    "{}"
-                ] = '<viz:color r="%d" g="%d" b="%d"></viz:color>\n' % (
+                colour_dict["{}"] = '<viz:color r="%d" g="%d" b="%d"></viz:color>\n' % (
                     ORIGINAL_COLOR[0],
                     ORIGINAL_COLOR[1],
                     ORIGINAL_COLOR[2],
@@ -180,9 +178,7 @@ class GraphPlayer(object):
                             if gexf_line.find("<node id=") > -1:
                                 # <node id="38345" label="38345">
                                 # 38345
-                                node_id = gexf_line.split()[1].split("=")[1][
-                                    1:-1
-                                ]
+                                node_id = gexf_line.split()[1].split("=")[1][1:-1]
                             output_lines.append(gexf_line)
                 # each line generate a new file
                 new_gexf = "{0}/{1}.gexf".format(out_dir, ts)
@@ -245,9 +241,7 @@ class GraphPlayer(object):
 
         return G
 
-    def get_state_changes(
-        self, gexf_file, grep_log_file, steps=400, out_dir=None
-    ):
+    def get_state_changes(self, gexf_file, grep_log_file, steps=400, out_dir=None):
         """
         grep -R "changed to state" --include=*.log . > statelog.txt
         the simulation time will be evenly divided up by "steps"
@@ -265,17 +259,11 @@ class GraphPlayer(object):
                 alllines = f.readlines()
             with open(csv_file, "w") as fo:
                 for line in alllines:
-                    ts = (
-                        line.split("[DEBUG]")[0].split("dlgNM.log:")[1].strip()
-                    )
-                    ts = int(
-                        dt.strptime(ts, "%Y-%m-%d %H:%M:%S,%f").strftime("%s")
-                    )
+                    ts = line.split("[DEBUG]")[0].split("dlgNM.log:")[1].strip()
+                    ts = int(dt.strptime(ts, "%Y-%m-%d %H:%M:%S,%f").strftime("%s"))
                     oid = line.split("oid=")[1].split()[0]
                     state = line.split()[-1]
-                    fo.write(
-                        "{0},{1},{2},{3}".format(ts, oid, state, os.linesep)
-                    )
+                    fo.write("{0},{1},{2},{3}".format(ts, oid, state, os.linesep))
         else:
             logger.info("csv file already exists: %s", csv_file)
 
@@ -379,9 +367,7 @@ class GraphPlayer(object):
         else:
             G = nx.Graph()
             do_subgraph = False
-        subgraph_dict = defaultdict(
-            list
-        )  # k - node-ip, v - a list of graph nodes
+        subgraph_dict = defaultdict(list)  # k - node-ip, v - a list of graph nodes
         oid_gnid_dict = dict()
 
         for i, oid in enumerate(self.pg_spec.keys()):
@@ -542,9 +528,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     FORMAT = "%(asctime)-15s [%(levelname)5.5s] [%(threadName)15.15s] %(name)s#%(funcName)s:%(lineno)s %(message)s"
-    logging.basicConfig(
-        filename=options.log_file, level=logging.DEBUG, format=FORMAT
-    )
+    logging.basicConfig(filename=options.log_file, level=logging.DEBUG, format=FORMAT)
 
     if options.edgelist and options.dot_file is not None:
         logger.info("Loading networx graph from file %s", options.graph_path)

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -191,7 +191,6 @@ class AbstractDROP(EventFirer, EventHandler):
 
         self._listeners = collections.defaultdict(list)
 
-    @track_current_drop
     def __init__(self, oid, uid, **kwargs):
         """
         Creates a DROP. The only mandatory argument are the Object ID
@@ -227,6 +226,10 @@ class AbstractDROP(EventFirer, EventHandler):
         self._log_level = self._popArg(
             kwargs, "log_level", logging.getLevelName(logger.getEffectiveLevel())
         )
+        if self._log_level == "" or self._log_level == logging.getLevelName(
+            logging.NOTSET
+        ):
+            self._log_level = logging.getLevelName(logger.getEffectiveLevel())
         self._global_log_level = logging.getLevelName(logger.getEffectiveLevel())
 
         # The physical graph drop type. This is determined

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -101,7 +101,7 @@ except:
 
     _checksumType = ChecksumTypes.CRC_32
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class ListAsDict(list):
@@ -191,6 +191,7 @@ class AbstractDROP(EventFirer, EventHandler):
 
         self._listeners = collections.defaultdict(list)
 
+    @track_current_drop
     def __init__(self, oid, uid, **kwargs):
         """
         Creates a DROP. The only mandatory argument are the Object ID
@@ -220,7 +221,7 @@ class AbstractDROP(EventFirer, EventHandler):
         # A simple name that the Drop might receive
         # This is usually set in the Logical Graph Editor,
         # but is not necessarily always there
-        self.name = self._popArg(kwargs, "name", self)
+        self.name = self._popArg(kwargs, "name", "")
 
         # Set log_level for this drop to level provided
         self._log_level = self._popArg(

--- a/daliuge-engine/dlg/drop.py
+++ b/daliuge-engine/dlg/drop.py
@@ -218,6 +218,17 @@ class AbstractDROP(EventFirer, EventHandler):
         self._oid = str(oid)
         self._uid = str(uid)
 
+        # A simple name that the Drop might receive
+        # This is usually set in the Logical Graph Editor,
+        # but is not necessarily always there
+        self.name = self._popArg(kwargs, "name", self)
+
+        # Set log_level for this drop to level provided
+        self._log_level = self._popArg(
+            kwargs, "log_level", logging.getLevelName(logger.getEffectiveLevel())
+        )
+        self._global_log_level = logging.getLevelName(logger.getEffectiveLevel())
+
         # The physical graph drop type. This is determined
         # by the drop category when generating the drop spec
         self._type = self._popArg(kwargs, "categoryType", None)
@@ -227,11 +238,6 @@ class AbstractDROP(EventFirer, EventHandler):
         # general it cannot be assumed it will (e.g., unit tests create drops
         # directly outside the context of a session).
         self._dlg_session_id = self._popArg(kwargs, "dlg_session_id", "")
-
-        # A simple name that the Drop might receive
-        # This is usually set in the Logical Graph Editor,
-        # but is not necessarily always there
-        self.name = self._popArg(kwargs, "name", "")
 
         # The key of this drop in the original Logical Graph
         # This information might or might not be present depending on how the
@@ -1112,6 +1118,13 @@ class AbstractDROP(EventFirer, EventHandler):
         self.commit()
         reprodata = {"data": self._merkleData, "merkleroot": self.merkleroot}
         self._fire(eventType="reproducibility", reprodata=reprodata)
+        if logger.getEffectiveLevel() != logging.getLevelName(self._global_log_level):
+            logger.warning(
+                "log-level after %s.%s: %s",
+                self.name,
+                self._humanKey,
+                logging.getLevelName(logger.getEffectiveLevel()),
+            )
 
     @track_current_drop
     def setError(self):

--- a/daliuge-engine/dlg/drop_loaders.py
+++ b/daliuge-engine/dlg/drop_loaders.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from dlg.data.drops.data_base import DataDROP
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 # Used to check whether a command specifies via UID reference the path or
 # data URL of an input or output

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from dlg.apps.app_base import AppDROP
     from dlg.data.drops.data_base import DataDROP
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 # Used to check whether a command specifies via UID reference the path or
 # data URL of an input or output
@@ -88,7 +88,9 @@ class DROPWaiterCtx(object):
          a.setCompleted()
     """
 
-    def __init__(self, test, drops, timeout=1, expected_states:list[DROPStates] = None):
+    def __init__(
+        self, test, drops, timeout=1, expected_states: list[DROPStates] = None
+    ):
         self._drops = listify(drops)
         self._expected_states = expected_states or (
             DROPStates.COMPLETED,
@@ -233,7 +235,7 @@ def getLeafNodes(drops):
     ]
 
 
-def depthFirstTraverse(node: "AbstractDROP", visited: list[AbstractDROP]=None):
+def depthFirstTraverse(node: "AbstractDROP", visited: list[AbstractDROP] = None):
     """
     Depth-first iterator for a DROP graph.
 

--- a/daliuge-engine/dlg/event.py
+++ b/daliuge-engine/dlg/event.py
@@ -25,7 +25,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional, Union, List, DefaultDict
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class Event(object):
@@ -69,13 +69,11 @@ class EventFirer(object):
 
     def __init__(self):
         # Union string key with object to handle __ALL_EVENTS above
-        self._listeners: DefaultDict[
-            Union[str, object], List[EventHandler]
-        ] = defaultdict(list)
+        self._listeners: DefaultDict[Union[str, object], List[EventHandler]] = (
+            defaultdict(list)
+        )
 
-    def subscribe(
-        self, listener: EventHandler, eventType: Optional[str] = None
-    ):
+    def subscribe(self, listener: EventHandler, eventType: Optional[str] = None):
         """
         Subscribes `listener` to events fired by this object. If `eventType` is
         not `None` then `listener` will only receive events of `eventType` that
@@ -90,18 +88,20 @@ class EventFirer(object):
         eventType = eventType or EventFirer.__ALL_EVENTS
         self._listeners[eventType].append(listener)
 
-    def unsubscribe(
-        self, listener: EventHandler, eventType: Optional[str] = None
-    ):
+    def unsubscribe(self, listener: EventHandler, eventType: Optional[str] = None):
         """
         Unsubscribes `listener` from events fired by this object.
         """
-        logger.debug(
-            "Removing listener to %r eventType=%s: %r",
-            self.oid,
-            eventType,
-            listener.oid,
-        ) if hasattr(listener, "oid") else None
+        (
+            logger.debug(
+                "Removing listener to %r eventType=%s: %r",
+                self.oid,
+                eventType,
+                listener.oid,
+            )
+            if hasattr(listener, "oid")
+            else None
+        )
 
         eventType = eventType or EventFirer.__ALL_EVENTS
         if listener in self._listeners[eventType]:

--- a/daliuge-engine/dlg/graph_loader.py
+++ b/daliuge-engine/dlg/graph_loader.py
@@ -74,7 +74,7 @@ __TOONE = {DROPLinkType.PARENT: "parent"}
 __TOMANY.update({v: k for k, v in __TOMANY.items()})
 __TOONE.update({v: k for k, v in __TOONE.items()})
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def addLink(linkType, lhDropSpec, rhOID, force=False):
@@ -246,9 +246,9 @@ def loadDropSpecs(dropSpecList):
     return dropSpecs, reprodata
 
 
-def createGraphFromDropSpecList(dropSpecList: List[dict],
-                                session: Optional["Session"]=None
-                                ) -> List[AbstractDROP]:
+def createGraphFromDropSpecList(
+    dropSpecList: List[dict], session: Optional["Session"] = None
+) -> List[AbstractDROP]:
     logger.debug("Found %d DROP definitions", len(dropSpecList))
 
     # Step #1: create the actual DROPs

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -133,7 +133,7 @@ from ..ddap_protocol import DROPStates, DROPPhases, AppDROPStates
 from ..drop import AbstractDROP
 from ..data.drops.container import ContainerDROP
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class DataLifecycleManagerBackgroundTask(threading.Thread):
@@ -212,9 +212,7 @@ class DataLifecycleManager:
     An object that deals with automatic data drop replication and deletion.
     """
 
-    def __init__(
-        self, check_period=0, cleanup_period=0, enable_drop_replication=False
-    ):
+    def __init__(self, check_period=0, cleanup_period=0, enable_drop_replication=False):
         self._reg = registry.InMemoryRegistry()
         self._listener = DropEventListener(self)
         self._enable_drop_replication = enable_drop_replication
@@ -238,9 +236,7 @@ class DataLifecycleManager:
     def startup(self):
         # Spawn the background threads
         if self._check_period:
-            self._drop_checker = DROPChecker(
-                "DropChecker", self, self._check_period
-            )
+            self._drop_checker = DROPChecker("DropChecker", self, self._check_period)
             self._drop_checker.start()
         if self._cleanup_period:
             self._drop_garbage_collector = DROPGarbageCollector(
@@ -293,8 +289,7 @@ class DataLifecycleManager:
             # are finished using this DROP
             if not drop.persist and drop.expireAfterUse:
                 allDone = all(
-                    c.execStatus
-                    in [AppDROPStates.FINISHED, AppDROPStates.ERROR]
+                    c.execStatus in [AppDROPStates.FINISHED, AppDROPStates.ERROR]
                     for c in drop.consumers
                 )
                 if not allDone:
@@ -467,9 +462,7 @@ class DataLifecycleManager:
         Remove drops from DLM's monitoring
         """
         self._drops = {
-            oid: drop
-            for oid, drop in self._drops.items()
-            if oid not in drop_oids
+            oid: drop for oid, drop in self._drops.items() if oid not in drop_oids
         }
 
     def handleOpenedDrop(self, oid, uid):
@@ -489,9 +482,7 @@ class DataLifecycleManager:
 
         drop = self._drops[uid]
         if drop.persist and self.isReplicable(drop):
-            logger.debug(
-                "Replicating %r because it's marked to be persisted", drop
-            )
+            logger.debug("Replicating %r because it's marked to be persisted", drop)
             try:
                 self.replicateDrop(drop)
             except:
@@ -520,9 +511,7 @@ class DataLifecycleManager:
         availableSpace = store.getAvailableSpace()
 
         if size > availableSpace:
-            raise Exception(
-                "Cannot replicate DROP to store %s: not enough space left"
-            )
+            raise Exception("Cannot replicate DROP to store %s: not enough space left")
 
         # Create new DROP and write the contents of the original into it
         # TODO: In a real world application this will probably happen in a separate
@@ -547,9 +536,7 @@ class DataLifecycleManager:
         # Dummy, but safe, new UID
         newUid = "uid:" + "".join(
             [
-                random.SystemRandom().choice(
-                    string.ascii_letters + string.digits
-                )
+                random.SystemRandom().choice(string.ascii_letters + string.digits)
                 for _ in range(10)
             ]
         )

--- a/daliuge-engine/dlg/lifecycle/hsm/manager.py
+++ b/daliuge-engine/dlg/lifecycle/hsm/manager.py
@@ -30,7 +30,7 @@ import logging
 
 from ..hsm import store
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class HierarchicalStorageManager(object):

--- a/daliuge-engine/dlg/lifecycle/hsm/store.py
+++ b/daliuge-engine/dlg/lifecycle/hsm/store.py
@@ -38,7 +38,7 @@ from dlg.data.drops.memory import InMemoryDROP
 from dlg.data.drops.ngas import NgasDROP
 from dlg.data.drops.file import FileDROP
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class AbstractStore(object):
@@ -62,8 +62,7 @@ class AbstractStore(object):
             total = self.getTotalSpace()
             perc = avail * 100.0 / total
             logger.debug(
-                "Available/Total space on %s: %d/%d (%.2f %%)",
-                self, avail, total, perc
+                "Available/Total space on %s: %d/%d (%.2f %%)", self, avail, total, perc
             )
         pass
 
@@ -202,7 +201,7 @@ class NgasStore(AbstractStore):
             # col14 = bytes_stored
             totalAvailable += float(disk["col13"])
             totalStored += int(disk["col14"])
-        totalAvailable *= 1024 ** 2  # to bytes
+        totalAvailable *= 1024**2  # to bytes
 
         # TODO: Check if these computations are correct, I'm not sure if the
         #       quantities stored by NGAS should be interpreted like this, or
@@ -254,7 +253,7 @@ class DirectoryStore(AbstractStore):
             )
         else:
             # Should be used only for testing
-            size = 1024 ** 3
+            size = 1024**3
             logger.info(
                 "Initializing %s with size %d. THIS SHOULD ONLY BE USED DURING TESTING",
                 sizeFile,

--- a/daliuge-engine/dlg/lifecycle/registry.py
+++ b/daliuge-engine/dlg/lifecycle/registry.py
@@ -39,7 +39,7 @@ from abc import abstractmethod, ABCMeta
 from ..ddap_protocol import DROPPhases
 from ..utils import prepare_sql
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class DROP(object):

--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -41,7 +41,7 @@ from dlg.constants import (
     MASTER_DEFAULT_REST_PORT,
     REPLAY_DEFAULT_REST_PORT,
     NODE_DEFAULT_RPC_PORT,
-    NODE_DEFAULT_EVENTS_PORT
+    NODE_DEFAULT_EVENTS_PORT,
 )
 from .node_manager import NodeManager
 from .replay import ReplayManager, ReplayManagerServer
@@ -70,7 +70,7 @@ class DlgFormatter(logging.Formatter):
 
 def launchServer(opts):
     # we might be called via __main__, but we want a nice logger name
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("dlg." + __name__)
     dmName = opts.dmType.__name__
 
     logger.info("DALiuGE version %s running at %s", version.full_version, os.getcwd())
@@ -199,6 +199,7 @@ def commonOptionsCheck(options, parser):
     if options.verbose and options.quiet:
         parser.error("-v and -q cannot be specified together")
 
+
 def start(options, parser):
     # Perform common option checks
     commonOptionsCheck(options, parser)
@@ -216,7 +217,7 @@ def start(options, parser):
         with daemon.DaemonContext(
             pidfile=PIDLockFile(pidfile, 1),
             files_preserve=[fileHandler.stream],
-            working_directory=utils.getDlgWorkDir()
+            working_directory=utils.getDlgWorkDir(),
         ):
             launchServer(options)
 
@@ -275,7 +276,6 @@ def setupLogging(opts):
     elif opts.quiet:
         lidx += min((opts.quiet, 2))
     level = levels[lidx]
-
 
     # Output to files/stdout uses a command format, which can or not contain
     # optionally a session_id and drop_uid to indicate what is currently being
@@ -404,7 +404,7 @@ def dlgNM(parser, args):
         type="int",
         dest="rpc_port",
         help="Set the port number for the NodeManager RPC client",
-        default=NODE_DEFAULT_RPC_PORT
+        default=NODE_DEFAULT_RPC_PORT,
     )
     parser.add_option(
         "--event_port",
@@ -412,7 +412,7 @@ def dlgNM(parser, args):
         type="int",
         dest="events_port",
         help="Set the port number for the NodeManager ZMQ client",
-        default=NODE_DEFAULT_EVENTS_PORT
+        default=NODE_DEFAULT_EVENTS_PORT,
     )
 
     (options, args) = parser.parse_args(args)
@@ -500,7 +500,7 @@ def dlgCompositeManager(parser, args, dmType, acronym, dmPort, dmRestServer):
     options.dmKwargs = {
         "pkeyPath": options.pkeyPath,
         "dmCheckTimeout": options.dmCheckTimeout,
-        "dump_graphs": options.dump_graphs
+        "dump_graphs": options.dump_graphs,
     }
     options.dmAcronym = acronym
     options.restType = dmRestServer

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -48,7 +48,7 @@ from dlg.exceptions import (
 from dlg.manager.past_sessions import PastSessionManager
 from dlg.utils import portIsOpen, getDlgWorkDir
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def uid_for_drop(dropSpec):
@@ -140,15 +140,15 @@ class CompositeManager(DROPManager):
     __metaclass__ = abc.ABCMeta
 
     def __init__(
-            self,
-            dmPort,
-            partitionAttr,
-            subDmId,
-            dmHosts: list[str] = None,
-            pkeyPath=None,
-            dmCheckTimeout=10,
-            dump_graphs=False,
-            hosts_are_dim=False
+        self,
+        dmPort,
+        partitionAttr,
+        subDmId,
+        dmHosts: list[str] = None,
+        pkeyPath=None,
+        dmCheckTimeout=10,
+        dump_graphs=False,
+        hosts_are_dim=False,
     ):
         """
         Creates a new CompositeManager. The sub-DMs it manages are to be located
@@ -218,7 +218,8 @@ class CompositeManager(DROPManager):
                 if not self.check_dm(host, self._dmPort, timeout=self._dmCheckTimeout):
                     logger.error(
                         "Couldn't contact manager for host %s with dmPort %d, will try again later",
-                        host, self._dmPort,
+                        host,
+                        self._dmPort,
                     )
             if self._dmCheckerEvt.wait(60):
                 break
@@ -300,9 +301,10 @@ class CompositeManager(DROPManager):
 
         :return: List of path names (str)
         """
-        return [path.name for path in self._past_session_manager.past_sessions(
-            self._sessionIds)]
-
+        return [
+            path.name
+            for path in self._past_session_manager.past_sessions(self._sessionIds)
+        ]
 
     def _do_in_host(self, action, sessionId, exceptions, f, collect, port, iterable):
         """
@@ -337,7 +339,7 @@ class CompositeManager(DROPManager):
                 host.host,
                 host.port,
                 sessionId,
-                f
+                f,
             )
 
     def replicate(self, sessionId, f, action, collect=None, iterable=None, port=None):
@@ -426,12 +428,11 @@ class CompositeManager(DROPManager):
         graph_path = session_dir / f"{sessionId}.graph"
 
         try:
-            with graph_path.open('w') as fp:
+            with graph_path.open("w") as fp:
                 json.dump(graphSpec, fp, indent=2)
             logger.debug("Graph saved at %s", graph_path)
         except NotADirectoryError:
-            logger.error("Session directory %s does not exist",
-                         graph_path.parent)
+            logger.error("Session directory %s does not exist", graph_path.parent)
 
     def _addGraphSpec(self, dm, host_and_graphspec, sessionId):
         host, graphSpec = host_and_graphspec
@@ -501,8 +502,8 @@ class CompositeManager(DROPManager):
         for rel in inter_partition_rels:
             # rhn = self._graph[rel.rhs]["node"].split(":")[0]
             # lhn = self._graph[rel.lhs]["node"].split(":")[0]
-            rhn = (self._graph[rel.rhs]["node"])
-            lhn = (self._graph[rel.lhs]["node"])
+            rhn = self._graph[rel.rhs]["node"]
+            lhn = self._graph[rel.lhs]["node"]
             drop_rels[lhn][rhn].append(rel)
             drop_rels[rhn][lhn].append(rel)
 
@@ -539,6 +540,7 @@ class CompositeManager(DROPManager):
             sessionId,
             host,
         )
+
     def deploySession(self, sessionId, completedDrops: list[str] = None):
         # Indicate the node managers that they have to subscribe to events
         # published by some nodes
@@ -652,8 +654,13 @@ class DataIslandManager(CompositeManager):
     The DataIslandManager, which manages a number of NodeManagers.
     """
 
-    def __init__(self, dmHosts: list[str] = None, pkeyPath=None, dmCheckTimeout=10,
-                 dump_graphs=False):
+    def __init__(
+        self,
+        dmHosts: list[str] = None,
+        pkeyPath=None,
+        dmCheckTimeout=10,
+        dump_graphs=False,
+    ):
         super(DataIslandManager, self).__init__(
             NODE_DEFAULT_REST_PORT,
             "node",
@@ -661,7 +668,7 @@ class DataIslandManager(CompositeManager):
             dmHosts=dmHosts,
             pkeyPath=pkeyPath,
             dmCheckTimeout=dmCheckTimeout,
-            dump_graphs=dump_graphs
+            dump_graphs=dump_graphs,
         )
 
         # In the case of the Data Island the dmHosts are the final nodes as well
@@ -675,8 +682,13 @@ class MasterManager(CompositeManager):
     The MasterManager, which manages a number of DataIslandManagers.
     """
 
-    def __init__(self, dmHosts: list[str] = None, pkeyPath=None, dmCheckTimeout=10,
-        dump_graphs=False):
+    def __init__(
+        self,
+        dmHosts: list[str] = None,
+        pkeyPath=None,
+        dmCheckTimeout=10,
+        dump_graphs=False,
+    ):
         super(MasterManager, self).__init__(
             ISLAND_DEFAULT_REST_PORT,
             "island",
@@ -685,6 +697,6 @@ class MasterManager(CompositeManager):
             pkeyPath=pkeyPath,
             dmCheckTimeout=dmCheckTimeout,
             dump_graphs=dump_graphs,
-            hosts_are_dim=True
+            hosts_are_dim=True,
         )
         logger.info("Created MasterManager for DIM hosts: %r", self._dmHosts)

--- a/daliuge-engine/dlg/manager/manager_data.py
+++ b/daliuge-engine/dlg/manager/manager_data.py
@@ -28,7 +28,7 @@ import logging
 import dlg.constants as constants
 from enum import IntEnum
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class NodeProtocolPosition(IntEnum):
@@ -46,11 +46,12 @@ class Node:
 
     def __init__(self, host: str, dim=False):
         try:
-            chunks = host.split(':')
+            chunks = host.split(":")
             num_chunks = len(chunks)
             self.host = constants.NODE_DEFAULT_HOSTNAME
             self.port = (
-                constants.ISLAND_DEFAULT_REST_PORT if dim 
+                constants.ISLAND_DEFAULT_REST_PORT
+                if dim
                 else constants.NODE_DEFAULT_REST_PORT
             )
             self.events_port = constants.NODE_DEFAULT_EVENTS_PORT
@@ -64,28 +65,33 @@ class Node:
                 self._rest_port_specified = True
             if num_chunks >= 3:
                 self.events_port = self._validate_port(
-                    chunks[NodeProtocolPosition.EVENTS_PORT])
+                    chunks[NodeProtocolPosition.EVENTS_PORT]
+                )
             if num_chunks >= 4:
-                self.rpc_port = self._validate_port(chunks[NodeProtocolPosition.RPC_PORT])
+                self.rpc_port = self._validate_port(
+                    chunks[NodeProtocolPosition.RPC_PORT]
+                )
         except AttributeError as e:
             raise RuntimeError(
                 "Constructor has been passed non-string object and cannot"
-                "be converted to Node: type %s.", type(host),
+                "be converted to Node: type %s.",
+                type(host),
             ) from e
         except ValueError as e:
-            logger.error("An issue has occured with translating node information",
-                         exc_info=e)
+            logger.error(
+                "An issue has occured with translating node information", exc_info=e
+            )
 
     def _validate_port(self, port: str) -> int:
         """
-         Confirm the port provided is within the correct range of ports and returns it
-         as an integer.
+        Confirm the port provided is within the correct range of ports and returns it
+        as an integer.
 
-         Param:
+        Param:
 
-         Raises: Invalid port
+        Raises: Invalid port
 
-         :return: int, integer representation of port passed to the command line.
+        :return: int, integer representation of port passed to the command line.
         """
         validated_port = int(port)
         if not 1 <= validated_port <= 65535:
@@ -120,8 +126,7 @@ class Node:
         return self.serialize()
 
     def __repr__(self):
-        """
-        """
+        """ """
         return self.serialize()
 
     def __eq__(self, other):

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -53,13 +53,11 @@ from dlg.exceptions import (
     SessionAlreadyExistsException,
     DaliugeException,
 )
-from dlg.utils import object_tracking
 from ..lifecycle.dlm import DataLifecycleManager
 
 from dlg.manager.manager_data import Node
 
 logger = logging.getLogger(__name__)
-track_current_drop = object_tracking("drop")
 
 
 class NMDropEventListener(object):
@@ -184,7 +182,6 @@ class NodeManagerProcessDropRunner(NodeManagerDropRunner):
         # (instead of the normal `shutdown()`)
         cls._rpc_client.start()
 
-    @track_current_drop
     def run_drop(self, app_drop: AppDROP):
         inputs_proxy_info, outputs_proxy_info = (
             NodeManagerProcessDropRunner._get_proxy_infos(app_drop)

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -53,11 +53,13 @@ from dlg.exceptions import (
     SessionAlreadyExistsException,
     DaliugeException,
 )
+from dlg.utils import object_tracking
 from ..lifecycle.dlm import DataLifecycleManager
 
 from dlg.manager.manager_data import Node
 
 logger = logging.getLogger(__name__)
+track_current_drop = object_tracking("drop")
 
 
 class NMDropEventListener(object):
@@ -143,7 +145,9 @@ class NodeManagerThreadDropRunner(NodeManagerDropRunner):
                 app_drop._humanKey,
                 logging.getLevelName(logger.getEffectiveLevel()),
             )
-        return self._thread_pool.submit(app_drop.run)
+        return self._thread_pool.submit(
+            app_drop.run,
+        )
 
     def close(self):
         self._thread_pool.shutdown(wait=True)
@@ -180,6 +184,7 @@ class NodeManagerProcessDropRunner(NodeManagerDropRunner):
         # (instead of the normal `shutdown()`)
         cls._rpc_client.start()
 
+    @track_current_drop
     def run_drop(self, app_drop: AppDROP):
         inputs_proxy_info, outputs_proxy_info = (
             NodeManagerProcessDropRunner._get_proxy_infos(app_drop)

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -135,6 +135,14 @@ class NodeManagerThreadDropRunner(NodeManagerDropRunner):
         self._thread_pool = ThreadPoolExecutor(max_workers=self._max_workers)
 
     def run_drop(self, app_drop: AppDROP) -> Future:
+        if logger.getEffectiveLevel() != logging.getLevelName(app_drop._log_level):
+            logging.getLogger("dlg").setLevel(app_drop._log_level)
+            logger.warning(
+                "Set log-level for %s.%s to %s",
+                app_drop.name,
+                app_drop._humanKey,
+                logging.getLevelName(logger.getEffectiveLevel()),
+            )
         return self._thread_pool.submit(app_drop.run)
 
     def close(self):
@@ -439,7 +447,7 @@ class NodeManagerBase(DROPManager):
         for nodesub in relationships:
             # node = Node(nodesub)
             # This needs to be changed
-            events_port = nodesub.events_port #constants.NODE_DEFAULT_EVENTS_PORT
+            events_port = nodesub.events_port  # constants.NODE_DEFAULT_EVENTS_PORT
             if type(nodesub) is tuple:
                 host, events_port, _ = nodesub
             else:
@@ -450,7 +458,6 @@ class NodeManagerBase(DROPManager):
                 host = nodesub
             logger.debug("Sending subscription to %s", f"{host}:{events_port}")
             self.subscribe(host, events_port)
-
 
     def has_method(self, sessionId, uid, mname):
         self._check_session_id(sessionId)

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -57,7 +57,7 @@ from ..lifecycle.dlm import DataLifecycleManager
 
 from dlg.manager.manager_data import Node
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class NMDropEventListener(object):

--- a/daliuge-engine/dlg/manager/proc_daemon.py
+++ b/daliuge-engine/dlg/manager/proc_daemon.py
@@ -39,7 +39,7 @@ from .. import utils
 from ..restserver import RestServer
 from dlg.nm_dim_assigner import NMAssigner
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def get_tool():

--- a/daliuge-engine/dlg/manager/replay.py
+++ b/daliuge-engine/dlg/manager/replay.py
@@ -32,7 +32,7 @@ from .rest import ManagerRestServer
 from .session import SessionStates
 from ..exceptions import NoSessionException, InvalidSessionState
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 build_step = 3
 deploy_step = 6

--- a/daliuge-engine/dlg/manager/rest.py
+++ b/daliuge-engine/dlg/manager/rest.py
@@ -59,7 +59,7 @@ from dlg.manager.session import generateLogFileName
 from dlg.common.deployment_methods import DeploymentMethods
 from dlg.manager.manager_data import Node
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def file_as_string(fname, enc="utf8"):
@@ -82,8 +82,8 @@ def daliuge_aware(func):
                 # logger.debug("CORS request comming from: %s", origin)
                 # logger.debug("Request method: %s", bottle.request.method)
                 if origin is None or re.match(
-                        r"(http://dlg-trans.local:80[0-9][0-9]|https://dlg-trans.icrar.org)",
-                        origin,
+                    r"(http://dlg-trans.local:80[0-9][0-9]|https://dlg-trans.icrar.org)",
+                    origin,
                 ):
                     pass
                 elif re.match(r"http://((localhost)|(127.0.0.1)):80[0-9][0-9]", origin):
@@ -339,8 +339,8 @@ class ManagerRestServer(RestServer):
         # WARNING: TODO: Somehow, the content_type can be overwritten to 'text/plain'
         logger.debug("Graph content type: %s", bottle.request.content_type)
         if (
-                "application/json" not in bottle.request.content_type
-                and "text/plain" not in bottle.request.content_type
+            "application/json" not in bottle.request.content_type
+            and "text/plain" not in bottle.request.content_type
         ):
             bottle.response.status = 415
             return
@@ -451,9 +451,7 @@ class NMRestServer(ManagerRestServer):
         self.dm.add_node_subscriptions(sessionId, subscriptions)
 
     def _parse_subscriptions(self, json_request):
-        return {Node(host): droprels
-                for host, droprels
-                in json_request.items()}
+        return {Node(host): droprels for host, droprels in json_request.items()}
 
     @daliuge_aware
     def trigger_drops(self, sessionId):
@@ -515,9 +513,9 @@ class CompositeManagerRestServer(ManagerRestServer):
     @daliuge_aware
     def getCMStatus(self):
         """
-            REST (GET): /api/
+        REST (GET): /api/
 
-            Return JSON-compatible list of Composite Manager nodes and sessions
+        Return JSON-compatible list of Composite Manager nodes and sessions
         """
         return {
             "hosts": [str(n) for n in self.dm.dmHosts],
@@ -581,19 +579,15 @@ class CompositeManagerRestServer(ManagerRestServer):
         """
         return self.pastSessions()
 
-
     def pastSessions(self):
         """
-        Retrieve sessions from this DropManager and place it in JSON-format, for 
-        serialisation across the wire. 
+        Retrieve sessions from this DropManager and place it in JSON-format, for
+        serialisation across the wire.
         """
 
-        
-        return [   
-            {"sessionId": pastSession}
-            for pastSession in self.dm.getPastSessionIds()
+        return [
+            {"sessionId": pastSession} for pastSession in self.dm.getPastSessionIds()
         ]
-
 
     def _tarfile_write(self, tar, headers, stream):
         file_header = headers.getheader("Content-Disposition")
@@ -715,7 +709,7 @@ class MasterManagerRestServer(CompositeManagerRestServer):
     @daliuge_aware
     def createDataIsland(self, host):
         with RestClient(
-                host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
+            host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
         ) as c:
             c._post_json("/managers/island/start", bottle.request.body.read())
         self.dm.addDmHost(host)
@@ -781,14 +775,14 @@ class MasterManagerRestServer(CompositeManagerRestServer):
     @daliuge_aware
     def getDIMInfo(self, host):
         with RestClient(
-                host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
+            host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
         ) as c:
             return json.loads(c._GET("/managers/island").read())
 
     @daliuge_aware
     def getMMInfo(self, host):
         with RestClient(
-                host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
+            host=host, port=constants.DAEMON_DEFAULT_REST_PORT, timeout=10
         ) as c:
             return json.loads(c._GET("/managers/master").read())
 

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -37,6 +37,7 @@ from dlg.common.reproducibility.reproducibility import init_runtime_repro_data
 from dlg.utils import createDirIfMissing
 
 from dlg import constants
+
 # from .. import constants
 from dlg import droputils
 from dlg import graph_loader
@@ -60,7 +61,7 @@ from dlg.exceptions import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class SessionStates:
@@ -531,7 +532,7 @@ class Session(object):
             droprels = [DROPRel(*x) for x in droprels]
 
             # Sanitize the host/rpc_port info if needed
-            rpc_port = host.rpc_port #constants.NODE_DEFAULT_RPC_PORT
+            rpc_port = host.rpc_port  # constants.NODE_DEFAULT_RPC_PORT
             # if type(host) is tuple:
             #     host, _, rpc_port = host
 

--- a/daliuge-engine/dlg/manager/shared_memory_manager.py
+++ b/daliuge-engine/dlg/manager/shared_memory_manager.py
@@ -27,7 +27,7 @@ import logging
 
 from dlg.shared_memory import DlgSharedMemory
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def _cleanup_block(session_id, name):

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -6,13 +6,13 @@ import dlg.droputils as droputils
 import dlg.drop_loaders as drop_loaders
 from typing import Tuple
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class DropParser(Enum):
     RAW = "raw"
     PICKLE = "pickle"
-    EVAL = "eval" 
+    EVAL = "eval"
     NPY = "npy"
     DILL = "dill"
     # JSON = "json"
@@ -68,9 +68,7 @@ def serialize_applicationArgs(applicationArgs, prefix="--", separator=" "):
     positional arguments and one for kw arguments that can be used to construct
     the final command line.
     """
-    applicationArgs = clean_applicationArgs(
-        applicationArgs
-    )
+    applicationArgs = clean_applicationArgs(applicationArgs)
     pargs = []
     kwargs = {}
     for name, vdict in applicationArgs.items():
@@ -145,7 +143,7 @@ def identify_named_ports(
             value = ""  # make sure we are passing NULL drop events
         if key in positionalArgs:
             try:
-                encoding = DropParser(positionalPortArgs[key]['encoding'])
+                encoding = DropParser(positionalPortArgs[key]["encoding"])
             except ValueError:
                 logger.warning("No encoding set for %key: possible default")
                 continue
@@ -161,7 +159,7 @@ def identify_named_ports(
                 keywordPortArgs.update({key: positionalPortArgs[key]})
         elif key in keywordArgs:
             try:
-                encoding = DropParser(keywordArgs[key]['encoding'])
+                encoding = DropParser(keywordArgs[key]["encoding"])
             except ValueError:
                 logger.warning("No encoding set for %key: possible default")
                 continue
@@ -398,6 +396,7 @@ def _get_args(appArgs, positional=False):
     logger.debug("%s arguments: %s", argType, args)
     return args
 
+
 def get_port_reader_function(input_parser: DropParser):
     """
     Return the function used to read input from a named port
@@ -417,12 +416,14 @@ def get_port_reader_function(input_parser: DropParser):
 
         reader = optionalEval
     elif input_parser is DropParser.UTF8:
+
         def utf8decode(drop: "DataDROP"):
             """
             Decode utf8
             Not stored in drop_loaders to avoid cyclic imports
             """
             return droputils.allDropContents(drop).decode("utf-8")
+
         reader = utf8decode
     elif input_parser is DropParser.NPY:
         reader = drop_loaders.load_npy

--- a/daliuge-engine/dlg/ngaslite.py
+++ b/daliuge-engine/dlg/ngaslite.py
@@ -34,7 +34,7 @@ import urllib.request
 import requests
 from xml.dom.minidom import parseString
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def open(

--- a/daliuge-engine/dlg/nm_dim_assigner.py
+++ b/daliuge-engine/dlg/nm_dim_assigner.py
@@ -1,7 +1,7 @@
 import logging
 from dlg.manager import client
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class NMAssigner:
@@ -12,6 +12,7 @@ class NMAssigner:
     Allocation logic is currently very simple, handling only the case of a single DIM, but with
     room for more advanced load-balancing, if we require in the future.
     """
+
     def __init__(self):
         self.DIMs = {}  # Set of DIMs   name -> (server, port)
         self.NMs = {}  # Set of NMs     name -> (server, port)

--- a/daliuge-engine/dlg/remote.py
+++ b/daliuge-engine/dlg/remote.py
@@ -33,7 +33,7 @@ from paramiko.rsakey import RSAKey
 import scp
 from typing import Union
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def execRemoteWithClient(client, command, timeout=None, bufsize=-1):

--- a/daliuge-engine/dlg/restserver.py
+++ b/daliuge-engine/dlg/restserver.py
@@ -25,7 +25,7 @@ import bottle
 
 from .restutils import RestServerWSGIServer
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class RestServer(object):

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -39,7 +39,7 @@ from dlg.manager.manager_data import Node
 
 from . import utils
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class RPCObject(object):
@@ -189,7 +189,7 @@ class ZeroRPCClient(RPCClientBase):
 
     def run_zrpcclient(self, host, port, req_queue):
         if isinstance(host, Node):
-            host = host.host # split(":")[0]
+            host = host.host  # split(":")[0]
         client = zerorpc.Client("tcp://%s:%d" % (host, port), context=self._context)
 
         forwarder = gevent.spawn(self.forward_requests, req_queue, client)

--- a/daliuge-engine/dlg/runtime/__init__.py
+++ b/daliuge-engine/dlg/runtime/__init__.py
@@ -59,9 +59,7 @@ def setup_logger_class():
                 drop = None
             try:
                 drop_uid = drop._humanKey if drop else ""
-                print(f">>>> makeRecord {drop.name} drop_uid: {drop_uid}")
             except AttributeError:
-                print(f">>>> makeRecord: no drop!!")
                 drop_uid = ""
 
             # Do the same with the session_id, which can be found via the drop (if any)
@@ -74,11 +72,6 @@ def setup_logger_class():
                     session_id = session.track_current_session.tlocal.session.sessionId
                 except AttributeError:
                     pass
-            (
-                print(f">>>> makeRecord >>> {drop.name} drop_uid: {drop_uid}")
-                if drop and hasattr(drop, "name")
-                else print(">>>> makeRecord pass")
-            )
             record.drop_uid = drop_uid
             record.session_id = session_id
             return record

--- a/daliuge-engine/dlg/runtime/__init__.py
+++ b/daliuge-engine/dlg/runtime/__init__.py
@@ -58,8 +58,10 @@ def setup_logger_class():
             except AttributeError:
                 drop = None
             try:
-                drop_uid = drop.uid if drop else ""
+                drop_uid = drop._humanKey if drop else ""
+                print(f">>>> makeRecord {drop.name} drop_uid: {drop_uid}")
             except AttributeError:
+                print(f">>>> makeRecord: no drop!!")
                 drop_uid = ""
 
             # Do the same with the session_id, which can be found via the drop (if any)
@@ -72,6 +74,11 @@ def setup_logger_class():
                     session_id = session.track_current_session.tlocal.session.sessionId
                 except AttributeError:
                     pass
+            (
+                print(f">>>> makeRecord >>> {drop.name} drop_uid: {drop_uid}")
+                if drop and hasattr(drop, "name")
+                else print(">>>> makeRecord pass")
+            )
             record.drop_uid = drop_uid
             record.session_id = session_id
             return record

--- a/daliuge-engine/dlg/shared_memory.py
+++ b/daliuge-engine/dlg/shared_memory.py
@@ -33,7 +33,7 @@ import warnings
 
 import _posixshmem  # Does not work on Windows
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 _O_CREX = os.O_CREAT | os.O_EXCL
 _MAXNAMELENGTH = 14  # Apparently FreeBSD has this limitation

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -31,12 +31,13 @@ try:
 except ModuleNotFoundError:
     from importlib_metadata import version, PackageNotFoundError
 
-from pathlib  import Path
+from pathlib import Path
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.install import install
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
+
 
 # Version information
 # We do like numpy: we have a major/minor/patch hand-written version written
@@ -53,14 +54,14 @@ def extract_version():
     """
     TAG_VERSION_FILE = "VERSION"
     content = ""
-    with (Path(__file__).parent / TAG_VERSION_FILE).open(
-            encoding="utf8") as open_file:
+    with (Path(__file__).parent / TAG_VERSION_FILE).open(encoding="utf8") as open_file:
         major, minor, patch = open_file.read().strip("v").split(".")
         print("logging details: ", major, minor, patch)
     return int(major), int(minor), int(patch)
 
+
 major, minor, patch = extract_version()
-VERSION=f"{major}.{minor}.{patch}"
+VERSION = f"{major}.{minor}.{patch}"
 RELEASE = True
 VERSION_FILE = "dlg/runtime/version.py"
 PTH_FILE = "lib64_dist.pth"
@@ -178,10 +179,7 @@ extra_requires = {
     "MPI": ["mpi4py"],
     # AWS storage types
     "aws": ["boto3"],
-    "test": [
-        "pytest",
-        "eagle-test-graphs"
-    ],
+    "test": ["pytest", "eagle-test-graphs"],
 }
 
 setup(
@@ -217,7 +215,7 @@ setup(
     package_data={
         "": ["VERSION"],
         "dlg.apps": ["dlg_app.h", "dlg_app2.h"],
-        "dlg.deploy.configs": ["*.ini", ".slurm"], 
+        "dlg.deploy.configs": ["*.ini", ".slurm"],
         "dlg.manager": [
             "web/*.html",
             "web/static/css/*.css",

--- a/daliuge-engine/test/apps/test_docker.py
+++ b/daliuge-engine/test/apps/test_docker.py
@@ -79,7 +79,7 @@ class DockerTests(unittest.TestCase):
         """
 
         a = FileDROP("a", "a")
-        b = DockerApp("b", "b", image="ubuntu:22.04", command="cp %i0 %o0")
+        b = DockerApp("b", "b", image="ubuntu:14.04", command="cp %i0 %o0")
         c = FileDROP("c", "c")
 
         b.addInput(a)
@@ -117,10 +117,10 @@ class DockerTests(unittest.TestCase):
         b = DockerApp(
             "b",
             "b",
-            image="ubuntu:22.04",
+            image="ubuntu:14.04",
             command="cat %i0 > /dev/tcp/%containerIp[c]%/8000",
         )
-        c = DockerApp("c", "c", image="ubuntu:22.04", command="nc -l 8000 > %o0")
+        c = DockerApp("c", "c", image="ubuntu:14.04", command="nc -l 8000 > %o0")
         d = FileDROP("d", "d")
 
         b.addInput(a)
@@ -146,7 +146,7 @@ class DockerTests(unittest.TestCase):
         """
 
         def assertMsgIsCorrect(msg, command):
-            a = DockerApp("a", "a", image="ubuntu:22.04", command=command)
+            a = DockerApp("a", "a", image="ubuntu:14.04", command=command)
             b = FileDROP("b", "b")
             a.addOutput(b)
             with DROPWaiterCtx(self, b, 100):
@@ -180,7 +180,7 @@ class DockerTests(unittest.TestCase):
             "HelloWorld_out.txt", "HelloWorld_out.txt"
         )  # not a filesystem-related DROP, we can reference its URL in the command-line
         a.ngasSrv = "ngas.icrar.org"
-        b = DockerApp("b", "b", image="ubuntu:22.04", command=command)
+        b = DockerApp("b", "b", image="ubuntu:14.04", command=command)
         c = FileDROP("c", "c")
         b.addInput(a)
         b.addOutput(c)
@@ -200,7 +200,7 @@ class DockerTests(unittest.TestCase):
         a = DockerApp(
             "a",
             "a",
-            image="ubuntu:22.04",
+            image="ubuntu:14.04",
             command="cp /opt/file %s" % (tempDir,),
             additionalBindings=[tempDir, "%s:/opt/file" % (tempFile,)],
         )
@@ -224,7 +224,7 @@ class DockerTests(unittest.TestCase):
             "a",
             "a",
             workingDir="/mydir",
-            image="ubuntu:22.04",
+            image="ubuntu:14.04",
             command="pwd > %o0 && sleep 0.05",
             ensureUserAndSwitch=ensureUserAndSwitch,
         )

--- a/daliuge-engine/test/apps/test_docker.py
+++ b/daliuge-engine/test/apps/test_docker.py
@@ -79,7 +79,7 @@ class DockerTests(unittest.TestCase):
         """
 
         a = FileDROP("a", "a")
-        b = DockerApp("b", "b", image="ubuntu:14.04", command="cp %i0 %o0")
+        b = DockerApp("b", "b", image="ubuntu:22.04", command="cp %i0 %o0")
         c = FileDROP("c", "c")
 
         b.addInput(a)
@@ -117,10 +117,10 @@ class DockerTests(unittest.TestCase):
         b = DockerApp(
             "b",
             "b",
-            image="ubuntu:14.04",
+            image="ubuntu:22.04",
             command="cat %i0 > /dev/tcp/%containerIp[c]%/8000",
         )
-        c = DockerApp("c", "c", image="ubuntu:14.04", command="nc -l 8000 > %o0")
+        c = DockerApp("c", "c", image="ubuntu:22.04", command="nc -l 8000 > %o0")
         d = FileDROP("d", "d")
 
         b.addInput(a)
@@ -146,7 +146,7 @@ class DockerTests(unittest.TestCase):
         """
 
         def assertMsgIsCorrect(msg, command):
-            a = DockerApp("a", "a", image="ubuntu:14.04", command=command)
+            a = DockerApp("a", "a", image="ubuntu:22.04", command=command)
             b = FileDROP("b", "b")
             a.addOutput(b)
             with DROPWaiterCtx(self, b, 100):
@@ -180,7 +180,7 @@ class DockerTests(unittest.TestCase):
             "HelloWorld_out.txt", "HelloWorld_out.txt"
         )  # not a filesystem-related DROP, we can reference its URL in the command-line
         a.ngasSrv = "ngas.icrar.org"
-        b = DockerApp("b", "b", image="ubuntu:14.04", command=command)
+        b = DockerApp("b", "b", image="ubuntu:22.04", command=command)
         c = FileDROP("c", "c")
         b.addInput(a)
         b.addOutput(c)
@@ -200,7 +200,7 @@ class DockerTests(unittest.TestCase):
         a = DockerApp(
             "a",
             "a",
-            image="ubuntu:14.04",
+            image="ubuntu:22.04",
             command="cp /opt/file %s" % (tempDir,),
             additionalBindings=[tempDir, "%s:/opt/file" % (tempFile,)],
         )
@@ -224,7 +224,7 @@ class DockerTests(unittest.TestCase):
             "a",
             "a",
             workingDir="/mydir",
-            image="ubuntu:14.04",
+            image="ubuntu:22.04",
             command="pwd > %o0 && sleep 0.05",
             ensureUserAndSwitch=ensureUserAndSwitch,
         )

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -40,7 +40,7 @@ from test.dlg_engine_testutils import NMTestsMixIn
 
 from ..manager import test_dm
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def func1(arg1):

--- a/daliuge-engine/test/apps/test_pyfunc.py
+++ b/daliuge-engine/test/apps/test_pyfunc.py
@@ -136,7 +136,7 @@ class TestPyFuncApp(unittest.TestCase):
 
     def test_pickle_func(self, f=lambda x: x, input_data="hello", output_data="hello"):
         a = InMemoryDROP("a", "a")
-        kwargs = {a.uid: 'x'}
+        kwargs = {a.uid: "x"}
         b = _PyFuncApp("b", "b", f, **kwargs)
         c = InMemoryDROP("c", "c")
 
@@ -154,21 +154,21 @@ class TestPyFuncApp(unittest.TestCase):
         input_data = [2, 2] if input_data is None else input_data
         output_data = [2, 2] if output_data is None else output_data
         a = InMemoryDROP("a", "a")
-        kwargs = {a.uid: 'x'}
+        kwargs = {a.uid: "x"}
         b = _PyFuncApp(
             "b",
             "b",
             f,
             input_parser=DropParser.EVAL,
             output_parser=DropParser.EVAL,
-            **kwargs
+            **kwargs,
         )
         c = InMemoryDROP("c", "c")
 
         b.addInput(a)
         b.addOutput(c)
 
-        with DROPWaiterCtx(self, c, 5):
+        with DROPWaiterCtx(self, c, 300):
             a.write(repr(input_data).encode("utf-8"))
             a.setCompleted()
         for drop in a, b, c:
@@ -181,15 +181,10 @@ class TestPyFuncApp(unittest.TestCase):
     def test_string2json_func(self, f=string2json, input_data=None, output_data=None):
         input_data = '["a", "b", "c"]' if input_data is None else input_data
         output_data = ["a", "b", "c"] if output_data is None else output_data
- 
+
         a = InMemoryDROP("a", "a")
-        kwargs = {a.uid: 'string'}
-        b = _PyFuncApp(
-            "b",
-            "b",
-            f,
-            **kwargs
-        )
+        kwargs = {a.uid: "string"}
+        b = _PyFuncApp("b", "b", f, **kwargs)
         c = InMemoryDROP("c", "c")
 
         b.addInput(a)
@@ -207,14 +202,14 @@ class TestPyFuncApp(unittest.TestCase):
         output_data = numpy.ones([2, 2]) if output_data is None else output_data
 
         a = InMemoryDROP("a", "a")
-        kwargs = {a.uid: 'x'}
+        kwargs = {a.uid: "x"}
         b = _PyFuncApp(
             "b",
             "b",
             f,
             input_parser=DropParser.NPY,
             output_parser=DropParser.NPY,
-            **kwargs
+            **kwargs,
         )
         c = InMemoryDROP("c", "c")
 
@@ -230,7 +225,7 @@ class TestPyFuncApp(unittest.TestCase):
 
     def _test_simple_functions(self, f, input_data, output_data, argname):
         a, c = [InMemoryDROP(x, x) for x in ("a", "c")]
-        kwargs = {a.uid:argname}
+        kwargs = {a.uid: argname}
         b = _PyFuncApp("b", "b", f, **kwargs)
         b.addInput(a)
         b.addOutput(c)
@@ -474,10 +469,8 @@ class PyFuncAppIntraNMTest(NMTestsMixIn, unittest.TestCase):
                 "dropclass": "dlg.apps.pyfunc.PyFuncApp",
                 "func_name": __name__ + ".func1",
                 "inputs": [
-                    {
-                        "A": "arg1"
-                    },
-                ]
+                    {"A": "arg1"},
+                ],
             },
             {
                 "oid": "C",
@@ -514,11 +507,9 @@ class PyFuncAppIntraNMTest(NMTestsMixIn, unittest.TestCase):
                 "dropclass": "dlg.apps.pyfunc.PyFuncApp",
                 "func_name": __name__ + ".func1",
                 "inputs": [
-                    {
-                        "A": "arg1"
-                    },
-                ]
-            }
+                    {"A": "arg1"},
+                ],
+            },
         ]
         g2 = [
             {

--- a/daliuge-engine/test/apps/test_simple.py
+++ b/daliuge-engine/test/apps/test_simple.py
@@ -46,7 +46,7 @@ from dlg.data.drops.file import FileDROP
 if sys.version_info >= (3, 8):
     from dlg.manager.shared_memory_manager import DlgSharedMemoryManager
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class TestSimpleApps(unittest.TestCase):
@@ -278,7 +278,9 @@ class TestSimpleApps(unittest.TestCase):
         max_threads = cpu_count(logical=False)
         drop_ids = [chr(97 + x) for x in range(max_threads)]
         threadpool = ThreadPool(processes=max_threads)
-        memory_manager = DlgSharedMemoryManager()  # pylint: disable=possibly-used-before-assignment
+        memory_manager = (
+            DlgSharedMemoryManager()
+        )  # pylint: disable=possibly-used-before-assignment
         session_id = 1
         memory_manager.register_session(session_id)
         S = InMemoryDROP("S", "S")

--- a/daliuge-engine/test/graphs/test_graphExecution.py
+++ b/daliuge-engine/test/graphs/test_graphExecution.py
@@ -70,7 +70,7 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         """
         sessionId = "lalo"
         ddGraph = "ddTest.graph"
-        with (files(test_graphs) /ddGraph).open() as f:  # @UndefinedVariable
+        with (files(test_graphs) / ddGraph).open() as f:  # @UndefinedVariable
             logger.debug(f"Loading graph: {f}")
             graphSpec = json.load(f)
         self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
@@ -98,8 +98,10 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         """
         init_oid = "2022-03-20T04:33:27_-2_0"  # first drop in graph
         sessionId = "lalo"
-        with (files(test_graphs) / "funcTestPG_namedPorts.graph").open() as f:  # @UndefinedVariable
-           graphSpec = json.load(f)
+        with (
+            files(test_graphs) / "funcTestPG_namedPorts.graph"
+        ).open() as f:  # @UndefinedVariable
+            graphSpec = json.load(f)
         # dropSpecs = graph_loader.loadDropSpecs(graphSpec)
         self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
 
@@ -121,8 +123,10 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         translate = lambda x: base64.b64encode(pickle.dumps(x))
         init_oid = "2023-07-04T00:13:32_-1_0"  # first drop in graph
         sessionId = "lalo"
-        with (files(test_graphs) / "appTestPG_namedPorts.graph").open() as f:  # @UndefinedVariable
-           graphSpec = json.load(f)
+        with (
+            files(test_graphs) / "appTestPG_namedPorts.graph"
+        ).open() as f:  # @UndefinedVariable
+            graphSpec = json.load(f)
         # dropSpecs = graph_loader.loadDropSpecs(graphSpec)
         self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
 
@@ -148,7 +152,9 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
             "2022-03-30T03:46:01_-6_0",
         ]  # first drops in graph
         sessionId = "lalo"
-        with (files(test_graphs) / "pyfunc_glob_testPG.graph").open() as f:  # @UndefinedVariable
+        with (
+            files(test_graphs) / "pyfunc_glob_testPG.graph"
+        ).open() as f:  # @UndefinedVariable
             graphSpec = json.load(f)
         # dropSpecs = graph_loader.loadDropSpecs(graphSpec)
         self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
@@ -196,8 +202,10 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         """
         init_oid = "2023-07-05T10:59:43_-5_0"  # first drop in graph
         sessionId = "lalo"
-        with (files(test_graphs) / "HelloWorld_universePG.graph").open() as f:  # @UndefinedVariable
-           graphSpec = json.load(f)
+        with (
+            files(test_graphs) / "HelloWorld_universePG.graph"
+        ).open() as f:  # @UndefinedVariable
+            graphSpec = json.load(f)
         # dropSpecs = graph_loader.loadDropSpecs(graphSpec)
         self.createSessionAndAddGraph(sessionId, graphSpec=graphSpec)
 
@@ -210,6 +218,6 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
             logger.debug(f"PyfuncAPPDrop producer names:{i}")
 
         st = time.time()
-        with droputils.DROPWaiterCtx(self, fd, 300):
+        with droputils.DROPWaiterCtx(self, fd, 3):
             init_drop.execute()
         # self.assertAlmostEqual(0.6, time.time() - st, 1)

--- a/daliuge-engine/test/integrate/chiles/chilesdo.py
+++ b/daliuge-engine/test/integrate/chiles/chilesdo.py
@@ -27,7 +27,7 @@ from six.moves import queue as Queue  # @UnresolvedImport
 from dlg.apps.app_base import BarrierAppDROP
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class SourceFlux(BarrierAppDROP):

--- a/daliuge-engine/test/integrate/freq_split.py
+++ b/daliuge-engine/test/integrate/freq_split.py
@@ -14,7 +14,7 @@ import sys
 from optparse import OptionParser
 from string import Template
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 ms_transform_tpl = """
 mstransform(vis='${infile}',

--- a/daliuge-engine/test/manager/test_scalability.py
+++ b/daliuge-engine/test/manager/test_scalability.py
@@ -29,7 +29,7 @@ from dlg.utils import terminate_or_kill
 
 from test.dlg_engine_testutils import DROPManagerUtils, TerminatingTestHelper
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 hostname = "localhost"
 
 

--- a/daliuge-engine/test/test_drop.py
+++ b/daliuge-engine/test/test_drop.py
@@ -20,9 +20,11 @@
 #    MA 02111-1307  USA
 #
 
+import base64
 import contextlib
 import io
 import os, unittest
+import pickle
 import random
 import shutil
 import sqlite3
@@ -43,7 +45,7 @@ from dlg.data.drops.directorycontainer import DirectoryContainer
 from dlg.data.drops.file import FileDROP
 from dlg.droputils import DROPWaiterCtx
 from dlg.exceptions import InvalidDropException
-from dlg.apps.simple import NullBarrierApp, SimpleBranch, SleepAndCopyApp
+from dlg.apps.simple import NullBarrierApp, Branch, SleepAndCopyApp
 
 try:
     from crc32c import crc32c
@@ -1157,11 +1159,15 @@ class TestDROPReproducibility(unittest.TestCase):
             os.unlink(dbfile)
 
 
+def func1(result):
+    return result
+
+
 class BranchAppDropTestsBase(object):
-    """Tests for the BranchAppDrop class"""
+    """Tests for the Branch class"""
 
     def _simple_branch_with_outputs(self, result, uids):
-        a = SimpleBranch(uids[0], uids[0], result=result)
+        a = Branch(uids[0], uids[0], result=result, func_name="test.test_drop.func1")
         b, c = (self.DataDropType(x, x) for x in uids[1:])
         a.addOutput(b)
         a.addOutput(c)
@@ -1275,7 +1281,7 @@ class BranchAppDropTestsBase(object):
             last_first_output = y
 
         with DROPWaiterCtx(
-            self, all_drops, 2, [DROPStates.COMPLETED, DROPStates.SKIPPED]
+            self, all_drops, 300, [DROPStates.COMPLETED, DROPStates.SKIPPED]
         ):
             a.async_execute()
 

--- a/daliuge-engine/test/test_named_port_apps.py
+++ b/daliuge-engine/test/test_named_port_apps.py
@@ -23,11 +23,11 @@
 """
 Unit/regression testing for the application of named_port_utils.py
 
-Use examples derived from the following DROP classes: 
+Use examples derived from the following DROP classes:
 - pyfunc
 - s3_drop
 - bash_shell_app
-- dockerapp 
+- dockerapp
 - mpi
 """
 import dill
@@ -37,7 +37,7 @@ import pytest
 import json
 
 logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 # Note this test will only run with a full installation of DALiuGE.
 pexpect = pytest.importorskip("dlg.dropmake")
@@ -52,10 +52,9 @@ from dlg.ddap_protocol import DROPStates
 from dlg.dropmake import path_utils
 
 
-def create_and_run_graph_spec_from_lgt(test_case: unittest.TestCase,
-                                       graph_name: str,
-                                       resolve_path = True,
-                                       app_root=True):
+def create_and_run_graph_spec_from_lgt(
+    test_case: unittest.TestCase, graph_name: str, resolve_path=True, app_root=True
+):
     """
     Boilerplate graph running code which takes a Logical Graph Template (LGT) and
     performs the translation and submission through the graph loader.
@@ -66,8 +65,8 @@ def create_and_run_graph_spec_from_lgt(test_case: unittest.TestCase,
         spec = Path(path_utils.get_lg_fpath("drop_spec", graph_name))
     else:
         spec = Path(graph_name)
-    with spec.open('r', encoding="utf-8") as f:
-            appDropSpec = json.load(f)
+    with spec.open("r", encoding="utf-8") as f:
+        appDropSpec = json.load(f)
 
     roots = graph_loader.createGraphFromDropSpecList(appDropSpec)
     # drops = [v for d,v in drops.items()]
@@ -85,26 +84,27 @@ def create_and_run_graph_spec_from_lgt(test_case: unittest.TestCase,
 
 class TestPortsEncoding(unittest.TestCase):
     """
-    Given a dropspec, make sure the ports are loaded correctly. 
-    """ 
+    Given a dropspec, make sure the ports are loaded correctly.
+    """
+
     def test_pyfunc_ports_encoding(self):
         """
-        
-        This test evaluates the use of per-port encoding using the test_ports.graph, 
-        described below. 
-        
+
+        This test evaluates the use of per-port encoding using the test_ports.graph,
+        described below.
+
         The CreateMultiA drop has inputs of 2,8 (non-default), which are replicated
-        with the chosen encoding (numpy and pickle, respectively). These are passed to 
+        with the chosen encoding (numpy and pickle, respectively). These are passed to
         CreateMultiB, which again replicates the output with selected encoding. These are
-        passed to FileDrops, from which we can confirm the encoding has worked as 
-        expected. 
+        passed to FileDrops, from which we can confirm the encoding has worked as
+        expected.
 
 
                     ------> numpy(2) ---              ------> "numpy(2)"
                     |                   |             |
-                    (npy)              (npy)        (UTF-8) 
+                    (npy)              (npy)        (UTF-8)
                     |                   |             |
-        <CreateMultiA(2,8)>                  <CreateMultiB> 
+        <CreateMultiA(2,8)>                  <CreateMultiB>
                     |                   |             |
                     (pickle)          (pickle)       (pickle)
                     |                   |             |
@@ -113,27 +113,27 @@ class TestPortsEncoding(unittest.TestCase):
 
         leafs = create_and_run_graph_spec_from_lgt(self, "test_ports.graph")
         for l in leafs:
-            self.assertEqual(DROPStates.COMPLETED, l.status) 
+            self.assertEqual(DROPStates.COMPLETED, l.status)
 
-        # Leaf Node 1 has been encoded first as numpy, second as UTF-8. 
+        # Leaf Node 1 has been encoded first as numpy, second as UTF-8.
         leaf = leafs.pop()
         desc = leaf.open()
         self.assertEqual(8, dill.loads(leaf.read(desc)))
         leaf = leafs.pop()
         desc = leaf.open()
         self.assertEqual("array(2)", leaf.read(desc).decode())
-        
 
     @unittest.skip
-    def test_bash_shell_ports(self): 
+    def test_bash_shell_ports(self):
         """
         "drop_spec", "pyfunc_glob_shell_test.graph"
         """
         leafs = create_and_run_graph_spec_from_lgt(self, "pyfunc_glob_shell_test.graph")
-        
+
         for l in leafs:
-            self.assertEqual(DROPStates.COMPLETED, l.status) 
+            self.assertEqual(DROPStates.COMPLETED, l.status)
         self.assertEqual(0, leafs.pop().proc.returncode)
+
 
 class TestSimpleFunctionGraphs(unittest.TestCase):
 
@@ -150,6 +150,7 @@ class TestSimpleFunctionGraphs(unittest.TestCase):
         """
 
         import daliuge_tests.engine.simple_functions as simple_functions
+
         graph = f"{files(simple_functions)}/string2jsonPG.graph"
         leafs = create_and_run_graph_spec_from_lgt(self, graph, resolve_path=False)
         for l in leafs:
@@ -159,9 +160,8 @@ class TestSimpleFunctionGraphs(unittest.TestCase):
         for l in leafs:
             self.assertEqual(DROPStates.COMPLETED, l.status)
         graph = f"{files(simple_functions)}/string2json_incorrect_paramtypePGT.graph"
-        leafs = create_and_run_graph_spec_from_lgt(self,
-                                                   graph,
-                                                   resolve_path=False,
-                                                   app_root=False)
+        leafs = create_and_run_graph_spec_from_lgt(
+            self, graph, resolve_path=False, app_root=False
+        )
         for l in leafs:
             self.assertEqual(DROPStates.COMPLETED, l.status)

--- a/daliuge-translator/dlg/dropmake/dm_utils.py
+++ b/daliuge-translator/dlg/dropmake/dm_utils.py
@@ -35,7 +35,7 @@ from .definition_classes import Categories, ConstructTypes
 
 from typing import Dict
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 LG_VER_OLD = 1
 LG_VER_EAGLE_CONVERTED = 2
@@ -70,9 +70,9 @@ def get_lg_ver_type(lgo):
 
     # First check whether modelData and schemaVersion is in graph
     if (
-            "modelData" in lgo
-            and len(lgo["modelData"]) > 0
-            and "schemaVersion" in lgo["modelData"]
+        "modelData" in lgo
+        and len(lgo["modelData"]) > 0
+        and "schemaVersion" in lgo["modelData"]
     ):
         if lgo["modelData"]["schemaVersion"] != "OJS":
             return lgo["modelData"]["schemaVersion"]
@@ -197,9 +197,7 @@ def convert_mkn(lgo):
         for ak in app_keywords:
             if ak not in node:
                 raise Exception(
-                    "MKN construct {0} must specify {1}".format(
-                        node["id"], ak
-                    )
+                    "MKN construct {0} must specify {1}".format(node["id"], ak)
                 )
         mknv_dict = dict()
         for mknv in node["fields"]:
@@ -360,9 +358,7 @@ def convert_mkn_all_share_m(lgo):
         for ak in app_keywords:
             if ak not in node:
                 raise Exception(
-                    "MKN construct {0} must specify {1}".format(
-                        node["id"], ak
-                    )
+                    "MKN construct {0} must specify {1}".format(node["id"], ak)
                 )
         mknv_dict = dict()
         for mknv in node["fields"]:
@@ -482,10 +478,10 @@ def convert_construct(lgo):
         # step 1
         app_args = {"fields": "inputAppFields"}
         if node["category"] == ConstructTypes.GATHER:
-            app_args['group_start'] = 1
+            app_args["group_start"] = 1
 
         if node["category"] == ConstructTypes.SERVICE:
-            app_args['isService'] = True
+            app_args["isService"] = True
 
         app_node = _create_from_node(node, node[has_app], app_args)
 
@@ -506,11 +502,12 @@ def convert_construct(lgo):
             keyset.add(dup_app_node_k)
             dup_app_args = {
                 "id": dup_app_node_k,
-                "fields": "appFields" if "appFields" in node else "inputAppFields"
+                "fields": "appFields" if "appFields" in node else "inputAppFields",
             }
-            tmp_node = _create_from_node(node=node, category=node[has_app],
-                                         app_params=dup_app_args)
-            redundant_keys = ['fields', 'reprodata']
+            tmp_node = _create_from_node(
+                node=node, category=node[has_app], app_params=dup_app_args
+            )
+            redundant_keys = ["fields", "reprodata"]
             tmp_node = {k: v for k, v in tmp_node.items() if k not in redundant_keys}
             duplicated_gather_app[new_id] = tmp_node
 
@@ -559,15 +556,12 @@ def convert_construct(lgo):
                     new_id = old_new_gather_map[k_old]
                     to_node = node_index[link["to"]]
                     gather_construct = node_index[new_id]
-                    if (
-                            "parentId" not in to_node
-                            and "parentId" not in gather_construct
-                    ):
+                    if "parentId" not in to_node and "parentId" not in gather_construct:
                         cond1 = True
                     elif (
-                            "parentId" in to_node
-                            and "parentId" in gather_construct
-                            and to_node["parentId"] == gather_construct["parentId"]
+                        "parentId" in to_node
+                        and "parentId" in gather_construct
+                        and to_node["parentId"] == gather_construct["parentId"]
                     ):
                         cond1 = True
                     else:
@@ -607,18 +601,18 @@ def _create_from_node(node: dict, category: str, app_params: dict) -> dict:
     new_node["id"] = node["id"]
     new_node["category"] = category
 
-    new_node["name"] = node["text"] if 'text' in node else node["name"]
+    new_node["name"] = node["text"] if "text" in node else node["name"]
     if "mkn" in node:
         new_node["mkn"] = node["mkn"]
 
     if "parentId" in node:
         new_node["parentId"] = node["parentId"]
 
-    if 'fields' in app_params:
+    if "fields" in app_params:
         field = app_params.pop("fields")
         if field in node:
-            new_node['fields'] = list(node[field])
-            new_node['fields'] += node["fields"]
+            new_node["fields"] = list(node[field])
+            new_node["fields"] += node["fields"]
             for afd in node[field]:
                 new_node[afd["name"]] = afd["value"]
 
@@ -677,9 +671,9 @@ def _update_keys(old_new_grpk_map: dict, lgo: dict) -> dict:
     return lgo
 
 
-def identify_and_connect_output_input(input_node: dict,
-                                      out_node: dict,
-                                      logical_graph: dict) -> dict:
+def identify_and_connect_output_input(
+    input_node: dict, out_node: dict, logical_graph: dict
+) -> dict:
     """
     # If the link is to a node that _isn't_ in the subgraph group
     # then it is an output node,  so check that group is either
@@ -694,30 +688,30 @@ def identify_and_connect_output_input(input_node: dict,
     :return: logical_graph: the updated logical_graph
     """
 
-    for link in logical_graph['linkDataArray']:
+    for link in logical_graph["linkDataArray"]:
         if link["to"] == input_node["id"]:
-            for n in logical_graph['nodeDataArray']:
+            for n in logical_graph["nodeDataArray"]:
 
                 if n["id"] == link["from"]:
                     try:
-                        if n['parentId'] == input_node['parentId']:
+                        if n["parentId"] == input_node["parentId"]:
                             link["to"] = out_node["id"]
                     except KeyError:
                         pass
         if link["from"] == input_node["id"]:
-            for n in logical_graph['nodeDataArray']:
+            for n in logical_graph["nodeDataArray"]:
                 if n["id"] == link["to"]:
                     try:
-                        if n['parentId'] != input_node['parentId']:
-                            link['from'] = out_node["id"]
+                        if n["parentId"] != input_node["parentId"]:
+                            link["from"] = out_node["id"]
                     except KeyError:
-                        link['from'] = out_node["id"]
+                        link["from"] = out_node["id"]
     return logical_graph
 
 
-def _extract_subgraph_nodes(input_node: dict,
-                            out_node: dict,
-                            logical_graph: dict) -> (dict, dict, dict):
+def _extract_subgraph_nodes(
+    input_node: dict, out_node: dict, logical_graph: dict
+) -> (dict, dict, dict):
     """
     1. Identify the SubGraph nodes that are not from the Construct
     2. Find the data inputs to the outputApp
@@ -737,44 +731,49 @@ def _extract_subgraph_nodes(input_node: dict,
     construct_apps = {input_node["id"], out_node["id"]}
 
     # 1. Identifying subgraph nodes that are not the input/ouput app
-    for n in logical_graph['nodeDataArray']:
-        if ('parentId' in n
-                and n['parentId'] == input_node['parentId']
-                and n["id"] not in construct_apps):
+    for n in logical_graph["nodeDataArray"]:
+        if (
+            "parentId" in n
+            and n["parentId"] == input_node["parentId"]
+            and n["id"] not in construct_apps
+        ):
             subgraphNodes[n["id"]] = n
 
     output_links = {}
 
-    for link in logical_graph['linkDataArray']:
-        if link['from'] in subgraphNodes:
+    for link in logical_graph["linkDataArray"]:
+        if link["from"] in subgraphNodes:
             # Find links from inside the SubGraph to the Output App to preserve
-            if link['to'] in construct_apps:
-                key = subgraphNodes[link['from']]
+            if link["to"] in construct_apps:
+                key = subgraphNodes[link["from"]]
                 output_links[key["id"]] = {}
-                output_links[key["id"]]['node'] = key
-                output_links[key["id"]]['link'] = link
+                output_links[key["id"]]["node"] = key
+                output_links[key["id"]]["link"] = link
             subgraphLinks.append(link)
-        if link['to'] in subgraphNodes.keys() and link not in subgraphLinks:
+        if link["to"] in subgraphNodes.keys() and link not in subgraphLinks:
             subgraphLinks.append(link)
 
     for e in subgraphNodes.values():
         if e["id"] not in output_links:
-            logical_graph['nodeDataArray'].remove(e)
+            logical_graph["nodeDataArray"].remove(e)
     for e in subgraphLinks:
-        logical_graph['linkDataArray'].remove(e)
+        logical_graph["linkDataArray"].remove(e)
 
     # Ensure we aren't linking from the Input/Output app into the subgraph
     # Any nodes outside the subgraph won't exist when it is deployed.
-    subgraphLinks = [link for link in subgraphLinks
-                     if (link['from'] not in construct_apps)]
-    subgraphLinks = [link for link in subgraphLinks
-                     if (link['to'] not in construct_apps)]
+    subgraphLinks = [
+        link for link in subgraphLinks if (link["from"] not in construct_apps)
+    ]
+    subgraphLinks = [
+        link for link in subgraphLinks if (link["to"] not in construct_apps)
+    ]
     # 4. Create links from the subgraph output data to input/output applications
 
     for n in output_links.values():
-        logical_graph['linkDataArray'].append(
-            {'to': n['node']["id"], 'from': input_node["id"]})
-        logical_graph['linkDataArray'].append(n['link'])
+        logical_graph["linkDataArray"].append(
+            {"to": n["node"]["id"], "from": input_node["id"]}
+        )
+        logical_graph["linkDataArray"].append(n["link"])
 
     return subgraphNodes, subgraphLinks, logical_graph
 
@@ -794,26 +793,26 @@ def _build_apps_from_subgraph_construct(subgraph_node: dict) -> (dict, dict):
         "SubGraphGroupKey": subgraph_node["id"],
         "parentId": subgraph_node["id"],
         "group_start": 1,
-        "fields": 'inputAppFields',
-        'inputApp': True
+        "fields": "inputAppFields",
+        "inputApp": True,
     }
-    input_node = _create_from_node(subgraph_node,
-                                   subgraph_node["inputApplicationType"],
-                                   input_app_args)
+    input_node = _create_from_node(
+        subgraph_node, subgraph_node["inputApplicationType"], input_app_args
+    )
 
     output_app_args = {
-        "id": subgraph_node['outputApplicationId'],
+        "id": subgraph_node["outputApplicationId"],
         "isSubGraphApp": True,
         "isSubGraphConstruct": False,
         "SubGraphGroupKey": input_node["id"],
         "parentId": input_node["id"],
         "group_start": 1,
-        "fields": 'outputAppFields',
-        "outputApp": True
+        "fields": "outputAppFields",
+        "outputApp": True,
     }
-    output_node = _create_from_node(subgraph_node,
-                                    subgraph_node["outputApplicationType"],
-                                    output_app_args)
+    output_node = _create_from_node(
+        subgraph_node, subgraph_node["outputApplicationType"], output_app_args
+    )
 
     return input_node, output_node
 
@@ -851,7 +850,7 @@ def convert_subgraphs(lgo: dict) -> dict:
         node["isSubGraphConstruct"] = True
         node["hasInputApp"] = True
         if not _has_app_keywords(node, app_keywords, requires_all=True):
-            node['hasInputApp'] = False
+            node["hasInputApp"] = False
             continue
 
         # Construct nodes
@@ -876,9 +875,9 @@ def convert_subgraphs(lgo: dict) -> dict:
             lgo = _update_keys(old_new_grpk_map, lgo)
 
             # Manage SubGraph nodes and links
-            subgraphNodes, subgraphLinks, lgo = _extract_subgraph_nodes(app_node,
-                                                                        out_node,
-                                                                        lgo)
+            subgraphNodes, subgraphLinks, lgo = _extract_subgraph_nodes(
+                app_node, out_node, lgo
+            )
 
             # Create SubGraph as InputData to the SubGraph Input App
             new_id = str(uuid.uuid4())
@@ -886,11 +885,11 @@ def convert_subgraphs(lgo: dict) -> dict:
             subgraph = {
                 "nodeDataArray": list(subgraphNodes.values()),
                 "linkDataArray": subgraphLinks,
-                "modelData": lgo['modelData']
+                "modelData": lgo["modelData"],
             }
-            for n in lgo['nodeDataArray']:
+            for n in lgo["nodeDataArray"]:
                 if n["id"] == app_node["id"]:
-                    app_node['subgraph'] = subgraph
+                    app_node["subgraph"] = subgraph
 
     return lgo
 
@@ -949,8 +948,8 @@ def convert_eagle_to_daliuge_json(lg_name):
                 group_category = group_node.get("category", "")
 
                 if (
-                        group_category == ConstructTypes.GATHER
-                        or group_category == ConstructTypes.GROUP_BY
+                    group_category == ConstructTypes.GATHER
+                    or group_category == ConstructTypes.GROUP_BY
                 ):
                     # Check if the node is first in that group.
                     fields = node["fields"]
@@ -992,9 +991,7 @@ def convert_eagle_to_daliuge_json(lg_name):
             json.dump(logical_graph, outfile, sort_keys=True, indent=4)
     except Exception as exp:
         raise Exception(
-            "Failed to save a pretranslated graph {0}:{1}".format(
-                lg_name, str(exp)
-            )
+            "Failed to save a pretranslated graph {0}:{1}".format(lg_name, str(exp))
         )
     finally:
         pass

--- a/daliuge-translator/dlg/dropmake/graph_config.py
+++ b/daliuge-translator/dlg/dropmake/graph_config.py
@@ -26,7 +26,7 @@ Module containing utility methods for working with GraphConfigs
 
 import logging
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("dlg." + __name__)
 ACTIVE_CONFIG_KEY = "activeGraphConfigId"
 CONFIG_KEY = "graphConfigurations"
 GRAPH_NODES = "nodeDataArray"
@@ -34,14 +34,14 @@ GRAPH_NODES = "nodeDataArray"
 
 def apply_active_configuration(logical_graph: dict) -> dict:
     """
-    Given a JSON representation of the LogicalGraph Template (LGT), apply the 
+    Given a JSON representation of the LogicalGraph Template (LGT), apply the
     "Active Configuration" to the relevant constructs/fields.
 
     :param: logical_graph, dict representation of JSON LGT
 
-    Currently, this does not raise any exceptions, but logs either warnings or errors. 
-    If there are missing keys or the configuration cannot be applied, it will return 
-    the original LGT. See graph_config.check_config_is_value for more details. 
+    Currently, this does not raise any exceptions, but logs either warnings or errors.
+    If there are missing keys or the configuration cannot be applied, it will return
+    the original LGT. See graph_config.check_config_is_value for more details.
 
     return: dict, the updated LG
     """
@@ -51,25 +51,30 @@ def apply_active_configuration(logical_graph: dict) -> dict:
     try:
         activeConfigurationID = logical_graph[ACTIVE_CONFIG_KEY]
         activeConfig = logical_graph[CONFIG_KEY][activeConfigurationID]
-        nodeDataArray = logical_graph[GRAPH_NODES] 
+        nodeDataArray = logical_graph[GRAPH_NODES]
 
         for node_id, fields in activeConfig["nodes"].items():
-            idx = get_key_idx_from_list(node_id, nodeDataArray) 
+            idx = get_key_idx_from_list(node_id, nodeDataArray)
             if idx is None:
                 LOGGER.warning(
                     "%s present in activeConfig but not available in Logical Graph.",
-                    node_id
+                    node_id,
                 )
-                continue 
+                continue
             node_name = nodeDataArray[idx]["name"]
             for field_id, cfg_field in activeConfig["nodes"][node_id]["fields"].items():
                 fieldidx = get_key_idx_from_list(field_id, nodeDataArray[idx]["fields"])
                 field = nodeDataArray[idx]["fields"][fieldidx]
                 prev_value = field["value"]
-                field["value"] =  cfg_field["value"]
+                field["value"] = cfg_field["value"]
                 field_name = field["name"]
-                LOGGER.info("Updating: Node %s, Field %s, from %s to %s",
-                            node_name, field_name, str(prev_value), str(field["value"]))
+                LOGGER.info(
+                    "Updating: Node %s, Field %s, from %s to %s",
+                    node_name,
+                    field_name,
+                    str(prev_value),
+                    str(field["value"]),
+                )
                 nodeDataArray[idx]["fields"][fieldidx] = field
         logical_graph[GRAPH_NODES] = nodeDataArray
 
@@ -80,39 +85,42 @@ def apply_active_configuration(logical_graph: dict) -> dict:
 
     return logical_graph
 
+
 def is_config_invalid(logical_graph: dict) -> bool:
     """
     Given a logical graph, verify that the correct keys are present prior to applying
-    the configuration. 
+    the configuration.
 
-    We want to make sure that: 
-        - "activeGraphConfigId" and "graphConfigurations" exist 
+    We want to make sure that:
+        - "activeGraphConfigId" and "graphConfigurations" exist
         - Both of these store non-empty information
 
-    Note: We do not perform any validation on if the graphConfig is self-consistent; that 
-    is, if it mentions a graphConfig Key not in the LG, or there is a field/node ID that 
-    is not in the LG, we report this as an error and continue (this implies an error 
+    Note: We do not perform any validation on if the graphConfig is self-consistent; that
+    is, if it mentions a graphConfig Key not in the LG, or there is a field/node ID that
+    is not in the LG, we report this as an error and continue (this implies an error
     upstream that we cannot resolve).
 
-    :return: True if the config has correct keys and they are present. 
+    :return: True if the config has correct keys and they are present.
     """
 
     checkActiveId = logical_graph.get(ACTIVE_CONFIG_KEY)
     if not checkActiveId:
         LOGGER.warning("No %s data available in Logical Graph.", ACTIVE_CONFIG_KEY)
-    checkGraphConfig = logical_graph.get(CONFIG_KEY)    
+    checkGraphConfig = logical_graph.get(CONFIG_KEY)
     if not checkGraphConfig:
         LOGGER.warning("No %s data available in Logical Graph.", CONFIG_KEY)
 
     return (not checkActiveId) or (not checkGraphConfig)
 
 
-def get_key_idx_from_list(key: str, dictList: list) -> int: 
+def get_key_idx_from_list(key: str, dictList: list) -> int:
     """
     Retrieve the index of the node that exists in the nodeDataArray sub-dict in the
-    Logical Graph. 
+    Logical Graph.
 
-    Note: This is necessary because we store each node in a list of dictionaries, rather 
-    than a dict of dicts. 
+    Note: This is necessary because we store each node in a list of dictionaries, rather
+    than a dict of dicts.
     """
-    return next((idx for idx, keyDict in enumerate(dictList) if keyDict['id']==key), None)
+    return next(
+        (idx for idx, keyDict in enumerate(dictList) if keyDict["id"] == key), None
+    )

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -57,7 +57,7 @@ from dlg.dropmake.definition_classes import Categories
 from dlg.dropmake.lg_node import LGNode
 from dlg.dropmake.graph_config import apply_active_configuration
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class LG:
@@ -305,7 +305,9 @@ class LG:
                             self._lg_links.append(lk)
                             logger.debug("Loop constructed: %s", gs._inputs)
                 else:
-                    for gs in (
+                    for (
+                        gs
+                    ) in (
                         gs_list
                     ):  # add artificial logical links to the "first" children
                         lgn.add_input(gs)
@@ -347,10 +349,12 @@ class LG:
                         # self._drop_dict['new_added'].append(src_drop['gather-data_drop'])
                 if recursive:
                     for child in lgn.children:
-                        self.lgn_to_pgn(child, miid, self.get_child_lp_ctx(lgn, lpcxt, i))
+                        self.lgn_to_pgn(
+                            child, miid, self.get_child_lp_ctx(lgn, lpcxt, i)
+                        )
                 else:
                     for child in lgn.children:
-                    # Approach next 'set' of children
+                        # Approach next 'set' of children
                         c_copy = copy.deepcopy(child)
                         c_copy.happy = True
                         c_copy.loop_ctx = self.get_child_lp_ctx(lgn, lpcxt, i)
@@ -431,12 +435,14 @@ class LG:
             Categories.PYTHON_APP,
         ]
 
-    def _link_drops(self, 
-                    slgn: LGNode, 
-                    tlgn: LGNode, 
-                    src_drop: dropdict, 
-                    tgt_drop: dropdict, 
-                    llink: dict):
+    def _link_drops(
+        self,
+        slgn: LGNode,
+        tlgn: LGNode,
+        src_drop: dropdict,
+        tgt_drop: dropdict,
+        llink: dict,
+    ):
         """ """
         sdrop = None
         if slgn.is_gather:
@@ -490,11 +496,11 @@ class LG:
             sname = slgn._getPortName("outputPorts", index=-1)
             tname = tlgn._getPortName("inputPorts")
 
-            # sname is dictionary of all output ports on the sDROP. 
+            # sname is dictionary of all output ports on the sDROP.
             # Therefore there's an expected number of output edges that we need to add
-            # We keep track of this by querying the sDROP's current outputs and seeing 
-            # what is currently 'lowest' in number. Eventual, all output port names will 
-            # be added. 
+            # We keep track of this by querying the sDROP's current outputs and seeing
+            # what is currently 'lowest' in number. Eventual, all output port names will
+            # be added.
             expected = [p for p in sname.keys()]
             output_port = expected[0]
             if "outputs" in sdrop:
@@ -502,9 +508,16 @@ class LG:
                 [actual.extend(pair.values()) for pair in sdrop["outputs"]]
                 actual_counts = {port: actual.count(port) for port in set(expected)}
                 expected_counts = {port: expected.count(port) for port in (expected)}
-                differences = {port: (expected_counts[port] - actual_counts.get(port,0)) for port in expected_counts}
-                candidates = {port: deficit for port, deficit in differences.items() if deficit>0}
-                if candidates: 
+                differences = {
+                    port: (expected_counts[port] - actual_counts.get(port, 0))
+                    for port in expected_counts
+                }
+                candidates = {
+                    port: deficit
+                    for port, deficit in differences.items()
+                    if deficit > 0
+                }
+                if candidates:
                     output_port = max(candidates, key=candidates.get)
             sdrop.addOutput(tdrop, name=output_port)
             tdrop.addProducer(sdrop, name=tname)

--- a/daliuge-translator/dlg/dropmake/lg_node.py
+++ b/daliuge-translator/dlg/dropmake/lg_node.py
@@ -44,7 +44,7 @@ from dlg.dropmake.dm_utils import (
 from dlg.dropmake.utils.bash_parameter import BashCommand
 from .definition_classes import Categories, DATA_TYPES, APP_TYPES
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class LGNode:
@@ -93,7 +93,7 @@ class LGNode:
                 group_q[grp_id].append(self)
 
         done_dict[self.id] = self
-        self.subgraph = jd['subgraph'] if 'subgraph' in jd else None
+        self.subgraph = jd["subgraph"] if "subgraph" in jd else None
         self.happy = False
         self.loop_ctx = None
         self.iid = None
@@ -185,9 +185,7 @@ class LGNode:
         elif self.jd["categoryType"] in ["Other"]:
             value = "Other"
         else:
-            logger.error(
-                "Found unknown categoryType: %s", self.jd["categoryType"]
-            )
+            logger.error("Found unknown categoryType: %s", self.jd["categoryType"])
             # raise ValueError
         for key in keys:
             if key in self.jd:
@@ -249,10 +247,10 @@ class LGNode:
         Add a group member
         """
         if (
-                lg_node.is_group
-                and not (lg_node.is_scatter)
-                and not (lg_node.is_loop)
-                and not (lg_node.is_groupby)
+            lg_node.is_group
+            and not (lg_node.is_scatter)
+            and not (lg_node.is_loop)
+            and not (lg_node.is_groupby)
         ):
             raise GInvalidNode(
                 "Only Scatters, Loops and GroupBys can be nested, but {0} is neither".format(
@@ -310,15 +308,9 @@ class LGNode:
         """
         key = []
         if self.is_app:
-            key = [
-                k
-                for k in self.jd
-                if re.match(r"execution[\s\_]time", k.lower())
-            ]
+            key = [k for k in self.jd if re.match(r"execution[\s\_]time", k.lower())]
         elif self.is_data:
-            key = [
-                k for k in self.jd if re.match(r"data[\s\_]volume", k.lower())
-            ]
+            key = [k for k in self.jd if re.match(r"data[\s\_]volume", k.lower())]
         try:
             self._weight = int(self.jd[key[0]])
         except (KeyError, ValueError, IndexError):
@@ -390,9 +382,9 @@ class LGNode:
         """
         result = False
         if self.has_group() and (
-                "group_start" in self.jd
-                or "Group start" in self.jd
-                or "Group Start" in self.jd
+            "group_start" in self.jd
+            or "Group start" in self.jd
+            or "Group Start" in self.jd
         ):
             gs = (
                 self.jd.get("group_start", False)
@@ -414,9 +406,7 @@ class LGNode:
         """
         result = False
         if self.has_group() and (
-                "group_end" in self.jd
-                or "Group end" in self.jd
-                or "Group End" in self.jd
+            "group_end" in self.jd or "Group end" in self.jd or "Group End" in self.jd
         ):
             ge = (
                 self.jd.get("group_end", False)
@@ -465,7 +455,7 @@ class LGNode:
 
     @property
     def is_subgraph(self):
-        if 'isSubGraphApp' in self._jd:
+        if "isSubGraphApp" in self._jd:
             return self._jd["isSubGraphApp"]
         else:
             return self._jd["category"] == Categories.SUBGRAPH
@@ -550,15 +540,11 @@ class LGNode:
             # group by followed by another group by
             if grpks is None or len(grpks) < 1:
                 raise GInvalidNode(
-                    "Must specify group_key for Group By '{0}'".format(
-                        self.name
-                    )
+                    "Must specify group_key for Group By '{0}'".format(self.name)
                 )
             # find the "root" groupby and get all of its scatters
             inputgrp = self
-            while (inputgrp is not None) and inputgrp.inputs[
-                0
-            ].group.is_groupby:
+            while (inputgrp is not None) and inputgrp.inputs[0].group.is_groupby:
                 inputgrp = inputgrp.inputs[0].group
             # inputgrp now is the "root" groupby that follows Scatter immiately
             # move it to Scatter
@@ -743,9 +729,7 @@ class LGNode:
 
         # NOTE: drop Argxx keywords
 
-    def _getPortName(
-            self, ports: str = "outputPorts", index: int = 0, portId=None
-    ):
+    def _getPortName(self, ports: str = "outputPorts", index: int = 0, portId=None):
         """
         Return name of port if it exists
         """
@@ -780,8 +764,7 @@ class LGNode:
         sij = self.inputs[0]
         if not sij.is_data:
             raise GInvalidNode(
-                "GroupBy should be connected to a DataDrop, not '%s'"
-                % sij.category
+                "GroupBy should be connected to a DataDrop, not '%s'" % sij.category
             )
         dw = sij.weight * self.groupby_width
 
@@ -799,9 +782,7 @@ class LGNode:
         )
         kwargs = {}
         kwargs["grp-data_drop"] = dropSpec_grp
-        kwargs[
-            "weight"
-        ] = 1  # barrier literarlly takes no time for its own computation
+        kwargs["weight"] = 1  # barrier literarlly takes no time for its own computation
         kwargs["sleep_time"] = 1
         drop_spec.update(kwargs)
         drop_spec.addOutput(dropSpec_grp, name="grpdata")
@@ -818,11 +799,7 @@ class LGNode:
         gi = self.inputs[0]
         if gi.is_groupby:
             gii = gi.inputs[0]
-            dw = (
-                    int(gii.jd["data_volume"])
-                    * gi.groupby_width
-                    * self.gather_width
-            )
+            dw = int(gii.jd["data_volume"]) * gi.groupby_width * self.gather_width
         else:  # data
             dw = gi.weight * self.gather_width
 
@@ -895,8 +872,10 @@ class LGNode:
                 app_class = "dlg.apps.dockerapp.DockerApp"
                 drop_spec["name"] = self.jd["command"]
             else:
-                logger.debug("Might be a problem with this node: %s", 
-                             json.dumps(self.jd, indent=2))
+                logger.debug(
+                    "Might be a problem with this node: %s",
+                    json.dumps(self.jd, indent=2),
+                )
 
         self.dropclass = app_class
         self.jd["dropclass"] = app_class
@@ -911,8 +890,7 @@ class LGNode:
         if self.weight is not None:
             if self.weight < 0:
                 raise GraphException(
-                    "Execution_time must be greater"
-                    " than 0 for Node '%s'" % self.name
+                    "Execution_time must be greater" " than 0 for Node '%s'" % self.name
                 )
             else:
                 kwargs["weight"] = self.weight
@@ -936,8 +914,8 @@ class LGNode:
             self.dropclass = self.jd["dataclass"]
         # Backwards compatibility
         if (
-                not hasattr(self, "dropclass")
-                or self.dropclass == "dlg.apps.simple.SleepApp"
+            not hasattr(self, "dropclass")
+            or self.dropclass == "dlg.apps.simple.SleepApp"
         ):
             if self.category == "File":
                 self.dropclass = "dlg.data.drops.file.FileDROP"

--- a/daliuge-translator/dlg/dropmake/pg_generator.py
+++ b/daliuge-translator/dlg/dropmake/pg_generator.py
@@ -38,7 +38,7 @@ from dlg.dropmake.lg import LG, GraphException
 from dlg.dropmake.pgt import PGT
 from dlg.dropmake.pgtp import MetisPGTP, MySarkarPGTP, MinNumPartsPGTP, PSOPGTP
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class _LGTemplate(string.Template):

--- a/daliuge-translator/dlg/dropmake/pgt.py
+++ b/daliuge-translator/dlg/dropmake/pgt.py
@@ -37,7 +37,7 @@ from dlg.dropmake.lg import GraphException
 from dlg.dropmake.scheduler import DAGUtil
 from dlg.common import CategoryType, dropdict
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class GPGTNoNeedMergeException(GraphException):
@@ -309,7 +309,9 @@ class PGT(object):
         # lm = {k:values[v] for (k, v) in lm.items()} # replace old values with new
 
         if tpl_fl:
-            nm_list = ["#%s" % x for x in range(len(nm_list))]  # so that nm_list[i] == '#i'
+            nm_list = [
+                "#%s" % x for x in range(len(nm_list))
+            ]  # so that nm_list[i] == '#i'
             is_list = [
                 "#%s" % x for x in range(len(is_list))
             ]  # so that is_list[i] == '#i'

--- a/daliuge-translator/dlg/dropmake/pgtp.py
+++ b/daliuge-translator/dlg/dropmake/pgtp.py
@@ -35,7 +35,7 @@ from dlg.dropmake.scheduler import (
 )
 from dlg.common import CategoryType
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class MetisPGTP(PGT):

--- a/daliuge-translator/dlg/dropmake/web/translator_rest.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_rest.py
@@ -131,7 +131,7 @@ app = FastAPI(
     },
 )
 app.mount("/static", StaticFiles(directory=file_location), name="static")
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 post_sem = threading.Semaphore(1)
 gen_pgt_sem = threading.Semaphore(1)

--- a/daliuge-translator/dlg/dropmake/web/translator_utils.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_utils.py
@@ -15,7 +15,7 @@ from dlg.dropmake.lg import load_lg
 from dlg.dropmake.pg_generator import unroll, partition
 from dlg.restutils import RestClientException
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 ALGO_PARAMS = [
     ("min_goal", int),

--- a/daliuge-translator/dlg/translator/tool_commands.py
+++ b/daliuge-translator/dlg/translator/tool_commands.py
@@ -36,7 +36,7 @@ from dlg.common.reproducibility.reproducibility import (
     init_pg_repro_data,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 def _open_i(path, flags=None):

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from setuptools import find_packages
 from setuptools import setup
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 # Version information
 # We do like numpy: we have a major/minor/patch hand-written version written
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # dlg/version.py file) we append it to the VERSION later.
 # The RELEASE flag allows us to create development versions properly supported
 # by setuptools/pkg_resources or "final" versions.
+
 
 def extract_version():
     """
@@ -46,16 +47,17 @@ def extract_version():
     """
     TAG_VERSION_FILE = "VERSION"
     content = ""
-    with (Path(__file__).parent / TAG_VERSION_FILE).open(
-            encoding="utf8") as open_file:
+    with (Path(__file__).parent / TAG_VERSION_FILE).open(encoding="utf8") as open_file:
         major, minor, patch = open_file.read().strip("v").split(".")
         print("logging details: ", major, minor, patch)
     return int(major), int(minor), int(patch)
 
+
 major, minor, patch = extract_version()
-VERSION=f"{major}.{minor}.{patch}"
+VERSION = f"{major}.{minor}.{patch}"
 RELEASE = True
 VERSION_FILE = "dlg/translator/version.py"
+
 
 def get_git_version():
     out = subprocess.check_output(["git", "rev-parse", "HEAD"])
@@ -132,7 +134,7 @@ extra_requires = {
         "np-merklelib",
         "parameterized>=0.9.0",
         "ruamel.yaml==0.16.0",
-        "pyyaml>=0.6"
+        "pyyaml>=0.6",
     ]
 }
 
@@ -163,8 +165,7 @@ setup(
     install_requires=install_requires,
     extras_require=extra_requires,
     packages=find_packages(),
-    package_data={"":["VERSION"], "dlg": src_files},
-    entry_points={"dlg.tool_commands": [
-        "translator=dlg.translator.tool_commands"]},
+    package_data={"": ["VERSION"], "dlg": src_files},
+    entry_points={"dlg.tool_commands": ["translator=dlg.translator.tool_commands"]},
     test_suite="test",
 )

--- a/daliuge-translator/test/dropmake/test_graph_config.py
+++ b/daliuge-translator/test/dropmake/test_graph_config.py
@@ -30,7 +30,7 @@ try:
 except ModuleNotFoundError:
     from importlib_resources import files
 
-LOG_PRFIX = "WARNING:__main__.dlg.dropmake.graph_config:"
+LOG_PRFIX = "WARNING:dlg.dlg.dropmake.graph_config:"
 
 
 def get_lg_from_fname(lg_name: str) -> dict:

--- a/daliuge-translator/test/dropmake/test_graph_config.py
+++ b/daliuge-translator/test/dropmake/test_graph_config.py
@@ -30,83 +30,94 @@ try:
 except ModuleNotFoundError:
     from importlib_resources import files
 
-LOG_PRFIX = "WARNING:dlg.dropmake.graph_config:"
+LOG_PRFIX = "WARNING:__main__.dlg.dropmake.graph_config:"
+
 
 def get_lg_from_fname(lg_name: str) -> dict:
     """
-    Return the logical graph from the graph_config files in the test graph repository 
+    Return the logical graph from the graph_config files in the test graph repository
     """
     fname = str(files(test_graphs) / f"graph_config/{lg_name}")
     with open(fname, "r") as fp:
-            return json.load(fp)
+        return json.load(fp)
 
-def get_value_from_lgnode_field(node_id: str, field_id: str, logical_graph: dict) -> str:
+
+def get_value_from_lgnode_field(
+    node_id: str, field_id: str, logical_graph: dict
+) -> str:
     """
     Helper function that retrieves the value of a specified field from a given node
 
     Returns: str representation of the value
     """
     idx = get_key_idx_from_list(node_id, logical_graph["nodeDataArray"])
-    field_idx = get_key_idx_from_list(field_id, logical_graph["nodeDataArray"][idx]["fields"])
+    field_idx = get_key_idx_from_list(
+        field_id, logical_graph["nodeDataArray"][idx]["fields"]
+    )
     return logical_graph["nodeDataArray"][idx]["fields"][field_idx]["value"]
 
 
 class TestGraphConfig(unittest.TestCase):
-    """
-    """
+    """ """
 
     def test_apply_with_empty_config(self):
         """
-        Exhaust the following possibilities that may exist when attempting to 
+        Exhaust the following possibilities that may exist when attempting to
         apply graph config:
             - "activeGraphConfigId" is not in graph
             - "activeGraphConfigId" is empty
             - "graphConfigurations" is not in graph
             - "graphConfigurations" is empty
-            - Keys from the activeGraphConfigId or graphConfigurations are not found in 
-            the logical graph. 
-        """ 
+            - Keys from the activeGraphConfigId or graphConfigurations are not found in
+            the logical graph.
+        """
         lg = get_lg_from_fname("ArrayLoopNoActiveID.graph")
-        with self.assertLogs('root', level="WARNING") as cm:
+        with self.assertLogs("root", level="WARNING") as cm:
             alt_lg = apply_active_configuration(lg)
         self.assertEqual(
-            [f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
-            f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
-            cm.output
+            [
+                f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
+                f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph.",
+            ],
+            cm.output,
         )
 
-        lg['activeGraphConfigId'] = ""
-        with self.assertLogs('root', level="WARNING") as cm:
+        lg["activeGraphConfigId"] = ""
+        with self.assertLogs("root", level="WARNING") as cm:
             alt_lg = apply_active_configuration(lg)
         self.assertEqual(
-            [f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
-            f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
-            cm.output
+            [
+                f"{LOG_PRFIX}No activeGraphConfigId data available in Logical Graph.",
+                f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph.",
+            ],
+            cm.output,
         )
- 
-        lg['activeGraphConfigId'] = "temporaryString"
 
-        with self.assertLogs('root', level="WARNING") as cm:
+        lg["activeGraphConfigId"] = "temporaryString"
+
+        with self.assertLogs("root", level="WARNING") as cm:
             alt_lg = apply_active_configuration(lg)
         self.assertEqual(
             [f"{LOG_PRFIX}No graphConfigurations data available in Logical Graph."],
-            cm.output
+            cm.output,
         )
 
-        lg['graphConfigurations'] = {"key": "value"}
+        lg["graphConfigurations"] = {"key": "value"}
 
-        with self.assertLogs('root', level="WARNING") as cm:
+        with self.assertLogs("root", level="WARNING") as cm:
             alt_lg = apply_active_configuration(lg)
             self.assertEqual(
-               [f"{LOG_PRFIX}Graph config key does not exist in logical graph. "
-                "Using base field values."],
-               cm.output
+                [
+                    f"{LOG_PRFIX}Graph config key does not exist in logical graph. "
+                    "Using base field values."
+                ],
+                cm.output,
             )
- 
+
     def test_apply_with_loop(self):
         """
-        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_iter" field in the 
-        "Loop" node (construct). 
+        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_iter" field in the
+        "Loop" node (construct).
         """
         lg = get_lg_from_fname("ArrayLoopLoop.graph")
         node_id = "732df21b-f714-4d25-9773-b4169db270a0"
@@ -119,8 +130,8 @@ class TestGraphConfig(unittest.TestCase):
 
     def test_apply_with_scatter(self):
         """
-        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_copies" field in the 
-        "Scatter" node (construct). 
+        ArrayLoopLoop.graph has a GraphConfig with modified "num_of_copies" field in the
+        "Scatter" node (construct).
         """
         lg = get_lg_from_fname("ArrayLoopScatter.graph")
         node_id = "5560c56a-10f3-4d42-a436-404816dddf5f"

--- a/daliuge-translator/test/dropmake/test_lgweb.py
+++ b/daliuge-translator/test/dropmake/test_lgweb.py
@@ -42,7 +42,7 @@ import daliuge_tests.dropmake as test_graphs
 
 lg_dir = files(test_graphs)
 lgweb_port = 8086
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dlg." + __name__)
 
 
 class TestLGWeb(unittest.TestCase):
@@ -88,8 +88,7 @@ class TestLGWeb(unittest.TestCase):
         c = RestClient("localhost", lgweb_port, timeout=10)
 
         # a specific one
-        lg = c._get_json(
-            "/jsonbody?lg_name=logical_graphs/chiles_simple.graph")
+        lg = c._get_json("/jsonbody?lg_name=logical_graphs/chiles_simple.graph")
         self.assertIsNotNone(lg)
 
         # by default the first one found by the lg_web should be returned
@@ -112,21 +111,18 @@ class TestLGWeb(unittest.TestCase):
             "lg_content": '{"id": 1, "name": "example"}',
             "rmode": "1",
         }
-        self.assertRaises(RestClientException, c._post_form,
-                          "/jsonbody", form_data)
+        self.assertRaises(RestClientException, c._post_form, "/jsonbody", form_data)
 
         # Replace the contents of an existing one
         # (but replace it back with original after the test)
-        original_fname = os.path.join(
-            lg_dir, "logical_graphs", "chiles_simple.graph")
+        original_fname = os.path.join(lg_dir, "logical_graphs", "chiles_simple.graph")
         copy_fname = tempfile.mktemp()
         shutil.copy(original_fname, copy_fname)
 
         try:
             form_data["lg_name"] = "logical_graphs/chiles_simple.graph"
             c._post_form("/jsonbody", form_data)
-            new = c._get_json(
-                "/jsonbody?lg_name=logical_graphs/chiles_simple.graph")
+            new = c._get_json("/jsonbody?lg_name=logical_graphs/chiles_simple.graph")
             self.assertIsNotNone(new)
             self.assertIn("id", new)
             self.assertIn("name", new)
@@ -167,8 +163,7 @@ class TestLGWeb(unittest.TestCase):
             "/pgt_jsonbody?pgt_name=unknown.json",
         )
         # good!
-        c._get_json(
-            "/pgt_jsonbody?pgt_name=logical_graphs/chiles_simple1_pgt.graph")
+        c._get_json("/pgt_jsonbody?pgt_name=logical_graphs/chiles_simple1_pgt.graph")
 
     def test_get_pgt_post(self, algo="metis", algo_options=None):
         c = RestClient("localhost", lgweb_port, timeout=10)
@@ -177,8 +172,7 @@ class TestLGWeb(unittest.TestCase):
         self.assertRaises(RestClientException, c._POST, "/gen_pgt")
 
         # new logical graph JSON
-        fname = os.path.join(lg_dir, "logical_graphs",
-                             "test-20190830-110556.graph")
+        fname = os.path.join(lg_dir, "logical_graphs", "test-20190830-110556.graph")
         with open(fname, "rb") as infile:
             json_data = infile.read()
 
@@ -421,10 +415,12 @@ class TestLGWeb(unittest.TestCase):
         for request in request_tests:
             self._test_post_request(c, test_url, request[0], request[1])
 
-    @parameterized.expand([
-        ("testLoop", "testLoop.graph"),
-        ("ArrayLoop", "ArrayLoop.graph"),
-    ])
+    @parameterized.expand(
+        [
+            ("testLoop", "testLoop.graph"),
+            ("ArrayLoop", "ArrayLoop.graph"),
+        ]
+    )
     def test_lg_unroll(self, n, graph):
         c = RestClient("localhost", lgweb_port, timeout=10)
         test_url = "/unroll"

--- a/tools/checkGraph.py
+++ b/tools/checkGraph.py
@@ -13,6 +13,7 @@ from jsonschema import validate, ValidationError
 
 LG_SCHEMA_FILENAME = "../daliuge-translator/dlg/dropmake/lg.graph.schema"
 
+
 def get_args():
     """
     Deal with the command line arguments
@@ -20,11 +21,13 @@ def get_args():
     :returns args.ifile:str
     """
     # inputdir, tag, outputfile, allow_missing_eagle_start, module_path, language
-    parser = argparse.ArgumentParser(epilog=__doc__,
-                            formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        epilog=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("ifile", help="input file name")
-    parser.add_argument("-v", "--verbose", help="increase output verbosity",
-                        action="store_true")
+    parser.add_argument(
+        "-v", "--verbose", help="increase output verbosity", action="store_true"
+    )
     args = parser.parse_args()
     if args.verbose:
         logger.setLevel(logging.DEBUG)
@@ -35,9 +38,9 @@ def get_args():
 if __name__ == "__main__":
     """
     Main method
-    
+
     """
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("dlg." + __name__)
     FORMAT = "%(asctime)s [  %(filename)s  ] [  %(lineno)s  ] [  %(funcName)s  ] || %(message)s ||"
     logging.basicConfig(
         format=FORMAT,
@@ -54,7 +57,7 @@ if __name__ == "__main__":
         graph = json.loads(file.read())
 
     # check graph is LG, if not, abort
-    if 'modelData' not in graph:
+    if "modelData" not in graph:
         logger.info("Not an LG")
         sys.exit(0)
 

--- a/tools/xml2palette/xml2palette.py
+++ b/tools/xml2palette/xml2palette.py
@@ -7,7 +7,7 @@ For more information please refer to the documentation
 https://daliuge.readthedocs.io/en/latest/development/app_development/eagle_app_integration.html#automatic-eagle-palette-generation
 
 
-TODO: This whole tool needs re-factoring into separate class files 
+TODO: This whole tool needs re-factoring into separate class files
 (compound, child, grandchild, grandgrandchild, node, param, pluggable parsers)
 Should also be made separate sub-repo with proper installation and entry point.
 """
@@ -134,9 +134,7 @@ def get_args():
     )
     parser.add_argument("idir", help="input directory path or file name")
     parser.add_argument("ofile", help="output file name")
-    parser.add_argument(
-        "-m", "--module", help="Module load path name", default=""
-    )
+    parser.add_argument("-m", "--module", help="Module load path name", default="")
     parser.add_argument(
         "-t", "--tag", help="filter components with matching tag", default=""
     )
@@ -201,9 +199,7 @@ def check_environment_variables() -> bool:
 
         if value is None:
             if variable == "PROJECT_NAME":
-                os.environ["PROJECT_NAME"] = os.path.basename(
-                    os.path.abspath(".")
-                )
+                os.environ["PROJECT_NAME"] = os.path.basename(os.path.abspath("."))
             elif variable == "PROJECT_VERSION":
                 os.environ["PROJECT_VERSION"] = "0.1"
             elif variable == "GIT_REPO":
@@ -339,9 +335,7 @@ def find_field_by_name(fields, name):
     return None
 
 
-def _check_required_fields_for_category(
-    text: str, fields: list, category: str
-):
+def _check_required_fields_for_category(text: str, fields: list, category: str):
     """
     Check if fields have mandatory content and alert with <text> if not.
 
@@ -461,9 +455,7 @@ def alert_if_missing(message: str, fields: list, internal_name: str):
     :param internal_name: str, identifier name of field to check
     """
     if find_field_by_name(fields, internal_name) is None:
-        logger.warning(
-            message + " component missing " + internal_name + " cparam"
-        )
+        logger.warning(message + " component missing " + internal_name + " cparam")
         pass
 
 
@@ -624,9 +616,7 @@ def create_palette_node_from_params(params) -> tuple:
     # process the params
     for param in params:
         if not isinstance(param, dict):
-            logger.error(
-                "param %s has wrong type %s. Ignoring!", param, type(param)
-            )
+            logger.error("param %s has wrong type %s. Ignoring!", param, type(param))
             continue
         key = param["key"]
         direction = param["direction"]
@@ -965,8 +955,7 @@ class greatgrandchild:
             for p in detailed_description.split(":param")[1:]
         ]
         type_lines = [
-            p.replace("\n", "").strip()
-            for p in detailed_description.split(":type")[1:]
+            p.replace("\n", "").strip() for p in detailed_description.split(":type")[1:]
         ]
         # param_lines = [line.strip() for line in detailed_description]
 
@@ -988,18 +977,14 @@ class greatgrandchild:
             # logger.debug("%s description: %s", param_name, param_description)
 
             if len(type_lines) != 0:
-                result.update(
-                    {param_name: {"desc": param_description, "type": None}}
-                )
+                result.update({param_name: {"desc": param_description, "type": None}})
             else:
                 result.update(
                     {
                         param_name: {
                             "desc": param_description,
                             "type": _typeFix(
-                                re.split(
-                                    r"[,\s\n]", param_description.strip()
-                                )[0]
+                                re.split(r"[,\s\n]", param_description.strip())[0]
                             ),
                         }
                     }
@@ -1108,9 +1093,7 @@ class greatgrandchild:
                 rpds = rpds[1:]
             else:  # if something else use first word and type Unknown
                 rpds = re.findall(r"\w+", rpds[0])[0:1] + ["Unknown"]
-            rdict = dict(
-                zip(rpds[::3], zip(rpds[1::3]))
-            )  # create initial return dict
+            rdict = dict(zip(rpds[::3], zip(rpds[1::3])))  # create initial return dict
             rdict = {
                 k: {"desc": v[0].replace("\n", " "), "type": _typeFix(k)}
                 for k, v in rdict.items()
@@ -1185,11 +1168,7 @@ class greatgrandchild:
             # Might not be complete or correct and has to be merged with the information
             # in the param section below.
             direction = None
-            if (
-                len(ggchild) > 0
-                and len(ggchild[0]) > 0
-                and ggchild[0][0].text != None
-            ):
+            if len(ggchild) > 0 and len(ggchild[0]) > 0 and ggchild[0][0].text != None:
                 # get description, params and return
                 dd = ggchild[0][0].text
                 d_format = self._identify_format(dd)  # identify docstyle
@@ -1281,10 +1260,7 @@ class greatgrandchild:
             # if str(name) == "self" and \
             #     self.func_name.rsplit("::",1)[-1] in ["__init__", "__class__"]:
             #     return None
-            if (
-                name in self.member["params"]
-                and "type" in self.member["params"][name]
-            ):
+            if name in self.member["params"] and "type" in self.member["params"][name]:
                 logger.debug(
                     "Existing type definition found for %s: %s",
                     name,
@@ -1587,9 +1563,7 @@ def _process_child(child: dict, language: str) -> dict:
         else:
             casa_mode = False
             hold_name = "Unknown"
-        logger.debug(
-            "Found compoundname: %s; extracted: %s", child.text, hold_name
-        )
+        logger.debug("Found compoundname: %s; extracted: %s", child.text, hold_name)
     if child.tag == "detaileddescription" and len(child) > 0 and casa_mode:
         # for child in ggchild:
         dStr = child[0][0].text
@@ -1729,9 +1703,7 @@ def process_compounddef_default(compounddef, language):
 
 
 # find the named aparam in params, and update the description
-def set_param_description(
-    name: str, description: str, p_type: str, params: dict
-):
+def set_param_description(name: str, description: str, p_type: str, params: dict):
     """
     Set the description field of a of parameter <name> from parameters.
     TODO: This should really be part of a class
@@ -1766,10 +1738,7 @@ def create_construct_node(node_type: str, node: dict) -> dict:
     # check that type is in the list of known types
     if node_type not in KNOWN_CONSTRUCT_TYPES:
         logger.warning(
-            " construct for node'"
-            + node["name"]
-            + "' has unknown type: "
-            + node_type
+            " construct for node'" + node["name"] + "' has unknown type: " + node_type
         )
         pass
 
@@ -1887,18 +1856,14 @@ def parseCasaDocs(dStr: str) -> dict:
     dStr = cleanString(dStr)
     dList = dStr.split("\n")
     try:
-        start_ind = [
-            idx for idx, s in enumerate(dList) if "-- parameter" in s
-        ][0] + 1
+        start_ind = [idx for idx, s in enumerate(dList) if "-- parameter" in s][0] + 1
         end_ind = [idx for idx, s in enumerate(dList) if "-- example" in s][0]
     except IndexError:
         logger.debug("Problems finding start or end index for task: {task}")
         return {}, ""
     paramsList = dList[start_ind:end_ind]
     paramsSidx = [
-        idx + 1
-        for idx, p in enumerate(paramsList)
-        if len(p) > 0 and p[0] != " "
+        idx + 1 for idx, p in enumerate(paramsList) if len(p) > 0 and p[0] != " "
     ]
     paramsEidx = paramsSidx[1:] + [len(paramsList) - 1]
     paramFirstLine = [
@@ -1929,7 +1894,7 @@ if __name__ == "__main__":
 
     TODO: Should be split up
     """
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("dlg." + __name__)
     FORMAT = "%(asctime)s [  %(filename)s  ] [  %(lineno)s  ] [  %(funcName)s  ] || %(message)s ||"
     logging.basicConfig(
         format=FORMAT,
@@ -1978,9 +1943,7 @@ if __name__ == "__main__":
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    logger.info(
-        "Wrote doxygen configuration file (Doxyfile) to " + doxygen_filename
-    )
+    logger.info("Wrote doxygen configuration file (Doxyfile) to " + doxygen_filename)
 
     # modify options in the Doxyfile
     modify_doxygen_options(doxygen_filename, DOXYGEN_SETTINGS)
@@ -2043,9 +2006,7 @@ if __name__ == "__main__":
             functions = functions[0] if len(functions) > 0 else functions
             logger.debug("Number of functions in compound: %d", len(functions))
             for f in functions:
-                f_name = [
-                    k["value"] for k in f["params"] if k["key"] == "name"
-                ]
+                f_name = [k["value"] for k in f["params"] if k["key"] == "name"]
                 logger.debug("Function names: %s", f_name)
                 if f_name == [".Unknown"]:
                     continue


### PR DESCRIPTION
# JIRA Ticket 
liu-456

# Type
This PR allows users to set the log-level of an application from the graph per application.

- [x] Feature (addition)
- [ ] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
Debugging issues with graphs or applications is pretty hard and looking through DEBUG level NodeManager logs is really cumbersome. This PR makes this a bit more approachable by allowing the user to set the log-level per application directly in the graph. That means, that if the NodeManager is started with log-level WARNING (default), a user can switch the log-level of a single APP in the graph to DEBUG to get all available logging information for that APP only and else just the minimal from WARNING upwards.

# Solution
1. A new parameter has been added to all template and built-in components in the doxygen descriptions.
2. The value of that parameter is read in the drop class to set the log-level as a drop attribute and it also sets a _global_log_level attribute to keep the original value of the log_level.
3. The node manager's run_app method is using the log_level value to set the log_level before submitting the app run function to the thread-pool.
4. The log-level is then reset to the original value in the execute method of the InputFiredAppDrop class. This can't be done higher up in the class hierarchy since the actual execution is first implemented there, not in the abstract drops above. This is also why the functionality has not been exposed to the data drops as of now.

The implementation also unveiled an issue with the logging configuration: Since the package structure is not hierarchical (common, engine and translator are on the same level) the standard getLogger(__name__) does not work as expected. I've thus added an explicit "dlg" layer on-top which solves this issue.

# Checklist

- [ ] Unittests added
  - No additional unittests added.
- [x] Documentation added
    - Documentation is in-line with the built-in and template components.
