### PR TITLE
LIU-460: Fix black box zooming graph during Deploying state 

### DIFF
--- a/daliuge-engine/dlg/manager/web/static/js/dm.js
+++ b/daliuge-engine/dlg/manager/web/static/js/dm.js
@@ -511,12 +511,12 @@ function drawGraphForDrops(g, drawGraph, oids, doSpecs) {
 
 	if (modified) {
 		drawGraph();
+		zoomFit();
 	}
 
 	var time3 = new Date().getTime();
 	console.log('Took %d [ms] to draw the hole thing', (time3 - time2))
 
-	zoomFit()
 }
 
 function setStatusColor(status) {
@@ -580,11 +580,18 @@ function startStatusQuery(serverUrl, sessionId, selectedNode, graph_update_handl
 			// to know when we go to RUNNING.
 			// During RUNNING (or potentially FINISHED/CANCELLED, if the execution is
 			// extremely fast) we need to start updating the status of the graph
-			if (status == 3 || status == 4 || status == 5) {
+			if (status === 3 || status === 4 || status === 5) {
 				startGraphStatusUpdates(serverUrl, sessionId, selectedNode, delay,
 					status_update_handler);
 			}
-			else if (status == 0 || status == 1 || status == 2 || status == -1) {
+			else if (status === 0 || status === 1 || status === 2 || status === -1) {
+				if (status === 2) {
+					// Visualise the drops if we are trying to 'deploy' them.
+					var keys = Object.keys(doSpecs);
+					keys.sort();
+					var statuses = keys.map(function (k) { return {"status": 0} });
+					status_update_handler(statuses);
+				}
 				// schedule a new JSON request
 				updateGraphDelayTimer = d3.timer(updateGraph, delay);
 				updateGraphDelayTimerActive = true;
@@ -605,7 +612,9 @@ function startStatusQuery(serverUrl, sessionId, selectedNode, graph_update_handl
 
 function _addNode(g, doSpec) {
 
-	if (g.hasNode(g)) {
+	var oid = doSpec.oid;
+
+	if (g.hasNode(oid)) {
 		return false;
 	}
 
@@ -627,7 +636,6 @@ function _addNode(g, doSpec) {
 		notes += 'storage: ' + doSpec.storage;
 	}
 
-	var oid = doSpec.oid;
 	var html = '<div class="drop-label ' + typeShape + '" id="id_' + oid + '">';
 	html += '<span class="notes">' + notes + '</span>';
     oid_date = doSpec.oid.split("_")[0];


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

LIU-460

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

When an exception is raised when loading DROPs into the daliuge-engine, the engine does not properly catch this exception and the web-UI hangs in deploy, with all the DROPs as black boxes, and the graph is constantly being re-drawn and the canvas zooming in and out.    

Even though the error is ultimately with the engine not sending through the information that would trigger the UI to update the graph (in this case, to be in an error state), the UI should be able to deal with being in that intermediary state. This PR provides a solution to do that. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 
|Before| After | 
| ---- | ---- | 
|![image](https://github.com/user-attachments/assets/20365b4f-223a-4d89-8c9e-da863f382c98) | ![Screenshot from 2025-04-12 20-14-59](https://github.com/user-attachments/assets/38d07407-d10d-459b-90ba-7a9aeca1a6a2) | 

The existing drawing code had a couple of small bugs that contributed to the behaviour we have been seeing: 

- https://github.com/ICRAR/daliuge/blob/0624a07b0774dcd7e602fd18a4f3e5fb2f36613b/daliuge-engine/dlg/manager/web/static/js/dm.js#L606-L608
    - This should be checking if  graph `g` has a node `doSpec`; this will always return false, which means the graph will always be regarded as being "modified" and so we will always re-draw the graph, even if we have no updates (whilst still in the deploy state). 
- https://github.com/ICRAR/daliuge/blob/0624a07b0774dcd7e602fd18a4f3e5fb2f36613b/daliuge-engine/dlg/manager/web/static/js/dm.js#L512-L519
    - The call to `zoomfit` only makes sense to do when we need to re-draw the graph (i.e. if the graph has had modifications).    

The black box behaviour is caused by us only applying our CSS to the `d3` graph rectangles once the following code is run: 
  
https://github.com/ICRAR/daliuge/blob/0624a07b0774dcd7e602fd18a4f3e5fb2f36613b/daliuge-engine/dlg/manager/web/session.html#L235-L240

This updates the class name of each node in the d3 graph based on the current status. Then, in `progressBar.cs`, the different CSS is applied to the different nodes. 

The problem is that the `status_update_handler` is only called once the session has first moved to a `Running` state, leaving us with nodes that have no stylesheet. I have fixed this by calling the handler in deploy mode, but without us running the entire `startGraphStatusUpdates` code it would normally be called in. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  -  We have no unittests for this code 
- ~[ ] Documentation added~
    - Bug fix, user interaction shouldn't change.  

## Summary by Sourcery

Fix zooming and graph visualization issues during the Deploying state of the DALiuGE engine

Bug Fixes:
- Corrected the timing of zoomFit() call to ensure proper graph visualization
- Fixed node addition logic to correctly check for existing nodes using the correct node identifier

Enhancements:
- Improved status handling during the Deploying state by visualizing drops with initial statuses
- Enhanced status comparison using strict equality checks