### PR TITLE
LIU-481: Default to local time logging with option for GMT

### DIFF
--- a/daliuge-engine/dlg/manager/cmdline.py
+++ b/daliuge-engine/dlg/manager/cmdline.py
@@ -186,6 +186,13 @@ def addCommonOptions(parser, defaultPort):
         default=utils.getDlgLogsDir(),
     )
 
+    parser.add_option(
+        "--gm-time",
+        action="store_true",
+        help="Use local system time when logging",
+        default=False,
+    )
+
 
 def commonOptionsCheck(options, parser):
     # These are all exclusive
@@ -289,9 +296,8 @@ def setupLogging(opts):
         fmt += "[%(session_id)10.10s] [%(drop_uid)10.10s] "
     fmt += "%(name)s#%(funcName)s:%(lineno)s %(message)s"
     fmt = DlgFormatter(fmt)
-    # fmt = logging.Formatter(fmt)
-    fmt.converter = time.gmtime
-
+    fmt.converter = time.gmtime if opts.gm_time else time.localtime
+    time_fmt =  "GMT" if opts.gm_time else "Local"
     # Let's configure logging now
     # Daemons don't output stuff to the stdout
     if not opts.daemon:
@@ -316,6 +322,7 @@ def setupLogging(opts):
     # user. A Warning message here let's the user know something is happening without
     # us needing to modify the default logging level.
     logging.warning("Starting with level: %s...", logging.getLevelName(level))
+    logging.warning("Using %s Time for logging...", time_fmt)
 
     return fileHandler
 
@@ -442,6 +449,7 @@ def dlgNM(parser, args):
         "max_threads": options.max_threads,
         "use_processes": options.use_processes,
         "logdir": options.logdir,
+        "use_gm_time": options.gm_time,
     }
     options.dmAcronym = "NM"
     options.restType = NMRestServer

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -55,8 +55,6 @@ from dlg.exceptions import (
 )
 from ..lifecycle.dlm import DataLifecycleManager
 
-from dlg.manager.manager_data import Node
-
 logger = logging.getLogger(f"dlg.{__name__}")
 
 
@@ -260,6 +258,7 @@ class NodeManagerBase(DROPManager):
         max_threads=0,
         use_processes=False,
         logdir=utils.getDlgLogsDir(),
+        use_gm_time=False
     ):
         self._events_port = events_port
         self._dlm = DataLifecycleManager(
@@ -269,6 +268,7 @@ class NodeManagerBase(DROPManager):
         )
         self._sessions = {}
         self.logdir = logdir
+        self.use_gm_time=use_gm_time
 
         # dlgPath may contain code added by the user with possible
         # DROP applications

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -161,7 +161,7 @@ class Session(object):
     graph has finished the session is moved to FINISHED.
     """
 
-    def __init__(self, sessionId, nm=None):
+    def __init__(self, sessionId, nm: "NodeManager"):
         self._sessionId = sessionId
         self._graph = {}  # key: oid, value: dropSpec dictionary
         self._drops = {}  # key: oid, value: actual drop object
@@ -196,11 +196,8 @@ class Session(object):
         fmt += "[%(drop_uid)10.10s] "
         fmt += "%(name)s#%(funcName)s:%(lineno)s %(message)s"
         fmt = logging.Formatter(fmt)
-        fmt.converter = time.gmtime
+        fmt.converter = time.gmtime if self._nm.use_gm_time else time.localtime
 
-        # logdir = utils.getDlgLogsDir()
-        # if self._nm is not None:
-        #     logdir = self._nm.logdir
         logfile = generateLogFileName(self._sessionDir, self.sessionId)
         try:
             self.file_handler = logging.FileHandler(logfile)


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

LIU-481

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix (?)
- [x] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
<!--- Provide an overview of what this PR address--->

We currently use `gmtime` for our timestamps, which means the timetstamps in our log files are not the same as the local time in which we ran the application. This can make it harder to review logs, especially for previous sessions. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have made the assumption that users will want local time over `gmtime`, especially in the default case. However, I recognise that it is possible we want to use `gmtime` in a deployment scenario to reduce ambiguity within the log files - as per Chesterton's fence, I am assuming we chose `gmtime` across the board for a reason. 

To allow for this, I've provided the `--gm-time` option to the Translator REST logs, and the DROPmanagers (which is where `gmtime` was set). 

Note: If we still want the default to be `gmtime`, the current code can be trivially modified to make that the default, and make users select local time if it is their preference. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - ~Reason for not adding unittests (remove this line if added)~
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)
    - I'll add some documentation 
