### PR TITLE
(WIP )LIU-3: Add support for global variable construct

### DIFF
--- a/daliuge-engine/dlg/apps/constructs.py
+++ b/daliuge-engine/dlg/apps/constructs.py
@@ -114,3 +114,15 @@ class ExclusiveForceDrop(BarrierAppDROP):
     """
     This only exists to make sure we have an exclusive force node in the template palette
     """
+
+##
+# @brief GlobalVariables
+# @details A Global variable store
+# @par EAGLE_START
+# @param category Global
+# @param tag template
+# @par EAGLE_END
+class GlobalDrop(BarrierAppDROP):
+    """
+    This exists to make sure we have a comment in the template palette
+    """

--- a/daliuge-translator/dlg/dropmake/dm_utils.py
+++ b/daliuge-translator/dlg/dropmake/dm_utils.py
@@ -813,6 +813,34 @@ def _build_apps_from_subgraph_construct(subgraph_node: dict) -> (dict, dict):
 
     return input_node, output_node
 
+def extract_globals(logical_graph: dict):
+    """
+    Extract and remove the
+    :param logical_graph:
+    :return:
+    """
+
+    global_nodes = []
+    for node in logical_graph["nodeDataArray"]:
+        if node["category"] == "Global":
+            global_nodes.append(node)
+
+    # Remove all globals from graph
+    for gn in global_nodes:
+        logical_graph["nodeDataArray"].remove(gn)
+
+    global_map = {}
+    for gn in global_nodes:
+        for fields in gn["fields"]:
+            global_map[fields["name"]] = fields["value"]
+
+    for node in logical_graph["nodeDataArray"]:
+        for field in node['fields']:
+            for gn, gv in global_map.items():
+                if isinstance(field['value'], str) and f"{{{gn}}}" in field["value"]:
+                        field['value'] = field['value'].replace(f"{{{gn}}}", gv)
+
+    return logical_graph
 
 def convert_subgraphs(lgo: dict) -> dict:
     """

--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -47,6 +47,7 @@ from dlg.dropmake.dm_utils import (
     GInvalidLink,
     GInvalidNode,
     load_lg,
+    extract_globals
 )
 from dlg.dropmake.definition_classes import Categories
 from dlg.dropmake.lg_node import LGNode
@@ -87,6 +88,7 @@ class LG:
             lg = apply_active_configuration(lg)
 
         if LG_VER_EAGLE == lgver:
+            lg = extract_globals(lg)
             lg = convert_fields(lg)
             lg = convert_construct(lg)
             lg = convert_subgraphs(lg)


### PR DESCRIPTION
I've created a "GlobalVariables" construct that acts as our wrapper for any variable that would be used multiple times across the graph. I think a Construct is the appropriate type for this, as we will remove this in the translator (like the other Constructs) and therefore it does not end up becoming an actual DROP. It's also simpler because we can have no fields beyond whatever parameters the user has put into it.

I have tested this with a super basic example; I'll add tests in a future commit.

# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ ] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)
