### PR TITLE
Fix EAGLE schema compliance nad JSON loading

### DIFF
--- a/daliuge-engine/dlg/data/drops/memory.py
+++ b/daliuge-engine/dlg/data/drops/memory.py
@@ -61,11 +61,12 @@ def parse_pydata(pd: Union[bytes, dict]) -> bytes:
     builtin_types = get_builtins()
     if pd_dict["type"] != "raw" and type(pydata) in builtin_types.values() and pd_dict["type"] not in builtin_types.keys():
         logger.warning("Type of pydata %s provided differs from specified type: %s", type(pydata).__name__, pd_dict["type"])
-        pd_dict["type"] = type(pydata).__name__
+        # pd_dict["type"] = type(pydata).__name__
     if pd_dict["type"].lower() == "json":
         try:
             pydata = json.loads(pydata)
-        except Exception:
+        except Exception as err:
+            logger.warning("Loading of JSON data failed: %s. Encoding it as string.", err)
             pydata = pydata.encode()
     if pd_dict["type"].lower() == "eval":
         # try:
@@ -162,7 +163,8 @@ class InMemoryDROP(DataDROP):
             self.data_type = pdict["type"] if pdict else ""
         if pydata:
             args.append(pydata)
-            logger.debug("Loaded into memory: %s, %s, %s", pydata, self.data_type, type(pydata))
+            logger.debug("Loaded into memory: Specified type: %s, loaded type: %s, Bytes: %s ", 
+                         self.data_type, type(dill.loads(pydata)), sys.getsizeof(pydata),)
         self._buf = io.BytesIO(*args) if self.data_type != "String" else io.StringIO(*args)
         self.size = len(pydata) if pydata else 0
 

--- a/daliuge-translator/dlg/dropmake/lg.graph.schema
+++ b/daliuge-translator/dlg/dropmake/lg.graph.schema
@@ -42,7 +42,7 @@
                     "type": "string"
                 },
                 "lastModifiedDatetime": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "numLGNodes": {
                     "type": "integer"
@@ -133,14 +133,8 @@
                     "radius": {
                         "type": "number"
                     },
-                    "collapsed": {
-                        "type": "boolean"
-                    },
                     "subject": {
                         "type": "null"
-                    },
-                    "expanded": {
-                        "type": "boolean"
                     },
                     "inputApplicationName": {
                         "type": "string"
@@ -315,9 +309,6 @@
                                     "type": "boolean",
                                     "default": false
                                 },
-                                "keyAttribute": {
-                                    "type": "boolean"
-                                },
                                 "encoding": {
                                     "type": "string",
                                     "enum": ["binary", "pickle", "dill", "npy", "base64", "utf-8"],
@@ -341,7 +332,6 @@
                                 "precious",
                                 "options",
                                 "positional",
-                                "keyAttribute",
                                 "id",
                                 "parameterType",
                                 "usage"
@@ -405,13 +395,12 @@
                 },
                 "required": [
                     "category",
-                    "collapsed",
+                    "categoryType",
                     "color",
                     "commitHash",
                     "dataHash",
                     "description",
                     "drawOrderHint",
-                    "expanded",
                     "fields",
                     "inputAppFields",
                     "inputApplicationName",


### PR DESCRIPTION
# JIRA Ticket 
LIU-471

# Type

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

The LG graphs sent by the latest version of EAGLE produces schema verification errors in the translator. In addition the loading of JSON formatted pydata fields was broken with one of the latest merges. Both of these fixes are critical, since it prevents everyone to use the latest version of EAGLE (schema issues) and Omar to to do his work on the CHILES graphs using JSON in pydata fields.

# Solution

- JSON schema changes
- Commenting out a line trying to overwrite the provided type of the pydata field with the one guessed from the actual type (which is usually string). The commented line has been kept, since this check used to capture some edge case, which I don't recall the details of anymore.

# Checklist
The existing unit tests are covering the changes.