### PR TITLE
LIU-540: Add back port_map to translator.

### DIFF
--- a/daliuge-translator/dlg/dropmake/lg.py
+++ b/daliuge-translator/dlg/dropmake/lg.py
@@ -488,16 +488,23 @@ class LG:
             dropSpec_null.addStreamingConsumer(tdrop, name="stream")
             tdrop.addStreamingInput(dropSpec_null, name="stream")
             self._drop_dict["new_added"].append(dropSpec_null)
+
         elif s_type in ["Application", "Control"]:
             logger.debug("Getting source and traget port names and IDs of %s and %s", slgn.name, tlgn.name)
             sname = slgn.getPortName("outputPorts", index=-1)
             tname = tlgn.getPortName("inputPorts", index=-1)
 
             # sname is dictionary of all output ports on the sDROP.
+
             output_portname = sname[llink["fromPort"]]
             input_portname = tname[llink["toPort"]]
             sdrop.addOutput(tdrop, name=output_portname)
             tdrop.addProducer(sdrop, name=input_portname)
+
+            if "port_map" not in tdrop:
+                tdrop["port_map"] = {input_portname: output_portname}
+            else:
+                tdrop["port_map"][input_portname] = output_portname
 
             if Categories.BASH_SHELL_APP == s_type:
                 bc = src_drop["command"]


### PR DESCRIPTION
# JIRA Ticket 
<!---
If there is no JIRA ticket, please consider raising one to summarise the work there. Alternatively, link to a GitHub if that exists._
--->

[LIU-540](https://icrar.atlassian.net/browse/LIU-540)

# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->

I erroneously removed the port_map behaviour in lg.py when working on our Branch drop support. This needs to be added back.  

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 

Add back the lines. 

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)


[LIU-540]: https://icrar.atlassian.net/browse/LIU-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Reintroduce population of the target drop's port_map to correctly map input ports to source output ports during link creation.