### PR TITLE
translator deploy, reuse tabs!

### DIFF
--- a/daliuge-translator/dlg/dropmake/web/main.js
+++ b/daliuge-translator/dlg/dropmake/web/main.js
@@ -679,7 +679,7 @@ async function directRestDeploy() {
         })
     })
     const mgr_url = manager_url + "/session?sessionId=" + sessionId;
-    window.open(mgr_url, 'blank').focus();
+    window.open(mgr_url, 'deploy_target').focus();
 }
 
 function jsonEscape(str) {

--- a/daliuge-translator/dlg/dropmake/web/pg_viewer.html
+++ b/daliuge-translator/dlg/dropmake/web/pg_viewer.html
@@ -144,7 +144,7 @@
                     <a type="button" class="close material-icons" data-dismiss="modal">close</a>
                 </div>
                 <div class="modal-body">
-                    <form action="/gen_pg" method="get" target="blank" name="deploy_target" id="pg_form" >
+                    <form action="/gen_pg" method="get" target="deploy_target" name="deploy_target" id="pg_form" >
                         <div id="neccessaryHiddenItems">
                             <input id="managerUrlInput" type="text" name="dlg_mgr_url" value="http://localhost:8001" size="40" style="font-size:16px;">
                             <input type="checkbox" id="dlg_mgr_deploy" name="dlg_mgr_deploy" value="deploy" checked>
@@ -152,7 +152,7 @@
                         </div>
                         
                     </form>
-                    <form action="/gen_pg_helm" method="get" id="pg_helm_form" target="_blank" name="deploy_helm_target">
+                    <form action="/gen_pg_helm" method="get" id="pg_helm_form" target="deploy_target" name="deploy_helm_target">
                         <input type="checkbox" id="dlg_helm_deploy" style="visibility:hidden;" name="dlg_helm_deploy" value="helm_deploy" checked>
                         <input type="hidden" name="pgt_id" value="{{pgt_view_json_name}}">
                     </form>


### PR DESCRIPTION
# Type
- [ ] Feature (addition)
- [ X] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
complaint by user, deploy in translator was not reusing existing DIM tabs in browser

# Solution
replacing all calls for "_blank" in the window.open() functions and form targets on submit with "deploy_target". "deploy_target" will act like an id for that window, so all deploy methods will reuse the same one.

# Checklist
- [ ] Unittests added
  - minor change
- [ ] Documentation added
    - minor change

## Summary by Sourcery

Bug Fixes:
- Replace all "_blank"/"blank" targets in window.open calls and form actions with "deploy_target" to reuse the same tab