### PR TITLE
Patch: Test np.array is empty correctly in named_port_utils.py.

### DIFF
--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -1,9 +1,11 @@
 import ast
 import logging
 import collections
+
+import numpy as np
+
 from dlg.data.drops.data_base import DataDROP
 import dlg.droputils as droputils
-from dlg.data import path_builder
 import dlg.drop_loaders as drop_loaders
 
 from dataclasses import dataclass
@@ -349,10 +351,10 @@ def replace_named_ports(
 
     #  Construct the final keywordArguments and positionalPortArguments
     for k, v in keywordPortArgs.items():
-        if v not in [None, ""]:
-            keywordArgs.update({k: v})
+        if not _is_value_empty(v):
+                keywordArgs.update({k: v})
     for k, v in positionalPortArgs.items():
-        if v not in [None, ""]:
+        if not _is_value_empty(v):
             positionalArgs.update({k: v})
 
     keywordArgs = serialize_kwargs(keywordArgs)
@@ -360,6 +362,23 @@ def replace_named_ports(
 
     logger.debug("After port replacement: pargs: %s; keyargs: %s", pargs, keywordArgs)
     return keywordArgs, pargs
+
+def _is_value_empty(value: object):
+    """
+    Check if the value is empty
+
+    If it is a non-standard datatype, such as a numpy array, there can be truth
+    ambiguities for the emptiness. In this instance, we explicitly check for the
+    size of the array.
+
+    :param value: an object that could be a primitive (int), an iterator, an object, or
+    an array.
+    :return: True if the value is emptyr,
+    """
+    if isinstance(value, np.ndarray):
+        return True if value.size == 0 else False
+    else:
+        return False if value else True
 
 
 def _process_port(

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -378,7 +378,7 @@ def _is_value_empty(value: object):
     if isinstance(value, np.ndarray):
         return True if value.size == 0 else False
     else:
-        return False if value else True
+        return True if value in ["", None] else False
 
 
 def _process_port(

--- a/daliuge-engine/test/graphs/test_graphExecution.py
+++ b/daliuge-engine/test/graphs/test_graphExecution.py
@@ -72,7 +72,7 @@ class TestGraphs(LocalDimStarter, unittest.TestCase):
         sessionId = "lalo"
         bs = 10
         count = 2048
-        ddGraphs = ["ddExamplePG.graph","ddExample_mixedPortsPG.graph"]
+        ddGraphs = ["ddExamplePG.graph", "ddExample_mixedPortsPG.graph"]
         for ddGraph in ddGraphs:
             with (files(test_graphs) /ddGraph).open() as f:  # @UndefinedVariable
                 logger.debug(f"Loading graph: {f}")


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
<!--- Provide an overview of what this PR address--->

There is a check in named_port_utils.py to determine if the value provided for a keyword or positional argument is 'empty'. Unfortunately, that check does not work for numpy arrays, as they require an any/all call to evaluate to a boolean. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have added a new function that checks the type of the value, and applies a different approach to conditional satisifability based on the data type. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
- ~[ ] Documentation added~

## Summary by Sourcery

Improve empty-value filtering for named port arguments by introducing a helper that handles numpy arrays and other types correctly

Bug Fixes:
- Detect empty numpy arrays correctly when filtering named port arguments

Enhancements:
- Consolidate emptiness logic into a dedicated _is_value_empty helper function