### PR TITLE
Fix `eagle-test-graphs` version issue

### DIFF
--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -180,7 +180,7 @@ extra_requires = {
     "MPI": ["mpi4py"],
     # AWS storage types
     "aws": ["boto3"],
-    "test": ["pytest", "eagle-test-graphs==0.1.7"],
+    "test": ["pytest", "eagle-test-graphs==0.1.8"],
 }
 
 setup(

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -135,7 +135,8 @@ class lib64_path(install):
         lp = sysconfig.get_path("stdlib")
         with open(PTH_FILE, "w") as f:
             f.write("{0}/dist-packages".format(lp))
-        install.copy_file(self, PTH_FILE, os.path.join(self.install_lib, PTH_FILE))
+        install.copy_file(self, PTH_FILE, os.path.join(
+            self.install_lib, PTH_FILE))
 
 
 # Core requirements of DALiuGE
@@ -179,9 +180,7 @@ extra_requires = {
     "MPI": ["mpi4py"],
     # AWS storage types
     "aws": ["boto3"],
-    "test": ["pytest",
-            "eagle-test-graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-5"]
-             # "eagle-test-graphs==0.1.6"],
+    "test": ["pytest", "eagle-test-graphs==0.1.7"],
 }
 
 setup(

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -130,8 +130,7 @@ install_requires = [
 extra_requires = {
     "test": [
         "pytest",
-        "eagle-test-graphs @ git+https://github.com/ICRAR/EAGLE_test_repo@LIU-5",
-        # "eagle-test-graphs==0.1.6",
+        "eagle-test-graphs==0.1.7",
         "np-merklelib",
         "parameterized>=0.9.0",
         "ruamel.yaml==0.16.0",
@@ -167,6 +166,7 @@ setup(
     extras_require=extra_requires,
     packages=find_packages(),
     package_data={"": ["VERSION"], "dlg": src_files},
-    entry_points={"dlg.tool_commands": ["translator=dlg.translator.tool_commands"]},
+    entry_points={"dlg.tool_commands": [
+        "translator=dlg.translator.tool_commands"]},
     test_suite="test",
 )

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -130,7 +130,7 @@ install_requires = [
 extra_requires = {
     "test": [
         "pytest",
-        "eagle-test-graphs==0.1.7",
+        "eagle-test-graphs==0.1.8",
         "np-merklelib",
         "parameterized>=0.9.0",
         "ruamel.yaml==0.16.0",
@@ -166,7 +166,6 @@ setup(
     extras_require=extra_requires,
     packages=find_packages(),
     package_data={"": ["VERSION"], "dlg": src_files},
-    entry_points={"dlg.tool_commands": [
-        "translator=dlg.translator.tool_commands"]},
+    entry_points={"dlg.tool_commands": ["translator=dlg.translator.tool_commands"]},
     test_suite="test",
 )


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

We use the EAGLE_test_repo as the area for our tests graphs, so we need to test against those changes when testing our changes. In the #314 PR, I changed the eagle-test-graph version in `setup.py` to the git branch version to test against and confirm the changes. Unfortunately, I forgot to change those back. 

PyPI will not allow you to publish with git-based dependencies, so it is necessary to create the eagle-test-graphs release first and then reference that, and then release here. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

For the time being, I have released on EAGLE and bumped things. I am tempted to add a github action that fails if it finds any branch-based URLS in setup.py in the future. 

# Checklist

<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)

## Summary by Sourcery

Update eagle-test-graphs dependency to a released version in setup.py files

Bug Fixes:
- Replace git-based dependency with a specific PyPI release version of eagle-test-graphs

Chores:
- Remove git branch-based dependency to enable proper PyPI publishing