### PR TITLE
Issue 14 make scatter dop a required field

### DIFF
--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -1,0 +1,14 @@
+name: Create Branch from Issue
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  create_issue_branch_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Issue Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   create_issue_branch_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Create Issue Branch
         uses: robvanderleek/create-issue-branch@main

--- a/.github/workflows/issue-autolink.yml
+++ b/.github/workflows/issue-autolink.yml
@@ -1,0 +1,14 @@
+name: "Issue Autolink"
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  issue-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tkt-actions/add-issue-links@v1.8.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          branch-prefix: "issue-"
+          resolve: "true"

--- a/.github/workflows/issue-autolink.yml
+++ b/.github/workflows/issue-autolink.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
 jobs:
   issue-links:
     runs-on: ubuntu-latest

--- a/daliuge-translator/dlg/dropmake/lg_node.py
+++ b/daliuge-translator/dlg/dropmake/lg_node.py
@@ -622,11 +622,14 @@ class LGNode:
                         "num_of_splits",
                         "Number of copies",
                     ]:
-                        if kw in self.jd:
+                        if kw in self.jd and self.jd[kw]:
                             self._dop = int(self.jd[kw])
                             break
                     if self._dop is None:
-                        self._dop = 4  # dummy impl. TODO: Why is this here?
+                        raise GInvalidNode(
+                            f"Scatter '{self.name}' ({self.id}) has no degree of parallelism. "
+                            "One of 'num_of_copies', 'num_of_splits', 'Number of copies' is required."
+                        )
                 elif self.is_gather:
                     try:
                         tlgn = self.inputs[0]


### PR DESCRIPTION
# Type
<!---Select what type of work this PR is addressing. This is useful for preparing the [Changelog](https://github.com/ICRAR/daliuge/blob/master/CHANGELOG.md)--->

- [ ] Feature (addition)
- [x] Bug fix
- [ ] Refactor (change)
- [ ] Documentation 

# Problem/Issue 
Scatter default degree of parallelism is at a weird spot of defaulting to 4
<!--- Provide an overview of what this PR address--->

# Solution
<!--- A description of the solution, including design decisions or compromises made. Consider adding a figure or example of how the behaviour has changed. ---> 
Have it instead raising GInvalidNode.
Side fix : dop of empty string ('') can create TypeError, fixed it

# Checklist
<!--- Provide a description of documentation added, testing, including manual and programmatic ---> 

- [ ] Unittests added
  - Checked by phase 0
- [ ] Documentation added
    - Will need to discuss correctness

## Summary by Sourcery

Enforce explicit scatter parallelism and automate issue-to-branch and pull-request issue linking workflows.

Bug Fixes:
- Require scatter nodes to specify a valid degree of parallelism instead of silently defaulting to four, including treating empty values as missing.

CI:
- Add workflows to create branches automatically from assigned issues and link or resolve issues when pull requests are opened.