### PR TITLE
Logging improvements

### DIFF
--- a/daliuge-engine/dlg/apps/app_base.py
+++ b/daliuge-engine/dlg/apps/app_base.py
@@ -89,7 +89,7 @@ class InstanceLogHandler(logging.Handler):
              we are just interested in extracting and storing Record metadata
         """
 
-        exc = f"{str(record.exc_text)}" if record.exc_text else ""
+        exc = f"{str(record.exc_text)}" if record and record.exc_text else ""
         # msg = str(record.message).replace("\n", "<br>")
         msg = (f"<pre>{record.message.encode('utf-8').decode('unicode_escape')}\n"
                f"{exc}</pre>")

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -50,7 +50,6 @@ from dlg.named_port_utils import (
     replace_named_ports
 )
 from dlg.apps.app_base import BarrierAppDROP
-from dlg.drop import track_current_drop
 from dlg.exceptions import InvalidDropException
 from dlg.meta import (
     dlg_string_param,

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -782,13 +782,13 @@ class PyFuncApp(BarrierAppDROP):
         else:
             self.initialize_with_func_code()
 
-        logger.info(f"Args summary for '{self.func_name}':")
-        logger.info(f"Args: {self.argnames}")
+        logger.debug(f"Args summary for '{self.func_name}':")
+        logger.debug(f"Args: {self.argnames}")
         logger.info(f"Args defaults:  {self.fn_defaults}")
-        logger.info(f"Args pos/kw: {list(self.poskw.keys())}")
-        logger.info(f"Args keyword only: {list(self.kwonly.keys())}")
-        logger.info(f"VarArgs allowed:  {self.varargs}")
-        logger.info(f"VarKwds allowed:  {self.varkw}")
+        logger.debug(f"Args pos/kw: {list(self.poskw.keys())}")
+        logger.debug(f"Args keyword only: {list(self.kwonly.keys())}")
+        logger.debug(f"VarArgs allowed:  {self.varargs}")
+        logger.debug(f"VarKwds allowed:  {self.varkw}")
 
         # Mapping between argument name and input drop uids
         logger.debug(f"Input mapping provided: {self.func_arg_mapping}")
@@ -851,8 +851,8 @@ class PyFuncApp(BarrierAppDROP):
                 and "self" in funcargs):
             funcargs.pop("self")
 
-        logger.info(f"Running {self.func_name}")
-        logger.debug(f"Arguments: *{pargs} **{funcargs}")
+        logger.debug(f"Running {self.func_name}")
+        logger.info(f"Arguments for {self.func_name}: *{pargs} **{funcargs}")
 
         # 4. prepare for execution
         # we capture and log whatever is produced on STDOUT
@@ -873,9 +873,11 @@ class PyFuncApp(BarrierAppDROP):
                 result = self.func(*pargs, **funcargs)
 
         logger.debug("Returned result from %s: %s", self.func_name, result)
-        logger.info(
-            f"Captured output from function app '{self.func_name}': {capture.getvalue()}"
-        )
+        if capture.getvalue():
+            msg = f"STDOUT/STDERR output from function: '{self.func_name}': {capture.getvalue()}"
+        else:
+            msg = f"No STDOUT/STDERR output from function: '{self.func_name}'"
+        logger.info(msg)
         logger.debug(f"Finished execution of {self.func_name}.")
 
         # 6. Process results

--- a/daliuge-engine/dlg/apps/scp.py
+++ b/daliuge-engine/dlg/apps/scp.py
@@ -20,6 +20,7 @@
 #    MA 02111-1307  USA
 #
 from dlg.remote import copyTo, copyFrom
+from dlg.drop import track_current_drop
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.data.drops.data_base import NullDROP
 from dlg.data.drops.container import ContainerDROP
@@ -110,6 +111,7 @@ class ScpApp(BarrierAppDROP):
     def initialize(self, **kwargs):
         BarrierAppDROP.initialize(self, **kwargs)
 
+    @track_current_drop
     def run(self):
         # Check inputs/outputs are of a valid type
         for i in self.inputs + self.outputs:

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -181,6 +181,7 @@ class CopyApp(BarrierAppDROP):
         [dlg_streaming_input("binary/*")],
     )
 
+    @track_current_drop
     def run(self):
         logger.debug("Using buffer size %d", self.bufsize)
         logger.info(

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -185,8 +185,8 @@ class CopyApp(BarrierAppDROP):
         logger.debug("Using buffer size %d", self.bufsize)
         logger.info(
             "Copying data from inputs %s to outputs %s",
-            [x.name for x in self.inputs],
-            [x.name for x in self.outputs],
+            [x.path for x in self.inputs],
+            [x.path for x in self.outputs],
         )
         self.copyAll()
         logger.info(

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -186,8 +186,8 @@ class CopyApp(BarrierAppDROP):
         logger.debug("Using buffer size %d", self.bufsize)
         logger.info(
             "Copying data from inputs %s to outputs %s",
-            [x.path for x in self.inputs],
-            [x.path for x in self.outputs],
+            [(getattr(x, "path", "") or x.name) for x in self.inputs],
+            [(getattr(x, "path", "") or x.name) for x in self.outputs],
         )
         self.copyAll()
         logger.info(

--- a/daliuge-engine/dlg/apps/simple.py
+++ b/daliuge-engine/dlg/apps/simple.py
@@ -284,6 +284,7 @@ class RandomArrayApp(BarrierAppDROP):
         super(RandomArrayApp, self).initialize(**kwargs)
         self._keep_array = keep_array
 
+    @track_current_drop
     def run(self):
         # At least one output should have been added
         outs = self.outputs
@@ -364,6 +365,7 @@ class AverageArraysApp(BarrierAppDROP):
     def initialize(self, **kwargs):
         super().initialize(**kwargs)
 
+    @track_current_drop
     def run(self):
         # At least one output should have been added
 
@@ -449,6 +451,7 @@ class GenericGatherApp(BarrierAppDROP):
                 value = droputils.allDropContents(input)
                 output.write(value)
 
+    @track_current_drop
     def run(self):
         self.readWriteData()
 
@@ -547,6 +550,7 @@ class ArrayGatherApp(BarrierAppDROP):
                 self.value_list.append(pickle.loads(value))
             output.write(pickle.dumps(self.value_list))
 
+    @track_current_drop
     def run(self):
         self.value_list = []
         self.readWriteData()
@@ -604,6 +608,7 @@ class GenericNpyGatherApp(BarrierAppDROP):
     function: str = dlg_string_param("function", "sum")  # type: ignore
     reduce_axes: list = dlg_list_param("reduce_axes", "None")  # type: ignore
 
+    @track_current_drop
     def run(self):
         if len(self.inputs) < 1:
             raise Exception(f"At least one input should have been added to {self}")
@@ -690,6 +695,7 @@ class HelloWorldApp(BarrierAppDROP):
 
     greet = dlg_string_param("greet", "World")
 
+    @track_current_drop
     def run(self):
         ins = self.inputs
         # if no inputs use the parameter else use the input
@@ -747,6 +753,7 @@ class UrlRetrieveApp(BarrierAppDROP):
 
     url = dlg_string_param("url", "")
 
+    @track_current_drop
     def run(self):
         try:
             logger.info("Accessing URL %s", self.url)
@@ -876,6 +883,7 @@ class GenericNpyScatterApp(BarrierAppDROP):
     num_of_copies: int = dlg_int_param("num_of_copies", 1)
     scatter_axes: List[int] = dlg_list_param("scatter_axes", "[0]")
 
+    @track_current_drop
     def run(self):
         if len(self.inputs) * self.num_of_copies != len(self.outputs):
             raise DaliugeException(
@@ -914,6 +922,7 @@ class SimpleBranch(BranchAppDrop, NullBarrierApp):
         self.result = self._popArg(kwargs, "result", True)
         BranchAppDrop.initialize(self, **kwargs)
 
+    @track_current_drop
     def run(self):
         pass
 
@@ -1045,6 +1054,7 @@ class PickOne(BarrierAppDROP):
                 output.len = len(d)
             output.write(d)
 
+    @track_current_drop
     def run(self):
         value, rest = self.readData()
         self.writeData(value, rest)
@@ -1093,6 +1103,7 @@ class ListAppendThrashingApp(BarrierAppDROP):
         self.marray = []
         super(ListAppendThrashingApp, self).initialize(**kwargs)
 
+    @track_current_drop
     def run(self):
         # At least one output should have been added
         outs = self.outputs

--- a/daliuge-engine/dlg/apps/socket_listener.py
+++ b/daliuge-engine/dlg/apps/socket_listener.py
@@ -28,6 +28,7 @@ import contextlib
 import logging
 import socket
 
+from dlg.drop import track_current_drop
 from ..ddap_protocol import DROPRel, DROPLinkType
 from ..apps.app_base import BarrierAppDROP
 from ..exceptions import InvalidRelationshipException
@@ -100,6 +101,7 @@ class SocketListenerApp(BarrierAppDROP):
     def initialize(self, **kwargs):
         super(SocketListenerApp, self).initialize(**kwargs)
 
+    @track_current_drop
     def run(self):
         # At least one output should have been added
         outs = self.outputs

--- a/daliuge-engine/dlg/apps/subgraph.py
+++ b/daliuge-engine/dlg/apps/subgraph.py
@@ -23,8 +23,7 @@ import threading
 import time
 import datetime
 
-from typing import List, Dict
-
+from dlg.drop import track_current_drop
 from dlg.apps.app_base import BarrierAppDROP
 from dlg.common import get_roots
 from dlg.data.drops.data_base import logger
@@ -149,6 +148,7 @@ class SubGraphLocal(BarrierAppDROP):
         )
         return pg.to_pg_spec(node_list, ret_str=False)
 
+    @track_current_drop
     def run(self):
         """
         Start the required DROPManagers and deploy the subgraph

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -117,7 +117,7 @@ class FileDROP(DataDROP, PathBasedDrop):
     def _setupFilePaths(self):
         filepath = self.parameters.get("filepath", None)
         # TODO ADD SUFFIX/PREFIX
-        dirname = None
+        dirname = "."  # default is a relative filepath
         filename = None
 
         if filepath:  # if there is anything provided
@@ -125,7 +125,6 @@ class FileDROP(DataDROP, PathBasedDrop):
             if "/" not in filepath:  # just a name
                 filename = filepath
                 dirname = self.get_dir(".")
-            # filepath = self.sanitize_paths(self.filepath)
             elif filepath.endswith("/"):  # just a directory name
                 self.is_dir = True
                 filename = None
@@ -133,8 +132,6 @@ class FileDROP(DataDROP, PathBasedDrop):
             else:
                 filename = os.path.basename(filepath)
                 dirname = os.path.dirname(filepath)
-        if dirname is None:
-            dirname = "."
         filename = os.path.expandvars(filename) if filename else None
         dirname = self.sanitize_paths(dirname) if dirname else None
         # We later check if the file exists, but only if the user has specified

--- a/daliuge-engine/dlg/data/drops/file.py
+++ b/daliuge-engine/dlg/data/drops/file.py
@@ -117,14 +117,12 @@ class FileDROP(DataDROP, PathBasedDrop):
     def _setupFilePaths(self):
         filepath = self.parameters.get("filepath", None)
         # TODO ADD SUFFIX/PREFIX
-        dirname = "."  # default is a relative filepath
-        filename = None
 
         if filepath:  # if there is anything provided
-            # TODO do f-string substitution if necessary
             if "/" not in filepath:  # just a name
                 filename = filepath
                 dirname = self.get_dir(".")
+            # filepath = self.sanitize_paths(self.filepath)
             elif filepath.endswith("/"):  # just a directory name
                 self.is_dir = True
                 filename = None
@@ -132,6 +130,9 @@ class FileDROP(DataDROP, PathBasedDrop):
             else:
                 filename = os.path.basename(filepath)
                 dirname = os.path.dirname(filepath)
+        else:
+            dirname = "."
+            filename = None
         filename = os.path.expandvars(filename) if filename else None
         dirname = self.sanitize_paths(dirname) if dirname else None
         # We later check if the file exists, but only if the user has specified
@@ -157,7 +158,7 @@ class FileDROP(DataDROP, PathBasedDrop):
         )
         if check and not os.path.isfile(self._path):
             raise InvalidDropException(
-                self, "File does not exist or is not a file: %s" % self._path
+                self, f"File does not exist or is not a file: {self._path}"
             )
 
         self._wio = None

--- a/daliuge-engine/dlg/data/drops/ngas.py
+++ b/daliuge-engine/dlg/data/drops/ngas.py
@@ -67,6 +67,7 @@ class NgasDROP(DataDROP):
             self.fileId = self.ngasFileId
         else:
             self.fileId = self.uid
+        # self.path = self.fileId # we are using the path for logging
 
     def getIO(self):
         try:

--- a/daliuge-engine/dlg/data/drops/ngas.py
+++ b/daliuge-engine/dlg/data/drops/ngas.py
@@ -107,6 +107,9 @@ class NgasDROP(DataDROP):
         # this file, in which case we create an empty file so applications
         # downstream don't fail to read
         logger.debug("Trying to set size of NGASDrop")
+        if not self.getIO().exists():
+            self.setError()
+            raise FileNotFoundError(f"File with fileId '{self.fileId}' not found on host '{self.ngasSrv}'!")
         try:
             stat = self.getIO().fileStatus()
             logger.debug(
@@ -126,6 +129,7 @@ class NgasDROP(DataDROP):
             #     logger.error("Path not accessible: %s" % self.path)
             logger.debug("Setting size of NGASDrop to %s", 0)
             self._size = 0
+            self.setError()
             raise
         # Signal our subscribers that the show is over
         logger.debug("Moving %r to COMPLETED", self)

--- a/daliuge-engine/dlg/data/io.py
+++ b/daliuge-engine/dlg/data/io.py
@@ -647,7 +647,7 @@ class NgasLiteIO(DataIO):
         return len(data)
 
     def exists(self) -> bool:
-        logger.warning("This method is not supported by this class")
+        return ngaslite.fileIdExists(self._ngasSrv, self._ngasPort, self._fileId)
 
     def fileStatus(self):
         logger.debug("Getting status of file %s", self._fileId)

--- a/daliuge-engine/dlg/data/io.py
+++ b/daliuge-engine/dlg/data/io.py
@@ -647,7 +647,7 @@ class NgasLiteIO(DataIO):
         return len(data)
 
     def exists(self) -> bool:
-        raise NotImplementedError("This method is not supported by this class")
+        logger.warning("This method is not supported by this class")
 
     def fileStatus(self):
         logger.debug("Getting status of file %s", self._fileId)

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -146,10 +146,10 @@ def copyDropContents(source: "DataDROP", target: "DataDROP", bufsize: int = 6553
     """
     Manually copies data from one DROP into another, in bufsize steps
     """
-    logger.debug("Copying from %s to %s", repr(source), repr(target))
+    logger.debug("Copying from %s to %s", repr(source.path), repr(target.path))
     sdesc = source.open()
     buf = source.read(sdesc, bufsize)
-    logger.debug("Read %d bytes from %s", len(buf), repr(source))
+    logger.debug("Using buffersize of %d bytes", len(buf), repr(source))
     st = time.time()
     ssize = source.size if source.size is not None else -1
     logger.debug("Source size: %s; Source checksum: %s", ssize, source.checksum)

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -149,7 +149,7 @@ def copyDropContents(source: "DataDROP", target: "DataDROP", bufsize: int = 6553
     logger.debug("Copying from %s to %s", repr(source.path), repr(target.path))
     sdesc = source.open()
     buf = source.read(sdesc, bufsize)
-    logger.debug("Using buffersize of %d bytes", len(buf), repr(source))
+    logger.debug("Using buffersize of %d bytes", len(buf))
     st = time.time()
     ssize = source.size if source.size is not None else -1
     logger.debug("Source size: %s; Source checksum: %s", ssize, source.checksum)
@@ -171,7 +171,7 @@ def copyDropContents(source: "DataDROP", target: "DataDROP", bufsize: int = 6553
             ofl = True
         buf = source.read(sdesc, bufsize)
     dur = time.time() - st
-    logger.debug(
+    logger.info(
         "Wrote %d Bytes of %d to %s; rate %.2f MB/s",
         tot_w,
         ssize,

--- a/daliuge-engine/dlg/droputils.py
+++ b/daliuge-engine/dlg/droputils.py
@@ -146,7 +146,8 @@ def copyDropContents(source: "DataDROP", target: "DataDROP", bufsize: int = 6553
     """
     Manually copies data from one DROP into another, in bufsize steps
     """
-    logger.debug("Copying from %s to %s", repr(source.path), repr(target.path))
+    logger.debug("Copying from %s to %s", (getattr(source, "path", "") or source.name), 
+                 (getattr(target, "path", "") or target.name))
     sdesc = source.open()
     buf = source.read(sdesc, bufsize)
     logger.debug("Using buffersize of %d bytes", len(buf))

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -152,10 +152,13 @@ class DataLifecycleManagerBackgroundTask(threading.Thread):
         ev = self._dlm._finishedEvent
         dlm = self._dlm
         p = self._period
+        orig_level = logger.getEffectiveLevel()
         while True:
             if ev.wait(p):
                 break
+            logging.getLogger("dlg").setLevel(logging.INFO) # don't want repeating logs
             self.doTask(dlm)
+            logging.getLogger("dlg").setLevel(orig_level) # 
 
 
 class DROPChecker(DataLifecycleManagerBackgroundTask):

--- a/daliuge-engine/dlg/lifecycle/dlm.py
+++ b/daliuge-engine/dlg/lifecycle/dlm.py
@@ -153,12 +153,11 @@ class DataLifecycleManagerBackgroundTask(threading.Thread):
         dlm = self._dlm
         p = self._period
         orig_level = logger.getEffectiveLevel()
-        while True:
-            if ev.wait(p):
-                break
+        while not ev.wait(p):
             logging.getLogger("dlg").setLevel(logging.INFO) # don't want repeating logs
             self.doTask(dlm)
             logging.getLogger("dlg").setLevel(orig_level) # 
+
 
 
 class DROPChecker(DataLifecycleManagerBackgroundTask):

--- a/daliuge-engine/dlg/manager/node_manager.py
+++ b/daliuge-engine/dlg/manager/node_manager.py
@@ -517,7 +517,7 @@ class ZMQPubSubMixIn(object):
         self._subscriptions = queue.Queue()
 
         # Starts background threads, but wait until their sockets are created
-        timeout = 30
+        timeout = 10
         self._event_publisher = self._start_thread(
             self._publish_events, "Evt pub", timeout
         )

--- a/daliuge-engine/dlg/manager/session.py
+++ b/daliuge-engine/dlg/manager/session.py
@@ -708,7 +708,8 @@ class Session(object):
             drop = self._drops[uid]
             return getattr(drop, prop_name)
         except AttributeError:
-            raise DaliugeException("%r has no property called %s" % (drop, prop_name))
+            logger.critical("%r has no property called %s" % (drop, prop_name))
+            return getattr(drop, "name")
 
     def call_drop(self, uid, method, *args):
         if uid not in self._drops:

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -461,6 +461,16 @@ def get_port_reader_function(input_parser: DropParser):
             return ast.literal_eval(content) if len(content) > 0 else None
 
         reader = optionalEval
+    elif input_parser is DropParser.UTF8:
+
+        def utf8decode(drop: "DataDROP"):
+            """
+            Decode utf8
+            Not stored in drop_loaders to avoid cyclic imports
+            """
+            return droputils.allDropContents(drop).decode("utf-8")
+
+        reader = utf8decode
     elif input_parser is DropParser.NPY:
         reader = drop_loaders.load_npy
     elif input_parser is DropParser.PATH:

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -461,16 +461,6 @@ def get_port_reader_function(input_parser: DropParser):
             return ast.literal_eval(content) if len(content) > 0 else None
 
         reader = optionalEval
-    elif input_parser is DropParser.UTF8:
-
-        def utf8decode(drop: "DataDROP"):
-            """
-            Decode utf8
-            Not stored in drop_loaders to avoid cyclic imports
-            """
-            return droputils.allDropContents(drop).decode("utf-8")
-
-        reader = utf8decode
     elif input_parser is DropParser.NPY:
         reader = drop_loaders.load_npy
     elif input_parser is DropParser.PATH:

--- a/daliuge-engine/dlg/named_port_utils.py
+++ b/daliuge-engine/dlg/named_port_utils.py
@@ -200,7 +200,7 @@ def identify_named_ports(
                 continue
             parser = get_port_reader_function(encoding)
             if parser:
-                logger.debug("Reading from %s encoded port using %s", encoding, parser.__repr__())
+                logger.debug("Reading from %s encoded port using '%s'", encoding, parser)
                 value = parser(port_dict[keys[i]]["drop"])
             # if not found in appArgs we don't put them into portargs either
             # pargsDict.update({key: value})

--- a/daliuge-engine/dlg/ngaslite.py
+++ b/daliuge-engine/dlg/ngaslite.py
@@ -31,6 +31,7 @@ still need to access NGAS from time to time.
 import http.client
 import logging
 import urllib.request
+from xml.dom import minidom
 import requests
 from xml.dom.minidom import parseString
 
@@ -121,6 +122,33 @@ def finishArchive(conn, fileId):
             % (fileId, conn.host, conn.port, response.status, response.msg)
         )
 
+def fileIdExists(host:str, port:int, fileId:str, timeout:int=10) -> bool:
+    """Check whether file with ID exists on a NGAS node.
+
+    Args:
+        host (str): DNS name or IP address of NGAS host
+        port (int): Port the NGAS server is listening on
+        fileId (str): The fileId to check
+        timeout (int, optional): Timeout for the NGAS call. Defaults to 10.
+
+    Returns:
+        bool: True if fileId has been found else False
+    """
+    try:
+        _ = fileStatus(host, port, fileId, timeout)
+        return True
+    except ConnectionError:
+        raise
+    except Exception as err:
+        xp = minidom.parseString(err.args[0]['STATUS_ERR']['message'])
+        return False
+        _ = xp.getElementsByTagName("Status")[0].attributes["Message"].value
+        # TODO: do the more explicit checking
+        # message = xp.getElementsByTagName("Status")[0].attributes["Message"].value
+        # if message.startswith("NGAMS_ER_UNAVAIL_FILE"):
+        #     return False
+        # else:
+        #     return False
 
 def fileStatus(host, port, fileId, timeout=10):
     """
@@ -135,11 +163,19 @@ def fileStatus(host, port, fileId, timeout=10):
         conn = requests.request("GET", url)
         # conn = urllib.request.urlopen(url, timeout=timeout)
     except ConnectionError:
-        raise FileNotFoundError
+        raise
     if conn.status_code != http.HTTPStatus.OK:
+        # raise Exception(
+        #     "Error while getting STATUS %s from %s:%d: %d %s"
+        #     % (fileId, host, port, conn.status_code, conn.text)
+        # )
         raise Exception(
-            "Error while getting STATUS %s from %s:%d: %d %s"
-            % (fileId, host, port, conn.status_code, conn.text)
+            {"STATUS_ERR":{
+                "code": conn.status_code,
+                "host": host,
+                "port": port,
+                "message": conn.text
+            }}
         )
     dom = parseString(conn.content.decode())
     stat = dict(

--- a/daliuge-engine/dlg/rpc.py
+++ b/daliuge-engine/dlg/rpc.py
@@ -243,7 +243,7 @@ class ZeroRPCServer(RPCServerBase):
         super(ZeroRPCServer, self).start()
 
         # Starts the single-threaded ZeroRPC server for RPC requests
-        timeout = 30
+        timeout = 10
         server_started = threading.Event()
         self._zrpcserverthread = threading.Thread(
             target=self.run_zrpcserver,

--- a/daliuge-engine/test/deploy/test_graph_to_manager.py
+++ b/daliuge-engine/test/deploy/test_graph_to_manager.py
@@ -37,6 +37,7 @@ from dlg.ddap_protocol import DROPStates
 from dlg.testutils import ManagerStarter
 from test.dlg_engine_testutils import NMTestsMixIn, DROPManagerUtils
 
+
 def create_full_hostname(server_info, event_port, rpc_port):
 
     return (f"{server_info.server._server.listen}:"
@@ -79,6 +80,9 @@ class TestGraphLoaderToNodeManager(NMTestsMixIn, ManagerStarter, unittest.TestCa
         # Partitioning currently requires the to_go_js + to_pg_spec approach
         # We will partition using METIS, as the base PGT class doesn't actually partition
         # anything.
+        #
+        # NOTE: if this test fails to run with an zerorpc error 'port already in use', try to
+        # kill all python processes. Seems that sometimes the tear-down is not completed.
         lg_path = str(files(__package__) / "ArrayLoop.graph")
 
         # drop_list = lg.unroll_to_tpl()


### PR DESCRIPTION
# JIRA Ticket 
No JIRA ticket for this. Almost all the changes are related to missing log-entries from the graph log details in various test graphs.

# Type
Improvement of logs for users and to make them complete compared to what is actually in the dlgNM.log file.

- [x] Feature (addition)
- [ ] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
For some drops logs in the dlgNM.log file did not have the humanKey information and thus those entries also did not show up in the InstancesLog. In almost all cases this was caused by missing track_current_drop decorators on the run method of the component class. When checking all these logs I also realized a few other small issues. A bigger one was that for the CopyApp the log message about what is copied to where was very unhelpful in particular when plain files are copied, since it showed the FileDrop name, which is a pretty ugly string, rather than the much more useful full path.

# Solution
Add decorator to a number of components. Changed some log messages from INFO to DEBUG or visa versa.

# Checklist

- [ ] Unittests added
  - This is about log-messages in a general sense, adding a unittest would likely only cover special cases. We might think about a test checking all the logs for messages with empty humanKey fields, but what to compare that to?
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)

## Summary by Sourcery

Improve and standardize logging across the engine by adding missing drop‐tracking decorators, refining log levels and messages, and enhancing visibility into file and function operations.

Enhancements:
- Add @track_current_drop decorators to numerous component run methods to ensure humanKey entries appear in graph logs
- Adjust log levels and messages in Python function and simple apps to use INFO/DEBUG appropriately and include full paths instead of drop names
- Enhance STDOUT/STDERR capture logging for function apps to explicitly report presence or absence of output
- Update drop‐copy logging to show buffer sizes, source/target file paths, and switch final copy summary to INFO level
- Suppress repetitive logs in DataLifecycleManager background tasks by temporarily adjusting the logger level
- Simplify default file path handling by using a relative "." dirname and sanitize log output for named port readers
- Change unsupported IO.exists() exception to a warning and reduce NodeManager and ZeroRPC startup timeouts to 10 seconds

Chores:
- Add a note in test_graph_to_manager to aid debugging of port conflicts