### PR TITLE
Add back 'hello' parameter to HelloWorldApp

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
 
   finish:
     needs: run_tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -659,7 +659,8 @@ class GenericNpyGatherApp(BarrierAppDROP):
 # @par EAGLE_START
 # @param category PythonApp
 # @param tag daliuge
-# @param greet World/String/ApplicationArgument/NoPort/ReadWrite//False/False/What appears after 'Hello '
+# @param greet World/String/ApplicationArgument/InputPort/ReadWrite//False/False/What appears after 'Hello '
+# @param hello "world"/Object/ApplicationArgument/OutputPort/ReadWrite//False/False/message
 # @param log_level "NOTSET"/Select/ComponentParameter/NoPort/ReadWrite/NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL/False/False/Set the log level for this drop
 # @param dropclass dlg.apps.simple.HelloWorldApp/String/ComponentParameter/NoPort/ReadOnly//False/False/Application class
 # @param base_name simple/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

We were too enthusiastic when removing some Doxygen comments in the HelloWorldApp in #317 and got rid of the `hello` parameter. It turns out this is expected as part of EAGLE's tests, so we need to add it back. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have added it back. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
- ~[ ] Documentation added~

## Summary by Sourcery

Restore the 'hello' parameter to HelloWorldApp that was accidentally removed in a previous change

Bug Fixes:
- Reintroduced the 'hello' parameter in the HelloWorldApp to maintain compatibility with EAGLE's tests

Chores:
- Updated Doxygen comments to include the 'hello' parameter definition