### PR TITLE
LIU-470: Fix DROP Logs routing issue 

### DIFF
--- a/daliuge-engine/dlg/manager/rest.py
+++ b/daliuge-engine/dlg/manager/rest.py
@@ -209,6 +209,8 @@ class ManagerRestServer(RestServer):
         # The non-REST mappings that serve HTML-related content
         app.route("/static/<filepath:path>", callback=self.server_static)
         app.get("/session", callback=self.visualizeSession)
+        app.route("/api/sessions/<sessionId>/graph/drop/<dropId>",
+                  callback=self._getDropStatus)
         app.route("/sessions/<sessionId>/graph/drop/<dropId>",
                 callback=self.getDropStatus)
 


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

In my changes in #470, this was erroneously removed when trying to get build failures resolved in Python 3.10. The result is that the DROP logs REST request was not properly forwarded by the Node Manager.

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

Re-introduced the GET request. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - Reason for not adding unittests (remove this line if added) 
- ~[ ] Documentation added~
    - Reason for not adding documentation (remove this line if added)

## Summary by Sourcery

Enhancements:
- Added a new API route `/api/sessions/<sessionId>/graph/drop/<dropId>` to complement the existing route for retrieving drop status