### PR TITLE
Dependabot: Apply urllib3 updates to resolve security issues

### DIFF
--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -144,7 +144,7 @@ class lib64_path(install):
 install_requires = [
     "wheel",  # need to get wheel first...
     "bottle",
-    "urllib3<1.27,>=1.25.4",
+    "urllib3>=2.5.0", 
     "boto3",
     "configobj",
     "crc32c",

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -144,8 +144,8 @@ class lib64_path(install):
 install_requires = [
     "wheel",  # need to get wheel first...
     "bottle",
-    "urllib3>=2.5.0", 
-    "boto3",
+    "urllib3>=2.5.0",
+    "boto3>=1.38.0",
     "configobj",
     "crc32c",
     "daliuge-common",

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -144,7 +144,8 @@ class lib64_path(install):
 install_requires = [
     "wheel",  # need to get wheel first...
     "bottle",
-    "urllib3>=2.5.0",
+    "urllib3>=1.25.4, <1.27 ; python_version < '3.10'",
+    "urllib3>=2.5.0; python_version >= '3.10'",
     "boto3>=1.38.0",
     "configobj",
     "crc32c",


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->
N/A
# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ ] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 
- [x] Security patch

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

Dependabot has identified the following issues in the `urllib3`: https://github.com/ICRAR/daliuge/security/dependabot/2 https://github.com/ICRAR/daliuge/security/dependabot/3. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have updated `urllib3` to use version >=2.5.0*. This passes all unit tests and I have tested locally that I can translate a graph using both the Server and Browser Direct approach. 

This is for Python **>=3.10**. There is a requirement on `botocore` to use `urllib< 1.27`, and because we have a reliance on `botocore` (through `boto3`), we will also be applying this conditional requirement. Python 3.9 will use the same version of urllib3 as `botocore` (see[ corresponding setup.py](https://github.com/boto/botocore/blob/34c9a39285624dd23724ee34f6a9f9b74c7e74b0/setup.py)).   

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - Reason for not adding unittests: library update
- ~[ ] Documentation added~
    - Reason for not adding documentation: library update

## Summary by Sourcery

Build:
- Update urllib3 requirement to >=2.5.0 to resolve security issues