### PR TITLE
LIU-458: Upgrade test_docker.py images to 22.04

### DIFF
--- a/daliuge-engine/dlg/apps/dockerapp.py
+++ b/daliuge-engine/dlg/apps/dockerapp.py
@@ -391,7 +391,7 @@ class DockerApp(BarrierAppDROP):
         # The only interest we currently have is the containerIp of other
         # DockerApps, and only if our command actually uses this IP
         if isinstance(drop, DockerApp):
-            if "%containerIp[{0}]%".format(drop.uid) in self._command:
+            if f"%containerIp[{{{drop.uid}}}]%" in self._command:
                 self._waiters.append(ContainerIpWaiter(drop))
                 logger.debug("%r: Added ContainerIpWaiter for %r", self, drop)
 
@@ -538,7 +538,7 @@ class DockerApp(BarrierAppDROP):
             # started, and replace their IP placeholders by the real IPs
             for waiter in self._waiters:
                 uid, ip = waiter.waitForIp()
-                cmd = cmd.replace("%containerIp[{0}]%".format(uid), ip)
+                cmd = cmd.replace(f"%containerIp[{{{uid}}}]%", ip)
                 logger.debug("Command after IP replacement is: %s", cmd)
 
             # Wrap everything inside bash


### PR DESCRIPTION
- Doing this alone causes errors because nc is not available on base ubuntu:22.04 images.
- Need to install netstat (nc) onto image
- Easiest way to do this is using a dockerfile with the docker-py API.

# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-458](https://icrar.atlassian.net/browse/LIU-458)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [x] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
<!--- Provide an overview of what this PR address--->

Our test_docker instances are using Ubuntu:14.04 containers, which is incredibly old. We should support tests using newer versions of ubuntu. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have updated to 22.04 containers. This was almost as simple as bumping the numbers, but our `test_clientServer` test case uses the `nc` (netstat) command. This is not installed available by default on Ubuntu 22.04 (presumably because they are slimmer images). 

I have added a `CustomContainer` class in `test_docker.py` that builds a Dockerfile from an input string and then builds the image, using the docker-py library we already use. The image is not cleaned up so it takes much less time to run the test after the first time the image is built (I have added code to do so if needed). 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - These are the unit tests
- [ ] Documentation added
    - These are not user-facing changes.

## Summary by Sourcery

Upgrade test Docker images from Ubuntu 14.04 to Ubuntu 22.04 and add support for installing netcat in test containers

New Features:
- Added ability to create custom Docker images dynamically during testing

Bug Fixes:
- Resolved compatibility issues with Ubuntu 22.04 images by adding a custom container creation method to install netcat

Enhancements:
- Introduced a CustomContainer class to dynamically build Docker images with additional dependencies
- Updated Docker test cases to use Ubuntu 22.04 images

[LIU-458]: https://icrar.atlassian.net/browse/LIU-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ