### PR TITLE
Liu 489

### DIFF
--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -893,6 +893,7 @@ class PyFuncApp(BarrierAppDROP):
 
         encoding = "dill" # default if nothing else is found
         param_enc = None
+        drop_port = ""
         params = self.parameters.get("componentParams", {})
         params.update(self.parameters.get("applicationArguments", {}))
         if not params:
@@ -901,8 +902,8 @@ class PyFuncApp(BarrierAppDROP):
             self.parameters["outputs"]
         ):
             for outport in self.parameters["outputs"]:
-                drop_uid, drop_port = outport.items()[0]
-                if drop_uid == output_drop.uid:
+                drop_uid, drop_port = list(outport.items())[0]
+                if drop_uid == output_drop.uid and drop_port in params:
                     param_enc = params[drop_port]["encoding"]
         encoding = param_enc or encoding
         logger.debug("Using encoding: %s for output: %s", encoding, drop_port)


### PR DESCRIPTION
# JIRA Ticket 
LIU-489

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
If an output port was defined as an ApplicationParameter (which is now the default for new parameters in EAGLE), the encoding setting was ignored and the default dill encoding was used. That leads to unexpected results in particular when strings are passed around. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

# Checklist
This PR fixes that behavior by adding the ApplicationParameters to the parameters to be checked against the port.

- [ ] Unittests added
  - This fix makes the code using both main types of parameters to check against, instead of previously just one. Thus, there was a test missing before which would have revealed the issue.
- [ ] Documentation added
    - the code is now behaving as intended and documented.

## Summary by Sourcery

Resolve incorrect encoding selection for output ports defined as application parameters by consolidating component and application arguments and applying the specified encoding or falling back to the default dill serializer.

Bug Fixes:
- Include ApplicationArguments alongside ComponentParameters when matching output ports to respect custom encoding settings
- Ensure encoding setting is correctly applied even when parameters are defined as application arguments

Enhancements:
- Add debug logging to report the encoding used for each output port