### PR TITLE
LIU-517: (Bug Fix) Revert `node_str` parameter name in `rest.py` function definition. 

### DIFF
--- a/daliuge-engine/dlg/manager/client.py
+++ b/daliuge-engine/dlg/manager/client.py
@@ -20,7 +20,7 @@
 #    MA 02111-1307  USA
 #
 """Backwards compatibility for client"""
-from .. import clients
+from dlg import clients
 
 BaseDROPManagerClient = clients.BaseDROPManagerClient
 NodeManagerClient = clients.NodeManagerClient

--- a/daliuge-engine/dlg/manager/composite_manager.py
+++ b/daliuge-engine/dlg/manager/composite_manager.py
@@ -259,15 +259,15 @@ class CompositeManager(DROPManager):
         else:
             self._nodes.remove(node)
 
-    def get_node_from_json(self, node_str):
+    def get_node_from_json(self, node):
         """
         Given a node str, return the Node we have stored
         Return: Node
         Raises: ValueError if there is no existing Node added to the CompositeManager
         """
 
-        idx = self._nodes.index(Node(node_str))
-        return self._nodes[idx]
+        idx = self.nodes.index(node)
+        return self.nodes[idx]
 
     @property
     def dmPort(self):

--- a/daliuge-engine/dlg/manager/rest.py
+++ b/daliuge-engine/dlg/manager/rest.py
@@ -667,40 +667,40 @@ class CompositeManagerRestServer(ManagerRestServer):
         return data
 
     @daliuge_aware
-    def getNodeSessionInformation(self, node_str, sessionId):
+    def getNodeSessionInformation(self, node: str, sessionId):
         try:
-            node = self.dm.get_node_from_json(node_str)
-            with NodeManagerClient(host=node.host, port=node.port) as dm:
+            n = Node(self.dm.get_node_from_json(node))
+            with NodeManagerClient(host=n.host, port=n.port) as dm:
                 return dm.session(sessionId)
         except ValueError as e:
-            raise ValueError(f"{node_str} not in current list of nodes") from e
+            raise ValueError(f"{n} not in current list of nodes") from e
 
     @daliuge_aware
-    def getNodeSessionStatus(self, node_str, sessionId):
+    def getNodeSessionStatus(self, node: str, sessionId):
         try:
-            node = self.dm.get_node_from_json(node_str)
-            with NodeManagerClient(host=node.host, port=node.port) as dm:
+            n = Node(self.dm.get_node_from_json(node))
+            with NodeManagerClient(host=n, port=n.port) as dm:
                 return dm.session_status(sessionId)
         except ValueError as e:
-            raise ValueError(f"{node_str} not in current list of nodes") from e
+            raise ValueError(f"{node} not in current list of nodes") from e
 
     @daliuge_aware
-    def getNodeGraph(self, node_str, sessionId):
+    def getNodeGraph(self, node: str, sessionId):
         try:
-            node = self.dm.get_node_from_json(node_str)
-            with NodeManagerClient(host=node.host, port=node.port) as dm:
+            n = Node(self.dm.get_node_from_json(node))
+            with NodeManagerClient(host=n.host, port=n.port) as dm:
                 return dm.graph(sessionId)
         except ValueError as e:
-            raise ValueError(f"{node_str} not in current list of nodes") from e
+            raise ValueError(f"{node} not in current list of nodes") from e
 
     @daliuge_aware
-    def getNodeGraphStatus(self, node_str, sessionId):
+    def getNodeGraphStatus(self, node: str, sessionId):
         try:
-            node = self.dm.get_node_from_json(node_str)
-            with NodeManagerClient(host=node.host, port=node.port) as dm:
+            n = Node(self.dm.get_node_from_json(node))
+            with NodeManagerClient(host=n.host, port=n.port) as dm:
                 return dm.graph_status(sessionId)
         except ValueError as e:
-            raise ValueError(f"{node_str} not in current list of nodes") from e
+            raise ValueError(f"{node} not in current list of nodes") from e
 
     # ===========================================================================
     # non-REST methods


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

This issue was introduced with the Node class back in https://github.com/ICRAR/daliuge/pull/283. The purpose of that class was to improve the wrapping of DRopManager ports so we aren't reliant on default ports across the nodes, which becomes a problem if you want to run more than one manager on a single machine (port conflicts incur). One side effect of this was updating the parameters to some of our REST functions from `node` to `node_str`. This was intended to make it clear that we are getting a 'string' node rather than a Node node, but it actually broke out API calls scattered around our web interface.

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

 I've corrected the mistake and a couple of other outstanding issues related to adding the `Node` class. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)

## Summary by Sourcery

Revert unintended parameter rename in REST endpoints and related methods to restore API compatibility, correct node lookup logic in the composite manager, and fix client import path.

Bug Fixes:
- Restore the `node` parameter name in REST methods instead of `node_str` to fix broken API calls
- Fix get_node_from_json in composite manager to accept a node identifier directly and return the matching Node
- Correct the import path for the clients module in the manager client to restore backwards compatibility

Enhancements:
- Refactor REST endpoint implementations to instantiate the Node wrapper and update exception messages accordingly