### PR TITLE
LIU-382: Remove final pkg_resources references from code

### DIFF
--- a/daliuge-common/setup.py
+++ b/daliuge-common/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup
 # here. If we find the git commit (either via "git" command execution or in a
 # dlg/version.py file) we append it to the VERSION later.
 # The RELEASE flag allows us to create development versions properly supported
-# by setuptools/pkg_resources or "final" versions.
+# by setuptools or "final" versions.
 
 
 def extract_version():

--- a/daliuge-engine/dlg/lifecycle/registry.py
+++ b/daliuge-engine/dlg/lifecycle/registry.py
@@ -31,6 +31,7 @@ The registry simply (for the time being) keeps a record of:
 @author: rtobar
 """
 
+import datetime
 import importlib
 import logging
 import time
@@ -260,7 +261,7 @@ class RDBMSRegistry(Registry):
             self.execute(
                 cur,
                 "INSERT INTO dlg_dropaccesstime (oid, accessTime) VALUES ({0},{1})",
-                (oid, time.time()),
+                (oid, datetime.datetime.now(datetime.timezone.utc).isoformat()),
             )
             cur.close()
 

--- a/daliuge-engine/dlg/lifecycle/registry.py
+++ b/daliuge-engine/dlg/lifecycle/registry.py
@@ -260,7 +260,7 @@ class RDBMSRegistry(Registry):
             self.execute(
                 cur,
                 "INSERT INTO dlg_dropaccesstime (oid, accessTime) VALUES ({0},{1})",
-                (oid, self._dbmod.TimestampFromTicks(time.time())),
+                (oid, time.time()),
             )
             cur.close()
 

--- a/daliuge-engine/dlg/manager/replay.py
+++ b/daliuge-engine/dlg/manager/replay.py
@@ -24,13 +24,16 @@ import json
 import logging
 
 import bottle
-import pkg_resources
 
+from pathlib import Path
 from typing import List, Optional
-from .drop_manager import DROPManager
-from .rest import ManagerRestServer
-from .session import SessionStates
-from ..exceptions import NoSessionException, InvalidSessionState
+
+from dlg.manager.drop_manager import DROPManager
+from dlg.manager.rest import ManagerRestServer
+from dlg.manager.session import SessionStates
+
+from dlg import utils
+from dlg.exceptions import NoSessionException, InvalidSessionState
 
 logger = logging.getLogger(f"dlg.{__name__}")
 
@@ -140,6 +143,9 @@ class ReplayManager(DROPManager):
     def getSessionIds(self):
         return [self._session_id]
 
+def file_as_string(fname, enc="utf8"):
+    res = Path(__file__).parent / fname
+    return utils.b2s(res.read_bytes(), enc)
 
 class ReplayManagerServer(ManagerRestServer):
     def initializeSpecifics(self, app):
@@ -148,9 +154,7 @@ class ReplayManagerServer(ManagerRestServer):
         app.get("/", callback=self.visualizeDM)
 
     def visualizeDM(self):
-        tpl = pkg_resources.resource_string(
-            __name__, "web/dm.html"
-        )  # @UndefinedVariable
+        tpl = file_as_string("web/dm.html")
         urlparts = bottle.request.urlparts
         serverUrl = urlparts.scheme + "://" + urlparts.netloc
         return bottle.template(

--- a/daliuge-engine/dlg/manager/rest.py
+++ b/daliuge-engine/dlg/manager/rest.py
@@ -827,6 +827,7 @@ class MasterManagerRestServer(CompositeManagerRestServer):
     def _getAllCMNodes(self):
         nodes = []
         for host in self.dm.dmHosts:
-            with DataIslandManagerClient(host=host.host, port=host.port) as dm:
+            h = Node(host)
+            with DataIslandManagerClient(host=h.host, port=h.port) as dm:
                 nodes += dm.nodes()
         return [str(n) for n in nodes]

--- a/daliuge-engine/setup.py
+++ b/daliuge-engine/setup.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(f"dlg.{__name__}")
 # here. If we find the git commit (either via "git" command execution or in a
 # dlg/version.py file) we append it to the VERSION later.
 # The RELEASE flag allows us to create development versions properly supported
-# by setuptools/pkg_resources or "final" versions.
+# by setuptools or "final" versions.
 def extract_version():
     """
     Retrived the current version based on the most recent version tag, stored in daliuge-common/VERSION.

--- a/daliuge-engine/test/manager/test_dim.py
+++ b/daliuge-engine/test/manager/test_dim.py
@@ -28,8 +28,6 @@ import unittest
 import shutil
 from asyncio.log import logger
 
-# import pkg_resources
-
 from dlg import utils, droputils
 from dlg.testutils import ManagerStarter
 from dlg.common import tool

--- a/daliuge-engine/test/manager/test_mm.py
+++ b/daliuge-engine/test/manager/test_mm.py
@@ -26,7 +26,8 @@ import sys
 import time
 import unittest
 
-import pkg_resources
+import importlib.resources
+
 from dlg import droputils
 from dlg import utils
 from dlg.common import tool
@@ -340,9 +341,8 @@ class TestREST(DimAndNMStarter, unittest.TestCase):
             # Since the original complexGraph doesn't have node information
             # we need to add it manually before submitting -- otherwise it will
             # get rejected by the DIM.
-            with pkg_resources.resource_stream(
-                "test", "graphs/complex.js"
-            ) as f:  # @UndefinedVariable
+            fpath = importlib.resources.files("test") / "graphs/complex.js"
+            with fpath.open('rb') as f:
                 complexGraphSpec = json.load(codecs.getreader("utf-8")(f))
             for dropSpec in complexGraphSpec:
                 dropSpec["node"] = f"{hostname}:{constants.NODE_DEFAULT_REST_PORT}"

--- a/daliuge-engine/test/pyext/test_pyext.py
+++ b/daliuge-engine/test/pyext/test_pyext.py
@@ -13,7 +13,7 @@ def test_overload_argc():
     assert f(1) == 1
     assert f(1, 2) == 2
     with pytest.raises(TypeError): f(1, 2, 3)
-    assert len(inspect.getargspec(f).args) == 0
+    assert len(inspect.getfullargspec(f).args) == 0
 
 def test_overload_args():
     @pyext.overload.args(str, int)
@@ -29,7 +29,7 @@ def test_overload_args():
     assert f('s') == str
     assert f('s', 0) == (str, int)
     with pytest.raises(TypeError): f(0, 's')
-    assert len(inspect.getargspec(f).args) == 0
+    assert len(inspect.getfullargspec(f).args) == 0
     class x(object):
         @pyext.overload.args(str, is_cls=True)
         def f(self, s): return 1

--- a/daliuge-translator/dlg/dropmake/web/translator_rest.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_rest.py
@@ -140,7 +140,7 @@ gen_pgt_sem = threading.Semaphore(1)
 global lg_dir
 global pgt_dir
 global pg_mgr
-LG_SCHEMA = json.loads(file_as_string("lg.graph.schema", package="dlg.dropmake"))
+LG_SCHEMA = json.loads(file_as_string("lg.graph.schema", module="dlg.dropmake"))
 
 
 @app.post("/jsonbody", tags=["Original"])
@@ -486,7 +486,6 @@ async def gen_pgt_post(
         except ValidationError as ve:
             error = "Validation Error {1}: {0}".format(str(ve), lg_name)
             logger.error(error)
-            # raise HTTPException(status_code=500, detail=error)
         logical_graph = prepare_lgt(logical_graph, rmode)
         # LG -> PGT
         # TODO: Warning: I dislike doing it this way with a passion, however without changing the tests/ usage of the api getting all form fields is difficult.

--- a/daliuge-translator/dlg/dropmake/web/translator_utils.py
+++ b/daliuge-translator/dlg/dropmake/web/translator_utils.py
@@ -1,9 +1,9 @@
 import os
 import logging
-import pkg_resources
+import importlib.resources
 from urllib.parse import urlparse
 
-from dlg import common
+from dlg import common, utils
 from dlg.clients import CompositeManagerClient
 from dlg.common.reproducibility.reproducibility import (
     init_lg_repro_data,
@@ -72,10 +72,10 @@ def _repo_contents(root_dir):
 
     return contents
 
-
-def file_as_string(fname, package=__name__, enc="utf8"):
-    b = pkg_resources.resource_string(package, fname)  # @UndefinedVariable
-    return common.b2s(b, enc)
+def file_as_string(fname, module, enc="utf8"):
+    module_path = importlib.resources.files(module)
+    res = module_path / fname
+    return utils.b2s(res.read_bytes(), enc)
 
 
 def prepare_lgt(filename, rmode: str):

--- a/daliuge-translator/setup.py
+++ b/daliuge-translator/setup.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(f"dlg.{__name__}")
 # here. If we find the git commit (either via "git" command execution or in a
 # dlg/version.py file) we append it to the VERSION later.
 # The RELEASE flag allows us to create development versions properly supported
-# by setuptools/pkg_resources or "final" versions.
+# by setuptools or "final" versions.
 
 
 def extract_version():

--- a/daliuge-translator/test/dropmake/test_lgweb.py
+++ b/daliuge-translator/test/dropmake/test_lgweb.py
@@ -29,8 +29,6 @@ from parameterized import parameterized
 import urllib.parse
 import logging
 
-# import pkg_resources
-
 from dlg import common
 from dlg.common import tool
 from dlg.dropmake.web.translator_utils import get_mgr_deployment_methods

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error::DeprecationWarning


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-382](https://icrar.atlassian.net/browse/LIU-382)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ ] Bug fix
- [x] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

We are unable to support later versions of Python as we use pkg_resources, which is no longer supported in Python 3.12+. This stops us from using the latest Ubuntu build servers (https://github.com/ICRAR/daliuge/pull/312). 

This PR aims to remove our dependency on pkg_resources. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have removed the final remnants of pkg_resources from the last couple of files (mostly in our REST interfaces that serve web pages). 

I have also added a `pytest.ini` file with the `error::DeprecationWarning` setting. This will flag all DeprecationWarnings as errors and require them fixed before the CI turns green. In the process of completing this PR, it highlighted another warning that I had missed. This will make us more proactive in our addresses these issues moving forward. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- ~[ ] Unittests added~
  - Reason for not adding unittests: Replacing existing code covered by tests. 
- ~[ ] Documentation added~
    - Reason for not adding documentation: Non-user facing changes. 

## Summary by Sourcery

Remove all remaining pkg_resources usage by migrating file resource loading to importlib.resources and pathlib, introduce a file_as_string helper, and adjust related imports and tests accordingly.

Enhancements:
- Replace pkg_resources.resource_string and resource_stream calls with a pathlib or importlib.resources-based file_as_string helper using utils.b2s
- Centralize file reading by adding file_as_string in replay manager and translator utils
- Update DataIslandManagerClient usage to wrap hosts with a Node object for consistent host resolution

Tests:
- Adapt existing tests to load resource files via importlib.resources and pathlib instead of pkg_resources

Chores:
- Remove pkg_resources imports and clean up setup.py comments

[LIU-382]: https://icrar.atlassian.net/browse/LIU-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove dependency on pkg_resources across the codebase by migrating resource loading to importlib.resources and pathlib, introduce a unified file_as_string helper, enforce deprecation warnings as errors in CI, and apply related cleanups.

Enhancements:
- Remove pkg_resources references and centralize file loading via new file_as_string helper using pathlib and importlib.resources
- Replace deprecated inspect.getargspec() with inspect.getfullargspec() in tests
- Wrap hosts in a Node object for DataIslandManagerClient instantiation
- Update registry to record access times using datetime.now().isoformat() instead of TimestampFromTicks

CI:
- Introduce pytest.ini to treat DeprecationWarnings as errors

Tests:
- Update tests to use importlib.resources/files for resource access instead of pkg_resources