### PR TITLE
Issue 7 create typed artefact envelopes

### DIFF
--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -1,0 +1,14 @@
+name: Create Branch from Issue
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  create_issue_branch_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Issue Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   create_issue_branch_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Create Issue Branch
         uses: robvanderleek/create-issue-branch@main

--- a/daliuge-translator/dlg/translator/artefacts.py
+++ b/daliuge-translator/dlg/translator/artefacts.py
@@ -1,0 +1,114 @@
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+L = TypeVar("L", bound="LogicalArtefact")
+P = TypeVar("P", bound="PhysicalArtefact")
+
+
+@dataclass(frozen=True)
+class LogicalArtefact:
+    """
+    Shared shape for the dict-form logical artefacts.
+
+    `source`: EAGLE JSON document, reprodata key included.
+    """
+
+    source: dict
+
+    @classmethod
+    def from_wire(cls: type[L], payload: dict) -> L:
+        """
+        Wrap an already-parsed EAGLE JSON document.
+        """
+        if not isinstance(payload, dict):
+            raise TypeError(
+                f"{cls.__name__} wire form must be a dict, "
+                f"got {type(payload).__name__}"
+            )
+
+        reprodata = payload.get("reprodata")
+        if reprodata is not None and not isinstance(reprodata, dict):
+            raise TypeError(
+                f"{cls.__name__} 'reprodata' must be a dict, "
+                f"got {type(reprodata).__name__}"
+            )
+
+        return cls(source=deepcopy(payload))
+
+    def to_wire(self) -> dict:
+        """
+        Return the graph as a fresh document the caller owns.
+        """
+        return deepcopy(self.source)
+
+    @property
+    def reprodata(self) -> dict:
+        return self.source.get("reprodata", {})
+
+
+@dataclass(frozen=True)
+class PhysicalArtefact:
+    """
+    Shared shape for the list-form physical artefacts.
+    """
+
+    drops: list[dict]
+    reprodata: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls: type[P], payload: list[dict]) -> P:
+        """
+        Split a wire list into drops and reprodata.
+        """
+        if not isinstance(payload, list):
+            raise TypeError(
+                f"{cls.__name__} wire form must be a list, "
+                f"got {type(payload).__name__}"
+            )
+
+        if not all(isinstance(e, dict) for e in payload):
+            bad = next(i for i, e in enumerate(payload) if not isinstance(e, dict))
+            raise TypeError(
+                f"{cls.__name__} element {bad} must be a dict, "
+                f"got {type(payload[bad]).__name__}"
+            )
+
+        if payload and isinstance(payload[-1], dict) and not payload[-1].get("oid"):
+            return cls(
+                drops=deepcopy(payload[:-1]),
+                reprodata=deepcopy(payload[-1])
+            )
+        else:
+            return cls(drops=deepcopy(payload))
+
+    def to_wire(self) -> list:
+        """
+        Return drops with reprodata appended
+        """
+        return deepcopy([*self.drops, self.reprodata])
+
+
+@dataclass(frozen=True)
+class LogicalGraphTemplate(LogicalArtefact):
+    """Bare EAGLE's graph output"""
+
+
+@dataclass(frozen=True)
+class LogicalGraph(LogicalArtefact):
+    """LGT with its parameters resolved and graph configuration applied."""
+
+
+@dataclass(frozen=True)
+class PhysicalGraphTemplate(PhysicalArtefact):
+    """Expanded logical graph, a flat list of drops where the workflow will run"""
+
+
+@dataclass(frozen=True)
+class PhysicalGraphTemplatePartitioned(PhysicalArtefact):
+    """Partitioned PGT with placeholders node and island (`#N` / `#M`)"""
+
+
+@dataclass(frozen=True)
+class PhysicalGraph(PhysicalArtefact):
+    """Complete physical graph with real hostnames, engine ready"""


### PR DESCRIPTION
# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [ ] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 

<!--- Provide an overview of what this PR address--->
Addresses #8 . Current codebase implementation makes it hard to guess what data are we handling at that point (usually dicts for logical artefacts and lists for physical artefacts)

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 
Introduces artefacts.py, a typed envelope for all of the artefacts (LGT, LG, PGT, PGT-P, PG)

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Reason for not adding unittests (remove this line if added) 
- [ ] Documentation added
    - Reason for not adding documentation (remove this line if added)

## Summary by Sourcery

Add typed artefact envelopes to make graph data shapes explicit throughout translation.

New Features:
- Introduce typed envelopes for logical and physical artefacts across the graph translation pipeline.

Enhancements:
- Provide validated wire-format conversion and safe access to logical graph metadata, physical drops, and reprodata.

CI:
- Add an automated workflow to create branches when issues are assigned.