### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.9"
           - python-version: "3.10"
           - python-version:  "3.11"
           - python-version:  "3.12"
@@ -55,7 +54,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.9"
           - python-version: "3.10"
           - python-version:  "3.11"
           - python-version:  "3.12"
@@ -95,7 +93,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.9"
           - python-version: "3.10"
           - python-version:  "3.11"
           - python-version:  "3.12"

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,6 +4,15 @@
 
 .. _installation:
 
+Python
+======
+
+DALiuGE is supported for the following Python versions:
+
+* 3.10
+* 3.11
+* 3.12
+
 Installation 
 ============
 .. note::


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ ] Bug fix
- [x] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

New version of python-benedict dropped official support for Python 3.9: https://github.com/fabiocaccamo/python-benedict/releases/tag/0.34.0. This is causing build failures (as of today) due to new versions being released (0.35.0) with type hinting. 

Python 3.9 is also now official EOL (2025/10): https://devguide.python.org/versions/. 

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

Remove from our unit testing CI/CD. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests: Non-code related change
- [x] Documentation added

## Summary by Sourcery

Remove Python 3.9 support across the project now that it is EOL and no longer supported by a key dependency.

Enhancements:
- Drop Python 3.9 from all CI testing matrices

CI:
- Remove Python 3.9 jobs from GitHub Actions workflows

Documentation:
- Update installation documentation to reflect Python 3.10+ support only