### PR TITLE
V6.0.0: Support DirectoryDROP naming

### DIFF
--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -606,7 +606,9 @@ class PyFuncApp(BarrierAppDROP):
                 if parser == DropParser.PATH:
                     try:
                         argument.value = filepath_from_string(
-                            argument.value, dirname=output_drop.dirname, uid=output_drop.uid,
+                            argument.value, path=output_drop.path,
+                            dirname=output_drop.dirname,
+                            uid=output_drop.uid,
                             humanKey=output_drop.humanKey
                         )
                     except RuntimeError as e:

--- a/daliuge-engine/dlg/apps/pyfunc.py
+++ b/daliuge-engine/dlg/apps/pyfunc.py
@@ -606,7 +606,7 @@ class PyFuncApp(BarrierAppDROP):
                 if parser == DropParser.PATH:
                     try:
                         argument.value = filepath_from_string(
-                            argument.value, path=output_drop.path,
+                            argument.value, path_type=output_drop.path_type,
                             dirname=output_drop.dirname,
                             uid=output_drop.uid,
                             humanKey=output_drop.humanKey

--- a/daliuge-engine/dlg/data/drops/data_base.py
+++ b/daliuge-engine/dlg/data/drops/data_base.py
@@ -26,6 +26,7 @@ import logging
 from typing import Union
 
 from dlg.drop import AbstractDROP, track_current_drop
+from dlg.data.path_builder import PathType
 from dlg.data.io import (
     DataIO,
     OpenMode,
@@ -499,13 +500,13 @@ class DataDROP(AbstractDROP):
         DROP implementations will use different URI schemes.
         """
 
-
 class PathBasedDrop(object):
     """
     Base class for data drops that handle paths (i.e., file and directory drops)
     """
 
     _path: str = None
+    _path_type: PathType = PathType.File
 
     def get_dir(self, dirname, create_if_missing=True):
         """
@@ -539,6 +540,9 @@ class PathBasedDrop(object):
     def path(self) -> str:
         return self._path
 
+    @property
+    def path_type(self) -> PathType:
+        return self._path_type
 
 ##
 # @brief NULL

--- a/daliuge-engine/dlg/data/drops/directory.py
+++ b/daliuge-engine/dlg/data/drops/directory.py
@@ -39,15 +39,13 @@ logger = logging.getLogger(f"dlg.{__name__}")
 # @par EAGLE_START
 # @param category Data
 # @param tag daliuge
-# @param dropclass dlg.data.drops.directory.DirectoryDROP/String/ComponentParameter/NoPort
-# /ReadWrite//False/False/Drop class
+# @param dropclass dlg.data.drops.directory.DirectoryDROP/String/ComponentParameter/NoPort/ReadWrite//False/False/Drop class
 # @param base_name directorycontainer/String/ComponentParameter/NoPort/ReadOnly//False/False/Base name of application class
 # @param data_volume 5/Float/ConstraintParameter/NoPort/ReadWrite//False/False/Estimated size of the data contained in this node
 # @param group_end False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/Is this node the end of a group?
-# @param check_exists False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False
-# /Perform a check to make sure the file path exists before proceeding with the application
+# @param check_exists False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/Perform a check to make sure the file path exists before proceeding with the application
 # @param dirname /String/ApplicationArgument/NoPort/ReadWrite//False/False/"Directory name/path"
-# @param create_if_missing True/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/"Create directory if it does not exist"
+# @param create_if_missing False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/"Create directory if it does not exist"
 # @param overwrite_existing False/Boolean/ApplicationArgument/NoPort/ReadWrite//False/False/"Overwrite existing directory if exists"
 # @param block_skip False/Boolean/ComponentParameter/NoPort/ReadWrite//False/False/If set the drop will block a skipping chain until the last producer has finished and is not also skipped.
 # @param io /Object/ApplicationArgument/OutputPort/ReadWrite//False/False/Input Output port
@@ -61,7 +59,7 @@ class DirectoryDROP(PathBasedDrop, DataDROP):
     """
 
     check_exists = dlg_bool_param("check_exists", False)
-    create_if_missing = dlg_bool_param("create_if_missing", True)
+    create_if_missing = dlg_bool_param("create_if_missing", False)
 
     def initialize(self, **kwargs):
         DataDROP.initialize(self, **kwargs)

--- a/daliuge-engine/dlg/data/drops/directory.py
+++ b/daliuge-engine/dlg/data/drops/directory.py
@@ -70,6 +70,7 @@ class DirectoryDROP(PathBasedDrop, DataDROP):
             )
         self.dirpath = os.path.expandvars(kwargs["dirname"])
         self.dirname = self.dirpath
+        self._path_type = path_builder.PathType.Directory
         self._setupDirectoryPath()
 
 
@@ -77,7 +78,7 @@ class DirectoryDROP(PathBasedDrop, DataDROP):
         """
         Return DirectoryIO object
         """
-        if not self._path:
+        if not self.parameters.get("dirname", None):
             self._map_input_ports_to_params()
             self._setupDirectoryPath()
         return DirectoryIO(self._path)

--- a/daliuge-engine/dlg/data/path_builder.py
+++ b/daliuge-engine/dlg/data/path_builder.py
@@ -124,20 +124,26 @@ def find_dlg_fstrings(filename: str) -> list[str]:
         return opts
 
 
-def filepath_from_string(filename: str, dirname: str = "", **kwargs) -> str:
+def filepath_from_string(filename: str, path: str, dirname: str = "", **kwargs) -> str:
     """
     Attempts to construct a filename from filename and possible mappings, which are
     built from a combination of FSTRING_MAP and **kwargs.
 
+    There is conflict between filename, path, and dirname.
+
     Returns
     -------
     filename
+    path
+    dirname
     """
 
     opts = []
     fstring_map = default_map() 
     fstring_map.update(kwargs)
-    if not filename and "humanKey" in fstring_map:
+    if path == dirname:
+        filename = "" # The path we want is a directory DROP and we do not care about filename
+    elif not filename and "humanKey" in fstring_map:
         return base_uid_pathname(fstring_map["uid"], fstring_map["humanKey"])
     elif not filename:
         return filename

--- a/daliuge-engine/dlg/data/path_builder.py
+++ b/daliuge-engine/dlg/data/path_builder.py
@@ -37,8 +37,15 @@ import os
 import uuid
 
 from pathlib import Path
+from enum import Enum, auto
 
 NON_FILENAME_CHARACTERS = re.compile(fr":|{os.sep}")
+
+class PathType(Enum):
+
+    File = auto()
+    Directory = auto()
+
 
 def default_map():
     """
@@ -124,43 +131,49 @@ def find_dlg_fstrings(filename: str) -> list[str]:
         return opts
 
 
-def filepath_from_string(filename: str, path: str, dirname: str = "", **kwargs) -> str:
+def filepath_from_string(path: str, path_type: PathType, dirname: str = "",
+                         **kwargs) -> (
+        str):
     """
-    Attempts to construct a filename from filename and possible mappings, which are
-    built from a combination of FSTRING_MAP and **kwargs.
+    Attempts to construct a path from path, dirname, and possible string replacements.
+    The replacements are built from a combination of FSTRING_MAP and **kwargs.
 
-    There is conflict between filename, path, and dirname.
+    If path_type is PathType.Directory and we do not have a 'path', we do not create a
+    base_uid_pathname, for we do not need to create a filename. Instead, we use dirname
+    only to construct the final path.
 
     Returns
     -------
-    filename
-    path
+    path: The provisional path provided. This may be empty, a file-path, or a directory path.
+    path_type: An indicator of what
     dirname
     """
 
     opts = []
     fstring_map = default_map() 
     fstring_map.update(kwargs)
-    if path == dirname:
-        filename = "" # The path we want is a directory DROP and we do not care about filename
-    elif not filename and "humanKey" in fstring_map:
+    if path_type == path_type.Directory and not path:
+        path = "" # The path we want is a directory DROP and we do not care about
+        # dirname = path
+        # filename
+    elif not path and "humanKey" in fstring_map:
         return base_uid_pathname(fstring_map["uid"], fstring_map["humanKey"])
-    elif not filename:
-        return filename
+    elif not path:
+        return path
 
-    full_filename = os.path.expandvars(filename)
-    full_dirname = os.path.expandvars(dirname)
+    expanded_path = os.path.expandvars(path)
+    expanded_dirname = os.path.expandvars(dirname)
 
-    if full_filename == filename and "$" in full_filename:
-        raise RuntimeError(f"Environment variable in path {filename} not set!")
-    if full_dirname == dirname and "$" in full_dirname:
+    if expanded_path == path and "$" in expanded_path:
+        raise RuntimeError(f"Environment variable in path {path} not set!")
+    if expanded_dirname == dirname and "$" in expanded_dirname:
         raise RuntimeError(f"Environment variable in path {dirname} not set!")
 
-    opts.extend(find_dlg_fstrings(filename))
+    opts.extend(find_dlg_fstrings(path))
     for fp in opts:
-        full_filename = full_filename.replace(f"{{{fp}}}", fstring_map[fp])
+        expanded_path = expanded_path.replace(f"{{{fp}}}", fstring_map[fp])
 
-    if Path(full_filename).is_absolute():
-        return full_filename
+    if Path(expanded_path).is_absolute():
+        return expanded_path
     else:
-        return f"{full_dirname}/{full_filename}" if full_dirname else full_filename
+        return f"{expanded_dirname}/{expanded_path}" if expanded_dirname else expanded_path

--- a/daliuge-engine/test/end_to_end/named_ports/test_path_builder.py
+++ b/daliuge-engine/test/end_to_end/named_ports/test_path_builder.py
@@ -48,14 +48,14 @@ class TestPathBuilders(unittest.TestCase):
 
     def test_file_path_from_string(self):
         uid = "123456"
-        res = filepath_from_string("prefix_{uid}_{datetime}.dat", uid=uid)
+        res = filepath_from_string("prefix_{uid}_{datetime}.dat", None, uid=uid)
         dstr = datetime.date.today().strftime("%Y-%m-%d")
         self.assertEqual(f"prefix_123456_{dstr}.dat", res)
         dt = "2025-08-17"
-        res = filepath_from_string("prefix_{uid}_{datetime}.dat",
+        res = filepath_from_string("prefix_{uid}_{datetime}.dat", None,
                                    uid=uid, datetime=dt)
         self.assertEqual("prefix_123456_2025-08-17.dat", res)
-        res = filepath_from_string(None, uid=None)
+        res = filepath_from_string(None, None, uid=None)
         self.assertEqual(None, res)
 
 


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [x] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

FileDROPs can be named on the DROP through the `filepath` attribute, or by PyFuncApps through a port, or by DALiUGE (the default, base approach). 

The current implementation of DirectoryDROPs only supports the first and last of these; we should support all three. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

I have modified the `path_builder` utilities to take into account different logic for if we are building a file-path or directory-path 'type'. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [x] Unittests added
- ~[ ] Documentation added~
    - This is ostensibly supporting already documented features. 
