### PR TITLE
LIU-515: Fix environment variable expansion

### DIFF
--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -605,10 +605,15 @@ class PyFuncApp(BarrierAppDROP):
                 argument = arg_map[arg]
                 parser = (DropParser(argument.encoding))
                 if parser == DropParser.PATH:
-                    argument.value = filepath_from_string(
-                        argument.value, dirname=output_drop.dirname, uid=output_drop.uid,
-                        humanKey=output_drop.humanKey
-                    )
+                    try:
+                        argument.value = filepath_from_string(
+                            argument.value, dirname=output_drop.dirname, uid=output_drop.uid,
+                            humanKey=output_drop.humanKey
+                        )
+                    except RuntimeError as e:
+                        raise InvalidDropException(
+                            "Path contains unset environment variable", e
+                        )
                     self._output_filepaths[output_uid] = argument.value
                 arg_map[arg] = argument
                 self.parameters[arg] = arg_map[arg].value

--- a/daliuge-engine/dlg/data/path_builder.py
+++ b/daliuge-engine/dlg/data/path_builder.py
@@ -143,6 +143,12 @@ def filepath_from_string(filename: str, dirname: str = "", **kwargs) -> str:
         return filename
 
     full_filename = os.path.expandvars(filename)
+    full_dirname = os.path.expandvars(dirname)
+
+    if full_filename == filename and "$" in full_filename:
+        raise RuntimeError(f"Environment variable in path {filename} not set!")
+    if full_dirname == dirname and "$" in full_dirname:
+        raise RuntimeError(f"Environment variable in path {dirname} not set!")
 
     opts.extend(find_dlg_fstrings(filename))
     for fp in opts:
@@ -151,4 +157,4 @@ def filepath_from_string(filename: str, dirname: str = "", **kwargs) -> str:
     if Path(full_filename).is_absolute():
         return full_filename
     else:
-        return f"{dirname}/{full_filename}" if dirname else full_filename
+        return f"{full_dirname}/{full_filename}" if full_dirname else full_filename

--- a/daliuge-engine/test/data/test_file.py
+++ b/daliuge-engine/test/data/test_file.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 from dlg.data.drops.file import FileDROP
+from dlg.exceptions import InvalidDropException
 
 
 class TestDROPFilepath(unittest.TestCase):
@@ -16,17 +17,16 @@ class TestDROPFilepath(unittest.TestCase):
     """
 
     def test_basic_filepath(self):
-        dir = Path("/tmp/daliuge_tfiles") # see PathBaseDrop.get_dir()
+        fdir = Path("/tmp/daliuge_tfiles") # see PathBaseDrop.get_dir()
         fdrop = FileDROP(uid="A", oid="A", filepath="test.txt")
-        self.assertEqual(dir/"test.txt", Path(fdrop.path))
+        self.assertEqual(fdir/"test.txt", Path(fdrop.path))
 
     def test_basic_dir(self):
-        dir = Path("/tmp/daliuge_tfiles")  # see PathBaseDrop.get_dir()
+        fdir = Path("/tmp/daliuge_tfiles")  # see PathBaseDrop.get_dir()
         fdrop = FileDROP(uid="A", oid="A", filepath="mydir/")
-        self.assertEqual(dir / "mydir", Path(fdrop.dirname))
+        self.assertEqual(fdir / "mydir", Path(fdrop.dirname))
 
     def test_root_dir(self):
-        # dir = Path("/tmp/daliuge_tfiles")  # see PathBaseDrop.get_dir()
         fdrop = FileDROP(uid="A", oid="A", filepath="/mydir/")
         self.assertEqual(Path("/mydir"), Path(fdrop.dirname))
 
@@ -38,11 +38,14 @@ class TestDROPFilepath(unittest.TestCase):
         fdrop = FileDROP(uid="A", oid="A", filepath="$MYDIR/test.txt")
         self.assertEqual(Path("/mydir") / "test.txt", Path(fdrop.path))
 
-        dir = Path("/tmp/daliuge_tfiles")  # see PathBaseDrop.get_dir()
+        fdir = Path("/tmp/daliuge_tfiles")  # see PathBaseDrop.get_dir()
         os.environ["MYDIR"] = "mydir/"
         fdrop = FileDROP(uid="A", oid="A", filepath="$MYDIR")
-        self.assertEqual(dir/"mydir/", Path(fdrop.dirname))
+        self.assertEqual(fdir/"mydir/", Path(fdrop.dirname))
 
         fdrop = FileDROP(uid="A", oid="A", filepath="$MYDIR/test.txt")
-        self.assertEqual(dir/"mydir/test.txt", Path(fdrop.path))
+        self.assertEqual(fdir/"mydir/test.txt", Path(fdrop.path))
 
+    def test_expand_missingenvar(self):
+        self.assertRaises(InvalidDropException, FileDROP, uid="A", oid="A",
+                                                        filepath="$MISSING/test.txt")


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-515](https://icrar.atlassian.net/browse/LIU-515)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

If I put something like `"$HOME/result.dat` in the `filepath` parameter of a DROP, I would expect this to be expanded. However, at some point this was broken and we end up treating it as a non-absolute path, and then expanding it to 

`$DLG_ROOT/workspace/<dlg_session_id>/home/<user>/result.dat`. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have updated `filepath_builder.py` and `file.py` to ensure filenames are appropriately expanded based on environment variables. I've also added some unittests to ensure this functionality is not broken in the future. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [x] Unittests added
- ~[ ] Documentation added~
    - Reason for not adding documentation: This supports behaviour that is already documented but isn't currently working.

## Summary by Sourcery

Restore environment variable expansion in file paths and improve path builder logic, including consistent method naming and absolute path detection, with added unit tests for file path handling.

Bug Fixes:
- Expand environment variables in filepath parameters in FileDROP and path_builder to correctly resolve $VAR references and avoid incorrect workspace prefixing

Enhancements:
- Rename _setupFilePaths to setupFilePaths and update its usage for consistency
- Enhance filepath_from_string to apply variable expansion early and detect absolute paths using pathlib for correct path joining

Tests:
- Add unit tests for basic filenames, directory paths, absolute paths, and environment variable expansion in FileDROP

[LIU-515]: https://icrar.atlassian.net/browse/LIU-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ